### PR TITLE
release: v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "description": "The open runtime for agentic development",
   "type": "module",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "start": "node dist/cli/index.js",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "pnpm --filter @polpo-ai/core build && pnpm --filter @polpo-ai/drizzle build && ./node_modules/.bin/tsc --noEmit",
+    "typecheck": "pnpm --filter @polpo-ai/core build && pnpm --filter @polpo-ai/vault-crypto build && pnpm --filter @polpo-ai/drizzle build && pnpm --filter @polpo-ai/tools build && pnpm --filter @polpo-ai/server build && ./node_modules/.bin/tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "keywords": [
@@ -71,9 +71,9 @@
     "@hono/zod-openapi": "^1.2.2",
     "@mariozechner/pi-agent-core": "^0.62.0",
     "@mariozechner/pi-ai": "^0.62.0",
-    "@polpo-ai/core": "^0.3.9",
-    "@polpo-ai/server": "^0.2.14",
-    "@polpo-ai/vault-crypto": "^0.2.4",
+    "@polpo-ai/core": "workspace:*",
+    "@polpo-ai/server": "workspace:*",
+    "@polpo-ai/vault-crypto": "workspace:*",
     "@sinclair/typebox": "^0.34.48",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
@@ -84,7 +84,7 @@
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
-    "@polpo-ai/drizzle": "^0.2.10",
+    "@polpo-ai/drizzle": "workspace:*",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.44.0",
     "nodemailer": "^8.0.1",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,10 @@
   "devDependencies": {
     "typescript": "^5.7.0"
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "license": "MIT",
   "keywords": [
     "polpo",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.2.13",
+  "version": "0.4.0",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.2.5",
+  "version": "0.4.0",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.2.17",
+  "version": "0.4.0",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@hono/zod-openapi": ">=1.0.0",
-    "@polpo-ai/core": "^0.3.5",
+    "@polpo-ai/core": "workspace:*",
     "hono": ">=4.0.0",
     "nanoid": ">=5.0.0"
   },

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.2.9",
+  "version": "0.4.0",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@polpo-ai/core": "^0.2.4",
+    "@polpo-ai/core": "workspace:*",
     "@mariozechner/pi-agent-core": "^0.57.1",
     "@sinclair/typebox": "^0.34.0",
     "nanoid": "^5.0.0"

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.2.4",
+  "version": "0.4.0",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,10 @@
   "devDependencies": {
     "typescript": "^5.7.3"
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "license": "MIT",
   "author": "OpenPolpo Contributors",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,14 +21,14 @@ importers:
         specifier: ^0.62.0
         version: 0.62.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@polpo-ai/core':
-        specifier: ^0.3.9
-        version: 0.3.9
+        specifier: workspace:*
+        version: link:packages/core
       '@polpo-ai/server':
-        specifier: ^0.2.14
-        version: 0.2.14(zod@4.3.6)
+        specifier: workspace:*
+        version: link:packages/server
       '@polpo-ai/vault-crypto':
-        specifier: ^0.2.4
-        version: 0.2.4
+        specifier: workspace:*
+        version: link:packages/vault-crypto
       '@sinclair/typebox':
         specifier: ^0.34.48
         version: 0.34.48
@@ -77,8 +77,8 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@polpo-ai/drizzle':
-        specifier: ^0.2.10
-        version: 0.2.12(@cloudflare/workers-types@4.20260307.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
+        specifier: workspace:*
+        version: link:packages/drizzle
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -185,8 +185,8 @@ importers:
         specifier: '>=1.0.0'
         version: 1.2.2(hono@4.11.9)(zod@4.3.6)
       '@polpo-ai/core':
-        specifier: ^0.3.5
-        version: 0.3.6
+        specifier: workspace:*
+        version: link:../core
       hono:
         specifier: '>=4.0.0'
         version: 4.11.9
@@ -203,8 +203,8 @@ importers:
         specifier: ^0.57.1
         version: 0.57.1(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@polpo-ai/core':
-        specifier: ^0.2.4
-        version: 0.2.5
+        specifier: workspace:*
+        version: link:../core
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.48
@@ -1110,39 +1110,6 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@polpo-ai/core@0.2.5':
-    resolution: {integrity: sha512-3KN3BTXM3qHxjt5D5g1CEsoLicGBiTVrQUHdK6TxnEDccx13zX4V7mzpLVKj/0d4PbuhICyx9EZLa0KZNDMa7A==}
-    engines: {node: '>=18.0.0'}
-
-  '@polpo-ai/core@0.3.6':
-    resolution: {integrity: sha512-Jd+tfwQ20ezrMatetF+IH5fJoCs5f3K1hgdEPkWsWLdFc70jh1iRu1nxLsdheGQlNVIzHhbFn0eqjeueoIzLjA==}
-    engines: {node: '>=18.0.0'}
-
-  '@polpo-ai/core@0.3.9':
-    resolution: {integrity: sha512-UpoLxfOAQzvvx4F346IM5v+dnnuHky7VRK3P2HFaVrPcH2qQLPerjyiQabCfnvGLc5wJo+0PvOxi6FjtjeiIGg==}
-    engines: {node: '>=18.0.0'}
-
-  '@polpo-ai/drizzle@0.2.12':
-    resolution: {integrity: sha512-GCorBh+cuy2w2E5YpSMzldLOnndJdKctFz8FpIQOw7SAPLKaJ3keiRm8yY8XeX7LheRErF40Nz4cGiAOijx9UA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      better-sqlite3: ^11.0.0 || ^12.0.0
-      postgres: ^3.4.0
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      postgres:
-        optional: true
-
-  '@polpo-ai/server@0.2.14':
-    resolution: {integrity: sha512-zQ84Mgg+U1DK2uf0yil8Zk64H0/XOt8+Lffz0hooeHTjG2fixkXhAaDFW8WNIMWPvy+QHJs2WgI8x2muIpMYTg==}
-    peerDependencies:
-      zod: '>=3.0.0 || >=4.0.0'
-
-  '@polpo-ai/vault-crypto@0.2.4':
-    resolution: {integrity: sha512-IsU/zdb9P3O2/If773LNpQ7H5toeTNqaHS3WDFQpr2aQpYywZg0xsRuPensTdrg5Eai9SyZMmDsxizNW8IFnlQ==}
-    engines: {node: '>=18.0.0'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4616,70 +4583,6 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
-
-  '@polpo-ai/core@0.2.5':
-    dependencies:
-      nanoid: 5.1.6
-      zod: 4.3.6
-
-  '@polpo-ai/core@0.3.6':
-    dependencies:
-      nanoid: 5.1.6
-      zod: 4.3.6
-
-  '@polpo-ai/core@0.3.9':
-    dependencies:
-      nanoid: 5.1.6
-      zod: 4.3.6
-
-  '@polpo-ai/drizzle@0.2.12(@cloudflare/workers-types@4.20260307.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)':
-    dependencies:
-      '@polpo-ai/core': 0.3.9
-      '@polpo-ai/vault-crypto': 0.2.4
-      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260307.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
-      nanoid: 5.1.6
-    optionalDependencies:
-      better-sqlite3: 12.6.2
-      postgres: 3.4.8
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - prisma
-      - sql.js
-      - sqlite3
-    optional: true
-
-  '@polpo-ai/server@0.2.14(zod@4.3.6)':
-    dependencies:
-      '@hono/zod-openapi': 1.2.2(hono@4.11.9)(zod@4.3.6)
-      '@polpo-ai/core': 0.3.9
-      hono: 4.11.9
-      nanoid: 5.1.6
-      zod: 4.3.6
-
-  '@polpo-ai/vault-crypto@0.2.4': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 

--- a/src/__tests__/checkpoints.test.ts
+++ b/src/__tests__/checkpoints.test.ts
@@ -600,58 +600,5 @@ describe("Checkpoints", () => {
     });
   });
 
-  describe("notification rules", () => {
-    it("registers notification rules for checkpoint notifyChannels", async () => {
-      const addedRules: Array<{ id: string; events: string[] }> = [];
-      const mockRouter = {
-        addRule: (rule: { id: string; events: string[] }) => { addedRules.push(rule); },
-      };
-      missionExec.setNotificationRouter(mockRouter as any);
-
-      const missionData = JSON.stringify({
-        tasks: [
-          { title: "Task A", description: "Do A" },
-          { title: "Task B", description: "Do B", dependsOn: ["Task A"] },
-        ],
-        checkpoints: [
-          { name: "review-a", afterTasks: ["Task A"], blocksTasks: ["Task B"], notifyChannels: ["slack-alerts"] },
-        ],
-      });
-      const mission = await missionExec.saveMission({ data: missionData, name: "my-mission" });
-      await missionExec.executeMission(mission.id);
-
-      const tasks = [createDoneTask("Task A"), createPendingTask("Task B")];
-      await missionExec.getBlockingCheckpoint("my-mission", "Task B", "id-b", tasks);
-
-      // Should have registered 2 rules: reached + resumed
-      expect(addedRules).toHaveLength(2);
-      expect(addedRules[0].events).toContain("checkpoint:reached");
-      expect(addedRules[1].events).toContain("checkpoint:resumed");
-    });
-
-    it("does not register rules when no notifyChannels", async () => {
-      const addedRules: unknown[] = [];
-      const mockRouter = {
-        addRule: (rule: unknown) => { addedRules.push(rule); },
-      };
-      missionExec.setNotificationRouter(mockRouter as any);
-
-      const missionData = JSON.stringify({
-        tasks: [
-          { title: "Task A", description: "Do A" },
-          { title: "Task B", description: "Do B", dependsOn: ["Task A"] },
-        ],
-        checkpoints: [
-          { name: "review-a", afterTasks: ["Task A"], blocksTasks: ["Task B"] },
-        ],
-      });
-      const mission = await missionExec.saveMission({ data: missionData, name: "my-mission" });
-      await missionExec.executeMission(mission.id);
-
-      const tasks = [createDoneTask("Task A"), createPendingTask("Task B")];
-      await missionExec.getBlockingCheckpoint("my-mission", "Task B", "id-b", tasks);
-
-      expect(addedRules).toHaveLength(0);
-    });
-  });
+  // notification rules tests removed — notification system was removed from OSS
 });

--- a/src/__tests__/task-manager.test.ts
+++ b/src/__tests__/task-manager.test.ts
@@ -903,7 +903,7 @@ describe("MissionExecutor", () => {
 
       // Mission is now active — second execution should throw
       await expect(missionExec.executeMission(mission.id)).rejects.toThrow(
-        'Cannot execute mission in "active" state (must be "draft", "scheduled", or "recurring")',
+        'Cannot execute mission in "active" state',
       );
     });
 


### PR DESCRIPTION
## Summary
- Bump all 8 packages to 0.4.0 (synced versions)
- Convert internal deps to `workspace:*` references
- Remove stale notification router tests
- Fix mission executor error message assertion

## Packages
polpo-ai, @polpo-ai/core, @polpo-ai/drizzle, @polpo-ai/server, @polpo-ai/sdk, @polpo-ai/react, @polpo-ai/tools, @polpo-ai/vault-crypto

## After merge
```
git tag v0.4.0 && git push --tags
```