### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,40 @@ permissions:
   id-token: write
 
 jobs:
-  ci:
-    name: CI Gate
-    uses: ./.github/workflows/ci.yml
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: polpo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - name: Run tests
+        run: pnpm run test run
+        env:
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/polpo_test
 
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    needs: [ci]
+    needs: [test]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
@@ -30,15 +56,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build all packages
-        run: |
-          pnpm --filter @polpo-ai/core build
-          pnpm --filter @polpo-ai/vault-crypto build
-          pnpm --filter @polpo-ai/drizzle build
-          pnpm --filter @polpo-ai/tools build
-          pnpm --filter @polpo-ai/server build
-          pnpm --filter @polpo-ai/sdk build
-          pnpm --filter @polpo-ai/react build
-          ./node_modules/.bin/tsc
+        run: pnpm run build
 
       - name: Publish @polpo-ai/core
         run: pnpm --filter @polpo-ai/core publish --no-git-checks --provenance --access public


### PR DESCRIPTION
## Summary
- Replace reusable CI workflow call with inline test job
- The reusable workflow failed because tag push doesn't match CI's branch triggers
- After merge, re-tag v0.4.0 to trigger the release