### PR TITLE
feat: Dockerfile + GHCR publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+.polpo
+.git
+.github
+.claude
+coverage
+*.log
+.DS_Store
+.env*
+examples

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 jobs:
   test:
@@ -98,10 +99,39 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  docker:
+    name: Docker Image
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   release-notes:
     name: Release Notes
     runs-on: ubuntu-latest
-    needs: [publish]
+    needs: [publish, docker]
     steps:
       - uses: actions/checkout@v6
       - uses: softprops/action-gh-release@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM node:22-slim AS base
+RUN corepack enable && corepack prepare pnpm@10.29.3 --activate
+WORKDIR /app
+
+# Install dependencies
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/core/package.json packages/core/
+COPY packages/vault-crypto/package.json packages/vault-crypto/
+COPY packages/drizzle/package.json packages/drizzle/
+COPY packages/server/package.json packages/server/
+COPY packages/tools/package.json packages/tools/
+COPY packages/client-sdk/package.json packages/client-sdk/
+COPY packages/react-sdk/package.json packages/react-sdk/
+RUN pnpm install --frozen-lockfile
+
+# Build
+FROM deps AS build
+COPY . .
+RUN pnpm build
+
+# Production
+FROM node:22-slim AS production
+RUN corepack enable && corepack prepare pnpm@10.29.3 --activate
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
+COPY --from=deps /app/packages/drizzle/node_modules ./packages/drizzle/node_modules
+COPY --from=deps /app/packages/server/node_modules ./packages/server/node_modules
+COPY --from=deps /app/packages/tools/node_modules ./packages/tools/node_modules
+COPY --from=deps /app/packages/vault-crypto/node_modules ./packages/vault-crypto/node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/packages/core/dist ./packages/core/dist
+COPY --from=build /app/packages/vault-crypto/dist ./packages/vault-crypto/dist
+COPY --from=build /app/packages/drizzle/dist ./packages/drizzle/dist
+COPY --from=build /app/packages/server/dist ./packages/server/dist
+COPY --from=build /app/packages/tools/dist ./packages/tools/dist
+COPY --from=build /app/package.json ./
+COPY --from=build /app/packages/core/package.json ./packages/core/
+COPY --from=build /app/packages/vault-crypto/package.json ./packages/vault-crypto/
+COPY --from=build /app/packages/drizzle/package.json ./packages/drizzle/
+COPY --from=build /app/packages/server/package.json ./packages/server/
+COPY --from=build /app/packages/tools/package.json ./packages/tools/
+COPY --from=build /app/playbooks ./playbooks
+
+ENV NODE_ENV=production
+ENV PORT=3890
+
+EXPOSE 3890
+
+# Default: start the server. Override with any polpo command.
+ENTRYPOINT ["node", "dist/cli/index.js"]
+CMD ["serve", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (deps → build → slim production)
- Publishes to `ghcr.io/lumea-labs/polpo:latest` + `:version` on release tag
- Supports linux/amd64 + linux/arm64
- Added `packages: write` permission to release workflow

## Usage
```bash
docker run -p 3890:3890 -v $(pwd):/workspace ghcr.io/lumea-labs/polpo:latest
```