### PR TITLE
feat: context compaction — prevent context window overflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,17 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - run: pnpm pack
+      - name: Pack all workspace packages
+        run: |
+          pnpm --filter @polpo-ai/core pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/vault-crypto pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/drizzle pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/server pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/tools pack --pack-destination /tmp/tarballs
+          pnpm pack --pack-destination /tmp/tarballs
       - name: Verify npm install from tarball
         run: |
           mkdir /tmp/install-test && cd /tmp/install-test
           npm init -y
-          npm install $GITHUB_WORKSPACE/polpo-ai-*.tgz
+          npm install /tmp/tarballs/*.tgz
           node --input-type=module -e "import 'polpo-ai'"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -193,6 +193,10 @@
     "./retry": {
       "types": "./dist/retry.d.ts",
       "import": "./dist/retry.js"
+    },
+    "./context-compactor": {
+      "types": "./dist/context-compactor.d.ts",
+      "import": "./dist/context-compactor.js"
     }
   },
   "sideEffects": false,

--- a/packages/core/src/__tests__/context-compaction-e2e.test.ts
+++ b/packages/core/src/__tests__/context-compaction-e2e.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Context Compaction E2E test — verifies compaction triggers and works
+ * with realistic message sequences that exceed the context window.
+ *
+ * Uses a tiny contextWindow (2000 tokens) so we can trigger compaction
+ * with just a few messages instead of needing 200K tokens.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  compactIfNeeded,
+  pruneToolOutputs,
+  estimateTokens,
+  estimateMessagesTokens,
+  type CompactionConfig,
+  type SummarizeFn,
+} from "../context-compactor.js";
+
+// ── Helpers ──────────────────────────────────────────────
+
+/** Create a user message */
+function userMsg(text: string) {
+  return { role: "user", content: text, timestamp: Date.now() };
+}
+
+/** Create an assistant text message */
+function assistantTextMsg(text: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  };
+}
+
+/** Create an assistant tool call message */
+function assistantToolCallMsg(toolName: string, args: Record<string, unknown>) {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id: `call_${Math.random().toString(36).slice(2)}`, name: toolName, arguments: args }],
+    timestamp: Date.now(),
+  };
+}
+
+/** Create a tool result message with large output */
+function toolResultMsg(toolCallId: string, toolName: string, output: string) {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName,
+    content: [{ type: "text", text: output }],
+    timestamp: Date.now(),
+  };
+}
+
+/** Generate a large string of N tokens (approx) */
+function generateLargeText(targetTokens: number): string {
+  // 4 chars per token
+  return "x".repeat(targetTokens * 4);
+}
+
+/** Build a conversation with many tool calls that fills up context */
+function buildLongConversation(numToolCalls: number, outputTokensEach: number) {
+  const messages: any[] = [
+    userMsg("Fix the authentication bug in the login page"),
+  ];
+
+  for (let i = 0; i < numToolCalls; i++) {
+    const tc = assistantToolCallMsg("read_file", { path: `/src/file_${i}.ts` });
+    const toolCallId = tc.content[0].id;
+    messages.push(tc);
+    messages.push(toolResultMsg(toolCallId, "read_file", generateLargeText(outputTokensEach)));
+  }
+
+  // Final assistant response
+  messages.push(assistantTextMsg("I've reviewed all the files. Here's my analysis..."));
+
+  return messages;
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("Context Compaction E2E", () => {
+  // Tiny context window so we can trigger compaction easily
+  const smallConfig: CompactionConfig = {
+    contextWindow: 2000,   // 2K tokens
+    maxOutputTokens: 200,  // 200 output tokens
+    // usable = 1800, trigger at 85% = 1530
+  };
+
+  const summarizeFn: SummarizeFn = vi.fn(async (_messages: any[], _prompt: string) => {
+    return "Summary: The agent was fixing an auth bug. Read 10 files. Found the issue in auth.ts line 42. Modified login handler.";
+  });
+
+  it("does NOT compact when context is small", async () => {
+    const messages = [
+      userMsg("Hello"),
+      assistantTextMsg("Hi! How can I help?"),
+    ];
+
+    const result = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: smallConfig,
+      summarize: summarizeFn,
+      mode: "task",
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(result.pruned).toBe(false);
+    expect(result.messages).toEqual(messages);
+    expect(summarizeFn).not.toHaveBeenCalled();
+  });
+
+  it("prunes tool outputs when context exceeds threshold", async () => {
+    // Use a larger context window where pruning alone is enough
+    // 8000 token window, 800 output → usable 7200, trigger at 6120
+    // 15 tool calls * 500 tokens = 7500 → over trigger
+    // Pruning protects last 40K (all of them since total < 40K)
+    // We need pruneProtect to be smaller to actually see pruning
+    const pruneConfig: CompactionConfig = {
+      contextWindow: 8000,
+      maxOutputTokens: 800,
+      pruneProtect: 1500,  // only protect last 1500 tokens
+      pruneMinimum: 500,   // prune if we can reclaim 500+
+    };
+
+    const messages = buildLongConversation(15, 500);
+    const tokensBefore = estimateMessagesTokens(messages);
+    expect(tokensBefore).toBeGreaterThan(6120);
+
+    const pruneSummarize = vi.fn(async () => "Should not be called");
+
+    const result = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: pruneConfig,
+      summarize: pruneSummarize,
+      mode: "task",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.pruned).toBe(true);
+    expect(result.tokensBefore).toBeGreaterThan(result.tokensAfter);
+
+    // Verify some tool outputs were pruned (contain placeholder text)
+    const allText = JSON.stringify(result.messages);
+    expect(allText).toContain("Output pruned");
+  });
+
+  it("calls summarize when pruning alone isn't enough", async () => {
+    // Many tool calls with large outputs — pruning won't bring it under target
+    const messages = buildLongConversation(20, 300);
+
+    const mockSummarize = vi.fn(async () => {
+      return "Summary: Fixed auth bug. Modified auth.ts and login.ts.";
+    });
+
+    const result = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "task",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(mockSummarize).toHaveBeenCalled();
+    expect(result.summary).toBeDefined();
+    expect(result.summary).toContain("Fixed auth bug");
+
+    // First message should be the summary injection
+    const firstMsg = result.messages[0];
+    expect(firstMsg.role).toBe("user");
+    expect(firstMsg.content).toContain("Previous context summary");
+    expect(firstMsg.content).toContain("Fixed auth bug");
+
+    // Token count should be significantly reduced
+    expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
+  });
+
+  it("preserves recent messages after summarization", async () => {
+    const messages = buildLongConversation(20, 300);
+    const lastAssistantMsg = messages[messages.length - 1];
+
+    const mockSummarize = vi.fn(async () => "Summary of old conversation.");
+
+    const result = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "task",
+    });
+
+    // The last message (assistant analysis) should still be in the result
+    const resultTexts = result.messages.map((m: any) =>
+      typeof m.content === "string" ? m.content : JSON.stringify(m.content)
+    );
+    const lastOriginalText = typeof lastAssistantMsg.content === "string"
+      ? lastAssistantMsg.content
+      : JSON.stringify(lastAssistantMsg.content);
+
+    expect(resultTexts.some((t: string) => t.includes("reviewed all the files"))).toBe(true);
+  });
+
+  it("uses task prompt for task mode", async () => {
+    const messages = buildLongConversation(20, 300);
+    let capturedPrompt = "";
+
+    const mockSummarize = vi.fn(async (_msgs: any[], prompt: string) => {
+      capturedPrompt = prompt;
+      return "Summary";
+    });
+
+    await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "task",
+    });
+
+    expect(capturedPrompt).toContain("Goal");
+    expect(capturedPrompt).toContain("Progress");
+    expect(capturedPrompt).toContain("Files");
+    expect(capturedPrompt).toContain("Next Steps");
+  });
+
+  it("uses chat prompt for chat mode", async () => {
+    const messages = buildLongConversation(20, 300);
+    let capturedPrompt = "";
+
+    const mockSummarize = vi.fn(async (_msgs: any[], prompt: string) => {
+      capturedPrompt = prompt;
+      return "Summary";
+    });
+
+    await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "chat",
+    });
+
+    expect(capturedPrompt).toContain("preferences");
+    expect(capturedPrompt).toContain("decisions");
+  });
+
+  it("passes older messages to summarize, not recent ones", async () => {
+    const messages = buildLongConversation(20, 300);
+    let summarizedCount = 0;
+
+    const mockSummarize = vi.fn(async (msgs: any[]) => {
+      summarizedCount = msgs.length;
+      return "Summary";
+    });
+
+    const result = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "task",
+    });
+
+    // Should have summarized some but not all messages
+    expect(summarizedCount).toBeGreaterThan(0);
+    expect(summarizedCount).toBeLessThan(messages.length);
+
+    // Result should have fewer messages than original
+    expect(result.messages.length).toBeLessThan(messages.length);
+  });
+
+  it("handles conversation with only text (no tool calls)", async () => {
+    // Build a text-heavy conversation that exceeds context
+    const messages: any[] = [];
+    for (let i = 0; i < 30; i++) {
+      messages.push(userMsg(generateLargeText(50)));
+      messages.push(assistantTextMsg(generateLargeText(50)));
+    }
+
+    const mockSummarize = vi.fn(async () => "Summary of long text conversation.");
+
+    const result = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "chat",
+    });
+
+    expect(result.compacted).toBe(true);
+    // With no tool outputs to prune, should go straight to summarization
+    expect(mockSummarize).toHaveBeenCalled();
+  });
+
+  it("respects disabled flag", async () => {
+    const messages = buildLongConversation(20, 300);
+
+    const result = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages,
+      config: { ...smallConfig, disabled: true },
+      summarize: summarizeFn,
+      mode: "task",
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(result.messages).toEqual(messages);
+  });
+
+  it("multiple compaction cycles work correctly", async () => {
+    // Simulate: first compaction, then more messages, then second compaction
+    const messages1 = buildLongConversation(15, 300);
+
+    const mockSummarize = vi.fn(async () => "Summary round 1.");
+
+    const result1 = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages: messages1,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "task",
+    });
+
+    expect(result1.compacted).toBe(true);
+
+    // Add more messages on top of compacted result
+    const extendedMessages = [
+      ...result1.messages,
+      ...buildLongConversation(10, 300).slice(1), // skip the initial user msg
+    ];
+
+    mockSummarize.mockResolvedValueOnce("Summary round 2 (includes round 1).");
+
+    const result2 = await compactIfNeeded({
+      systemPrompt: "You are an agent.",
+      messages: extendedMessages,
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "task",
+    });
+
+    expect(result2.compacted).toBe(true);
+    // The summary should be from round 2
+    if (result2.summary) {
+      expect(result2.summary).toContain("round 2");
+    }
+  });
+});

--- a/packages/core/src/__tests__/context-compactor.test.ts
+++ b/packages/core/src/__tests__/context-compactor.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  estimateTokens,
+  estimateMessagesTokens,
+  shouldCompact,
+  pruneToolOutputs,
+  compactIfNeeded,
+  getCompactionPrompt,
+  PRUNE_PROTECT,
+  PRUNE_MINIMUM,
+  TRIGGER_THRESHOLD,
+  TARGET_AFTER,
+  type CompactionConfig,
+  type CompactionInput,
+  type SummarizeFn,
+} from "../context-compactor.js";
+
+// ── estimateTokens ──────────────────────────────────────────────────────
+
+describe("estimateTokens", () => {
+  it("returns 0 for empty string", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it('estimates "hello" as ~1-2 tokens', () => {
+    // "hello" = 5 chars => 5/4 = 1.25 => Math.round => 1
+    expect(estimateTokens("hello")).toBe(1);
+  });
+
+  it("estimates longer text proportionally", () => {
+    const text = "a".repeat(400);
+    expect(estimateTokens(text)).toBe(100);
+  });
+});
+
+// ── estimateMessagesTokens ──────────────────────────────────────────────
+
+describe("estimateMessagesTokens", () => {
+  it("estimates string content messages", () => {
+    const messages = [
+      { role: "user", content: "Hello, how are you?" },
+      { role: "assistant", content: "I am fine." },
+    ];
+    const tokens = estimateMessagesTokens(messages);
+    // Each message: 4 (overhead) + text tokens
+    // "Hello, how are you?" = 19 chars => ~5 tokens => total 9
+    // "I am fine." = 10 chars => ~3 tokens => total 7
+    // Sum = 16
+    expect(tokens).toBeGreaterThan(0);
+    expect(tokens).toBe(
+      4 + estimateTokens("Hello, how are you?") +
+      4 + estimateTokens("I am fine."),
+    );
+  });
+
+  it("estimates tool call messages", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "readFile",
+            arguments: { path: "/tmp/test.txt" },
+          },
+        ],
+      },
+    ];
+    const tokens = estimateMessagesTokens(messages);
+    expect(tokens).toBeGreaterThan(4); // more than just overhead
+  });
+
+  it("estimates tool result messages", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        content: [
+          { type: "text", text: "File contents here: hello world" },
+        ],
+      },
+    ];
+    const tokens = estimateMessagesTokens(messages);
+    expect(tokens).toBe(4 + estimateTokens("File contents here: hello world"));
+  });
+
+  it("handles empty array", () => {
+    expect(estimateMessagesTokens([])).toBe(0);
+  });
+});
+
+// ── shouldCompact ───────────────────────────────────────────────────────
+
+describe("shouldCompact", () => {
+  const config: CompactionConfig = {
+    contextWindow: 100_000,
+    maxOutputTokens: 4_000,
+  };
+
+  it("returns false when below threshold", () => {
+    // usable = 96000, threshold = 81600 (85%)
+    expect(shouldCompact(config, 50_000)).toBe(false);
+  });
+
+  it("returns true when above threshold", () => {
+    // usable = 96000, threshold = 81600 (85%)
+    expect(shouldCompact(config, 85_000)).toBe(true);
+  });
+
+  it("returns true at exact threshold", () => {
+    const usable = config.contextWindow - config.maxOutputTokens;
+    const threshold = usable * TRIGGER_THRESHOLD;
+    expect(shouldCompact(config, threshold)).toBe(true);
+  });
+
+  it("returns false when disabled", () => {
+    expect(shouldCompact({ ...config, disabled: true }, 999_999)).toBe(false);
+  });
+
+  it("uses custom triggerThreshold", () => {
+    const custom: CompactionConfig = {
+      ...config,
+      triggerThreshold: 0.5,
+    };
+    // usable = 96000, threshold = 48000 (50%)
+    expect(shouldCompact(custom, 50_000)).toBe(true);
+    expect(shouldCompact(custom, 40_000)).toBe(false);
+  });
+});
+
+// ── pruneToolOutputs ────────────────────────────────────────────────────
+
+describe("pruneToolOutputs", () => {
+  const config: CompactionConfig = {
+    contextWindow: 200_000,
+    maxOutputTokens: 4_000,
+  };
+
+  it("returns unchanged messages when no tool outputs", () => {
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+    const result = pruneToolOutputs(messages, config);
+    expect(result).toEqual(messages);
+  });
+
+  it("protects recent tool outputs", () => {
+    // Create a single tool result that fits within PRUNE_PROTECT
+    const smallOutput = "x".repeat(100); // ~25 tokens, well within 40K
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: smallOutput }],
+        toolName: "readFile",
+      },
+    ];
+    const result = pruneToolOutputs(messages, config);
+    // Should be unchanged since it's within the protected window
+    expect(result[0].content[0].text).toBe(smallOutput);
+  });
+
+  it("prunes old outputs beyond the protection window", () => {
+    // Create outputs that exceed PRUNE_PROTECT + PRUNE_MINIMUM
+    const bigOutput = "x".repeat(PRUNE_PROTECT * 4 + PRUNE_MINIMUM * 4 + 100);
+    // Oldest message — should be pruned
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: bigOutput }],
+        toolName: "oldTool",
+      },
+      // Recent message — protected
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: "y".repeat(PRUNE_PROTECT * 4) }],
+        toolName: "recentTool",
+      },
+    ];
+
+    const result = pruneToolOutputs(messages, config);
+    // Old output should be pruned
+    expect(result[0].content[0].text).toContain("[Output pruned");
+    expect(result[0].content[0].text).toContain("Tool: oldTool");
+    // Recent output should be preserved
+    expect(result[1].content[0].text).toBe("y".repeat(PRUNE_PROTECT * 4));
+  });
+
+  it("does not prune if total prunable is under minimum", () => {
+    // Two small outputs — neither exceeds minimum for pruning
+    const smallOutput = "x".repeat(100);
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: smallOutput }],
+        toolName: "tool1",
+      },
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: smallOutput }],
+        toolName: "tool2",
+      },
+    ];
+
+    const result = pruneToolOutputs(messages, config);
+    // Both should be unchanged
+    expect(result[0].content[0].text).toBe(smallOutput);
+    expect(result[1].content[0].text).toBe(smallOutput);
+  });
+
+  it("does not mutate original messages", () => {
+    const bigOutput = "x".repeat((PRUNE_PROTECT + PRUNE_MINIMUM) * 4 + 400);
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: bigOutput }],
+        toolName: "tool1",
+      },
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: "y".repeat(PRUNE_PROTECT * 4) }],
+        toolName: "tool2",
+      },
+    ];
+
+    const originalFirstText = messages[0].content[0].text;
+    pruneToolOutputs(messages, config);
+    // Original should be untouched
+    expect(messages[0].content[0].text).toBe(originalFirstText);
+  });
+});
+
+// ── compactIfNeeded ─────────────────────────────────────────────────────
+
+describe("compactIfNeeded", () => {
+  const smallConfig: CompactionConfig = {
+    contextWindow: 1000,
+    maxOutputTokens: 100,
+    // usable = 900, trigger at 765 (85%), target after = 450 (50%)
+  };
+
+  const mockSummarize: SummarizeFn = vi.fn(async () => "Summary of previous context.");
+
+  function makeInput(overrides: Partial<CompactionInput> = {}): CompactionInput {
+    return {
+      systemPrompt: "You are a helpful assistant.",
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi there" },
+      ],
+      config: smallConfig,
+      summarize: mockSummarize,
+      mode: "task",
+      ...overrides,
+    };
+  }
+
+  it("returns unchanged when under threshold", async () => {
+    const input = makeInput({
+      config: {
+        contextWindow: 1_000_000,
+        maxOutputTokens: 4_000,
+      },
+    });
+
+    const result = await compactIfNeeded(input);
+    expect(result.compacted).toBe(false);
+    expect(result.pruned).toBe(false);
+    expect(result.messages).toBe(input.messages); // same reference
+    expect(result.tokensBefore).toBe(result.tokensAfter);
+  });
+
+  it("returns unchanged when disabled", async () => {
+    const input = makeInput({
+      config: { ...smallConfig, disabled: true },
+    });
+    // Even with a tiny context window, disabled means no compaction
+    const result = await compactIfNeeded(input);
+    expect(result.compacted).toBe(false);
+  });
+
+  it("prunes sufficiently without calling summarize", async () => {
+    const summarize = vi.fn(async () => "summary");
+
+    // Build messages that push over threshold due to large tool outputs,
+    // where pruning alone is enough to get under target.
+    //
+    // The pruning logic walks backwards (most recent first) and protects
+    // recent tool outputs up to pruneProtect tokens. Once that budget is
+    // filled, everything older is prunable.
+    //
+    // Config: contextWindow=2000, maxOutputTokens=100 => usable=1900
+    // trigger = 1615 (85%), target = 950 (50%)
+    const config: CompactionConfig = {
+      contextWindow: 2000,
+      maxOutputTokens: 100,
+      pruneProtect: 200, // protect 200 tokens of recent tool output
+      pruneMinimum: 50,  // prune if at least 50 tokens reclaimable
+    };
+
+    // System prompt "You are a helpful assistant." = 28 chars = 7 tokens
+    // Msg "do something" = 12 chars = 3 + 4 overhead = 7
+    // Old tool result "x"*6000 = 6000 chars = 1500 + 4 overhead = 1504 tokens
+    // Recent tool result "y"*1000 = 1000 chars = 250 + 4 overhead = 254 tokens
+    //   (250 > pruneProtect=200, so this alone fills the protect budget)
+    // Msg "done" = 4 chars = 1 + 4 overhead = 5
+    // Total = 7 + 7 + 1504 + 254 + 5 = 1777, well over trigger of 1615
+    //
+    // After pruning: old tool result becomes short placeholder (~15 tokens + overhead)
+    // Total after = 7 + 7 + ~19 + 254 + 5 = ~292, under target of 950
+    const messages = [
+      { role: "user", content: "do something" },
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: "x".repeat(6000) }],
+        toolName: "bigTool",
+      },
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: "y".repeat(1000) }],
+        toolName: "recentTool",
+      },
+      { role: "assistant", content: "done" },
+    ];
+
+    const input = makeInput({ messages, config, summarize });
+    const result = await compactIfNeeded(input);
+
+    expect(result.pruned).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
+    // Summarize should NOT have been called since pruning was sufficient
+    expect(summarize).not.toHaveBeenCalled();
+    // The old tool result should contain the placeholder
+    const prunedToolResult = result.messages[1];
+    expect(prunedToolResult.content[0].text).toContain("[Output pruned");
+  });
+
+  it("calls summarize when pruning is insufficient", async () => {
+    const summarize = vi.fn(async () => "Brief summary.");
+
+    // Very small context window forces summarization
+    const config: CompactionConfig = {
+      contextWindow: 200,
+      maxOutputTokens: 10,
+      // usable = 190, trigger = 161.5, target = 95
+      pruneProtect: 0,
+      pruneMinimum: 0,
+    };
+
+    // Generate enough text messages to exceed threshold
+    // Each message ~4 overhead + text tokens
+    const messages: any[] = [];
+    for (let i = 0; i < 30; i++) {
+      messages.push({ role: "user", content: `Question number ${i}: ${"context ".repeat(10)}` });
+      messages.push({ role: "assistant", content: `Answer number ${i}: ${"response ".repeat(10)}` });
+    }
+
+    const input = makeInput({ messages, config, summarize });
+    const result = await compactIfNeeded(input);
+
+    expect(result.compacted).toBe(true);
+    expect(summarize).toHaveBeenCalled();
+    expect(result.summary).toBe("Brief summary.");
+    // First message should be the summary injection
+    expect(result.messages[0].role).toBe("user");
+    expect(result.messages[0].content).toContain("[Previous context summary]");
+    expect(result.messages[0].content).toContain("Brief summary.");
+    expect(result.messages[0].content).toContain("[End summary — continue from here]");
+  });
+});
+
+// ── getCompactionPrompt ─────────────────────────────────────────────────
+
+describe("getCompactionPrompt", () => {
+  it("returns task prompt for task mode", () => {
+    const prompt = getCompactionPrompt("task");
+    expect(prompt).toContain("Summarize the conversation for handoff");
+    expect(prompt).toContain("### Goal");
+    expect(prompt).toContain("### Progress");
+    expect(prompt).toContain("### Files Modified");
+    expect(prompt).toContain("### Next Steps");
+  });
+
+  it("returns chat prompt for chat mode", () => {
+    const prompt = getCompactionPrompt("chat");
+    expect(prompt).toContain("Summarize the conversation to preserve context");
+    expect(prompt).toContain("user preferences");
+  });
+});
+
+// ── Constants exported correctly ────────────────────────────────────────
+
+describe("constants", () => {
+  it("exports expected values", () => {
+    expect(PRUNE_PROTECT).toBe(40_000);
+    expect(PRUNE_MINIMUM).toBe(20_000);
+    expect(TRIGGER_THRESHOLD).toBe(0.85);
+    expect(TARGET_AFTER).toBe(0.50);
+  });
+});

--- a/packages/core/src/context-compactor.ts
+++ b/packages/core/src/context-compactor.ts
@@ -1,0 +1,413 @@
+/**
+ * Context Compaction — prevents context window overflow.
+ *
+ * Two-phase approach (same as OpenCode):
+ * Phase 1: Prune old tool outputs (no LLM call, free)
+ * Phase 2: LLM summarization if pruning isn't enough
+ */
+
+// ── Token estimation ────────────────────────────────────────────────────
+
+/** Estimate token count: ~4 chars per token (industry standard heuristic) */
+export function estimateTokens(text: string): number {
+  return Math.round(text.length / 4);
+}
+
+// ── Constants (same as OpenCode) ────────────────────────────────────────
+
+/** Protect last 40K tokens of tool output from pruning */
+export const PRUNE_PROTECT = 40_000;
+
+/** Only prune if we can reclaim at least 20K tokens */
+export const PRUNE_MINIMUM = 20_000;
+
+/** Trigger compaction at 85% of usable context */
+export const TRIGGER_THRESHOLD = 0.85;
+
+/** Target 50% of usable context after compaction */
+export const TARGET_AFTER = 0.50;
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+export interface CompactionConfig {
+  /** Model's context window size in tokens */
+  contextWindow: number;
+  /** Max output tokens the model can generate */
+  maxOutputTokens: number;
+  /** Trigger compaction at this % of usable context (default: 0.85) */
+  triggerThreshold?: number;
+  /** Tokens of recent tool output to protect from pruning (default: 40000) */
+  pruneProtect?: number;
+  /** Minimum tokens to reclaim before pruning (default: 20000) */
+  pruneMinimum?: number;
+  /** Disable auto-compaction entirely */
+  disabled?: boolean;
+}
+
+export type SummarizeFn = (messages: any[], prompt: string) => Promise<string>;
+
+/** Event emitted when compaction occurs */
+export interface CompactionEvent {
+  /** What phase triggered: "prune" or "summarize" */
+  phase: "prune" | "summarize";
+  /** Token count before compaction */
+  tokensBefore: number;
+  /** Token count after compaction */
+  tokensAfter: number;
+  /** Tokens reclaimed */
+  tokensReclaimed: number;
+  /** Number of messages before */
+  messagesBefore: number;
+  /** Number of messages after */
+  messagesAfter: number;
+  /** Number of tool outputs pruned (phase 1) */
+  toolOutputsPruned?: number;
+  /** Summary text (phase 2 only) */
+  summary?: string;
+  /** Mode: task or chat */
+  mode: "task" | "chat";
+}
+
+export type OnCompactionFn = (event: CompactionEvent) => void;
+
+export interface CompactionInput {
+  systemPrompt: string;
+  messages: any[]; // AgentMessage[] from pi-agent-core
+  tools?: any[];
+  config: CompactionConfig;
+  summarize: SummarizeFn;
+  mode: "task" | "chat";
+  /** Called when compaction occurs — use for logging, events, UI updates */
+  onCompaction?: OnCompactionFn;
+}
+
+export interface CompactionResult {
+  messages: any[];
+  compacted: boolean;
+  pruned: boolean;
+  summary?: string;
+  tokensBefore: number;
+  tokensAfter: number;
+}
+
+// ── Summarization prompts ───────────────────────────────────────────────
+
+const TASK_COMPACTION_PROMPT = `Summarize the conversation for handoff to a continuation agent.
+
+## Required sections:
+### Goal
+What is the task trying to accomplish?
+
+### Progress
+- Completed: what's done
+- In progress: what was interrupted
+- Remaining: what's left
+
+### Key Decisions & Discoveries
+Technical decisions, constraints found, approaches tried and failed
+
+### Files Modified
+List of files read, created, or edited with brief description
+
+### Next Steps
+Specific actions to take next
+
+Be precise and concise. Preserve file paths, function names, and error messages exactly.`;
+
+const CHAT_COMPACTION_PROMPT = `Summarize the conversation to preserve context for continuation.
+Focus on: user preferences, decisions made, questions asked, key facts shared.
+Preserve any code snippets, file paths, or technical details mentioned.
+Be precise and concise.`;
+
+/** Get the appropriate compaction prompt for a given mode */
+export function getCompactionPrompt(mode: "task" | "chat"): string {
+  return mode === "task" ? TASK_COMPACTION_PROMPT : CHAT_COMPACTION_PROMPT;
+}
+
+// ── Token estimation for messages ───────────────────────────────────────
+
+/** Estimate total tokens across an array of messages */
+export function estimateMessagesTokens(messages: any[]): number {
+  let total = 0;
+  for (const msg of messages) {
+    total += estimateMessageTokens(msg);
+  }
+  return total;
+}
+
+function estimateMessageTokens(msg: any): number {
+  if (!msg) return 0;
+
+  // Role overhead (~4 tokens for role + formatting)
+  let tokens = 4;
+
+  const content = msg.content;
+  if (typeof content === "string") {
+    tokens += estimateTokens(content);
+  } else if (Array.isArray(content)) {
+    for (const block of content) {
+      if (block.type === "text" && typeof block.text === "string") {
+        tokens += estimateTokens(block.text);
+      } else if (block.type === "toolCall") {
+        // Tool call: name + stringified arguments
+        if (block.name) tokens += estimateTokens(block.name);
+        if (block.arguments !== undefined) {
+          const args =
+            typeof block.arguments === "string"
+              ? block.arguments
+              : JSON.stringify(block.arguments);
+          tokens += estimateTokens(args);
+        }
+      }
+    }
+  }
+
+  return tokens;
+}
+
+// ── Threshold check ─────────────────────────────────────────────────────
+
+/** Check whether compaction should be triggered based on current token usage */
+export function shouldCompact(config: CompactionConfig, currentTokens: number): boolean {
+  if (config.disabled) return false;
+  const usable = config.contextWindow - config.maxOutputTokens;
+  const threshold = config.triggerThreshold ?? TRIGGER_THRESHOLD;
+  return currentTokens >= usable * threshold;
+}
+
+// ── Phase 1: Prune tool outputs ─────────────────────────────────────────
+
+/**
+ * Walk backwards through messages and replace old tool result content with
+ * placeholders. Protects the most recent `pruneProtect` tokens of tool output.
+ * Only prunes if total prunable tokens >= `pruneMinimum`.
+ */
+export function pruneToolOutputs(
+  messages: any[],
+  config: CompactionConfig,
+): any[] {
+  const protectTokens = config.pruneProtect ?? PRUNE_PROTECT;
+  const minimumTokens = config.pruneMinimum ?? PRUNE_MINIMUM;
+
+  // First pass: walk backwards and collect tool result locations + sizes
+  interface ToolResultEntry {
+    messageIndex: number;
+    blockIndex?: number; // for array content within toolResult messages
+    tokens: number;
+    toolName: string;
+  }
+
+  const entries: ToolResultEntry[] = [];
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "toolResult" && Array.isArray(msg.content)) {
+      for (let j = msg.content.length - 1; j >= 0; j--) {
+        const block = msg.content[j];
+        if (block.type === "text" && typeof block.text === "string") {
+          const tokens = estimateTokens(block.text);
+          // Try to find the tool name from the message-level or block-level properties
+          const toolName = msg.toolName || msg.name || block.toolName || "unknown";
+          entries.push({
+            messageIndex: i,
+            blockIndex: j,
+            tokens,
+            toolName,
+          });
+        }
+      }
+    }
+  }
+
+  // entries are in reverse order (most recent first) due to backward walk
+  // Calculate how many tokens to protect and how many are prunable
+  let protectedSoFar = 0;
+  let prunableTokens = 0;
+  const prunableEntries: ToolResultEntry[] = [];
+
+  for (const entry of entries) {
+    if (protectedSoFar < protectTokens) {
+      protectedSoFar += entry.tokens;
+    } else {
+      prunableTokens += entry.tokens;
+      prunableEntries.push(entry);
+    }
+  }
+
+  // Only prune if we can reclaim enough
+  if (prunableTokens < minimumTokens) {
+    return messages;
+  }
+
+  // Deep-clone messages to avoid mutation
+  const result: any[] = JSON.parse(JSON.stringify(messages));
+
+  // Apply pruning
+  for (const entry of prunableEntries) {
+    const msg = result[entry.messageIndex];
+    if (entry.blockIndex !== undefined && Array.isArray(msg.content)) {
+      msg.content[entry.blockIndex] = {
+        type: "text",
+        text: `[Output pruned — was ${entry.tokens} tokens. Tool: ${entry.toolName}]`,
+      };
+    }
+  }
+
+  return result;
+}
+
+// ── Phase 2: Full compaction ────────────────────────────────────────────
+
+/**
+ * Main entry point. Checks if compaction is needed, tries pruning first,
+ * then falls back to LLM summarization if necessary.
+ */
+export async function compactIfNeeded(input: CompactionInput): Promise<CompactionResult> {
+  const { systemPrompt, messages, tools, config, summarize, mode, onCompaction } = input;
+
+  if (config.disabled) {
+    const tokens = estimateTotalTokens(systemPrompt, messages, tools);
+    return {
+      messages,
+      compacted: false,
+      pruned: false,
+      tokensBefore: tokens,
+      tokensAfter: tokens,
+    };
+  }
+
+  const tokensBefore = estimateTotalTokens(systemPrompt, messages, tools);
+  const usable = config.contextWindow - config.maxOutputTokens;
+  const threshold = config.triggerThreshold ?? TRIGGER_THRESHOLD;
+
+  // Not over threshold — nothing to do
+  if (tokensBefore < usable * threshold) {
+    return {
+      messages,
+      compacted: false,
+      pruned: false,
+      tokensBefore,
+      tokensAfter: tokensBefore,
+    };
+  }
+
+  const target = usable * TARGET_AFTER;
+
+  // Phase 1: try pruning tool outputs
+  const pruned = pruneToolOutputs(messages, config);
+  const tokensAfterPrune = estimateTotalTokens(systemPrompt, pruned, tools);
+
+  if (tokensAfterPrune <= target) {
+    onCompaction?.({
+      phase: "prune",
+      tokensBefore,
+      tokensAfter: tokensAfterPrune,
+      tokensReclaimed: tokensBefore - tokensAfterPrune,
+      messagesBefore: messages.length,
+      messagesAfter: pruned.length,
+      toolOutputsPruned: countPrunedOutputs(pruned),
+      mode,
+    });
+    return {
+      messages: pruned,
+      compacted: true,
+      pruned: true,
+      tokensBefore,
+      tokensAfter: tokensAfterPrune,
+    };
+  }
+
+  // Phase 2: LLM summarization
+  // Keep ~60% of target budget as recent messages
+  const recentBudget = target * 0.6;
+
+  // Walk backwards to find split point
+  let recentTokens = 0;
+  let splitIndex = pruned.length;
+  for (let i = pruned.length - 1; i >= 0; i--) {
+    const msgTokens = estimateMessageTokens(pruned[i]);
+    if (recentTokens + msgTokens > recentBudget && i < pruned.length - 1) {
+      splitIndex = i + 1;
+      break;
+    }
+    recentTokens += msgTokens;
+    if (i === 0) splitIndex = 0;
+  }
+
+  // Need at least some older messages to summarize
+  if (splitIndex <= 0) {
+    // Everything is "recent" — just return pruned
+    return {
+      messages: pruned,
+      compacted: true,
+      pruned: true,
+      tokensBefore,
+      tokensAfter: tokensAfterPrune,
+    };
+  }
+
+  const olderMessages = pruned.slice(0, splitIndex);
+  const recentMessages = pruned.slice(splitIndex);
+
+  const prompt = getCompactionPrompt(mode);
+  const summary = await summarize(olderMessages, prompt);
+
+  const summaryMessage = {
+    role: "user",
+    content: `[Previous context summary]\n${summary}\n[End summary — continue from here]`,
+  };
+
+  const compactedMessages = [summaryMessage, ...recentMessages];
+  const tokensAfter = estimateTotalTokens(systemPrompt, compactedMessages, tools);
+
+  onCompaction?.({
+    phase: "summarize",
+    tokensBefore,
+    tokensAfter,
+    tokensReclaimed: tokensBefore - tokensAfter,
+    messagesBefore: messages.length,
+    messagesAfter: compactedMessages.length,
+    toolOutputsPruned: countPrunedOutputs(pruned),
+    summary,
+    mode,
+  });
+
+  return {
+    messages: compactedMessages,
+    compacted: true,
+    pruned: true,
+    summary,
+    tokensBefore,
+    tokensAfter,
+  };
+}
+
+// ── Internal helpers ────────────────────────────────────────────────────
+
+function countPrunedOutputs(messages: any[]): number {
+  let count = 0;
+  for (const msg of messages) {
+    if (msg.role === "toolResult" && Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (block.type === "text" && typeof block.text === "string" && block.text.startsWith("[Output pruned")) {
+          count++;
+        }
+      }
+    }
+  }
+  return count;
+}
+
+function estimateTotalTokens(
+  systemPrompt: string,
+  messages: any[],
+  tools?: any[],
+): number {
+  let total = estimateTokens(systemPrompt);
+  total += estimateMessagesTokens(messages);
+  if (tools && tools.length > 0) {
+    // Rough estimate: stringify tool definitions
+    total += estimateTokens(JSON.stringify(tools));
+  }
+  return total;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,3 +112,25 @@ export { assessTask, runCheck, runMetric, type AssessmentDeps, type CheckProgres
 export { DEFAULT_DIMENSIONS, buildRubricSection, computeWeightedScore, computeMedianScores } from "./assessment-scoring.js";
 export { validateReviewPayload, ReviewPayloadSchema, ReviewScoreSchema, REVIEW_JSON_SCHEMA, type ValidatedReviewPayload } from "./assessment-schemas.js";
 export { withRetry, isTransientError, type RetryOptions } from "./retry.js";
+
+// ── Context Compaction ──────────────────────────────────────────────────
+export {
+  estimateTokens,
+  estimateMessagesTokens,
+  shouldCompact,
+  pruneToolOutputs,
+  compactIfNeeded,
+  getCompactionPrompt,
+  PRUNE_PROTECT,
+  PRUNE_MINIMUM,
+  TRIGGER_THRESHOLD,
+  TARGET_AFTER,
+} from "./context-compactor.js";
+export type {
+  CompactionConfig,
+  CompactionEvent,
+  OnCompactionFn,
+  SummarizeFn,
+  CompactionInput,
+  CompactionResult,
+} from "./context-compactor.js";

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -18,7 +18,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { streamSSE } from "hono/streaming";
 import { nanoid } from "nanoid";
-import { agentMemoryScope } from "@polpo-ai/core";
+import { agentMemoryScope, compactIfNeeded, type SummarizeFn, type CompactionEvent } from "@polpo-ai/core";
 
 const MAX_TURNS = 20;
 
@@ -265,6 +265,32 @@ function sseChunk(
   });
 }
 
+/**
+ * Build a SummarizeFn from deps.streamLLM.
+ * Collects all text deltas from a streaming LLM call and returns the full text.
+ */
+function buildSummarizeFn(
+  deps: CompletionRouteDeps,
+  model: any,
+  streamOpts: any,
+): SummarizeFn {
+  return async (msgs: any[], prompt: string): Promise<string> => {
+    const piStream = deps.streamLLM(model, {
+      systemPrompt: prompt,
+      messages: msgs,
+      tools: [],
+    }, streamOpts);
+
+    let text = "";
+    for await (const event of piStream) {
+      if (event.type === "text_delta") {
+        text += event.delta;
+      }
+    }
+    return text.trim();
+  };
+}
+
 function completionResponse(id: string, content: string, promptTokens: number, completionTokens: number) {
   return {
     id,
@@ -479,6 +505,37 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
           for (let turn = 0; turn < MAX_TURNS; turn++) {
             // Bail out early if the client already disconnected
             if (abortController.signal.aborted) break;
+
+            // Compact context if approaching the model's context window limit.
+            // Under threshold this is just a cheap token estimation — zero LLM calls.
+            const compactionResult = await compactIfNeeded({
+              systemPrompt: fullSystemPrompt,
+              messages,
+              tools: effectiveTools,
+              config: {
+                contextWindow: m.contextWindow ?? 200_000,
+                maxOutputTokens: m.maxTokens ?? 8192,
+              },
+              summarize: buildSummarizeFn(deps, m, streamOpts),
+              mode: "chat",
+              onCompaction: async (event: CompactionEvent) => {
+                await stream.writeSSE({
+                  data: sseChunk(completionId, {}, null, {
+                    compaction: {
+                      phase: event.phase,
+                      tokensBefore: event.tokensBefore,
+                      tokensAfter: event.tokensAfter,
+                      tokensReclaimed: event.tokensReclaimed,
+                      messagesBefore: event.messagesBefore,
+                      messagesAfter: event.messagesAfter,
+                    },
+                  }),
+                });
+              },
+            });
+            if (compactionResult.compacted) {
+              messages.splice(0, messages.length, ...compactionResult.messages);
+            }
 
             const piStream = deps.streamLLM(m, {
               systemPrompt: fullSystemPrompt,
@@ -699,6 +756,24 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
 
       try {
         for (let turn = 0; turn < MAX_TURNS; turn++) {
+          // Compact context if approaching the model's context window limit.
+          // Under threshold this is just a cheap token estimation — zero LLM calls.
+          const compactionResult = await compactIfNeeded({
+            systemPrompt: fullSystemPrompt,
+            messages,
+            tools: effectiveTools,
+            config: {
+              contextWindow: m.contextWindow ?? 200_000,
+              maxOutputTokens: m.maxTokens ?? 8192,
+            },
+            summarize: buildSummarizeFn(deps, m, streamOpts),
+            mode: "chat",
+            // Non-streaming: no SSE to write to, compaction is silent
+          });
+          if (compactionResult.compacted) {
+            messages.splice(0, messages.length, ...compactionResult.messages);
+          }
+
           const piStream = deps.streamLLM(m, {
             systemPrompt: fullSystemPrompt,
             messages,

--- a/src/adapters/engine.ts
+++ b/src/adapters/engine.ts
@@ -22,12 +22,14 @@ export function createActivity(): AgentActivity {
   };
 }
 import { Agent } from "@mariozechner/pi-agent-core";
-import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import { join, sep } from "node:path";
 import { resolveModel, resolveApiKeyAsync, enforceModelAllowlist } from "../llm/pi-client.js";
 import { createSystemTools, createAllTools } from "../tools/system-tools.js";
 import { loadAgentSkills, buildSkillPrompt } from "../llm/skills.js";
 import { nanoid } from "nanoid";
+import { compactIfNeeded, type SummarizeFn, type CompactionEvent } from "@polpo-ai/core";
+import { completeSimple } from "@mariozechner/pi-ai";
 
 /**
  * Build an "## Available Tools" section for the agent's system prompt.
@@ -414,12 +416,58 @@ export function spawnEngine(agentConfig: AgentConfig, task: Task, cwd: string, c
   // Resolve reasoning level: agent config > global settings (via SpawnContext) > "off"
   const thinkingLevel = agentConfig.reasoning ?? ctx?.reasoning ?? "off";
 
+  // Build the system prompt once for reuse in both the Agent and context compaction
+  const systemPrompt = buildSystemPrompt(agentConfig, cwd, ctx?.polpoDir, outputDir, effectiveAllowedPaths);
+
   // Create the pi-agent-core Agent (starts with coding tools only; extended tools added before prompt)
   // Pass model.maxTokens to override pi-ai's 32K default cap, so each model uses its full output capacity.
   const agent = new Agent({
     getApiKey: (provider: string) => resolveApiKeyAsync(provider),
+    // Context compaction: prune old tool outputs, then LLM-summarize if still over threshold.
+    // Runs before every LLM call. Under threshold → zero overhead (just token estimation).
+    transformContext: async (messages: AgentMessage[]) => {
+      const summarize: SummarizeFn = async (msgs, prompt) => {
+        const apiKey = await resolveApiKeyAsync(model.provider as string);
+        const response = await completeSimple(model, {
+          systemPrompt: prompt,
+          messages: msgs as any[],
+        }, apiKey ? { apiKey, maxTokens: model.maxTokens } : { maxTokens: model.maxTokens });
+        return response.content
+          .filter((c: any): c is { type: "text"; text: string } => c.type === "text")
+          .map((c: { type: "text"; text: string }) => c.text)
+          .join("\n")
+          .trim();
+      };
+
+      const result = await compactIfNeeded({
+        systemPrompt,
+        messages,
+        tools: agent.state.tools,
+        config: {
+          contextWindow: model.contextWindow ?? 200_000,
+          maxOutputTokens: model.maxTokens ?? 8192,
+        },
+        summarize,
+        mode: "task",
+        onCompaction: (event: CompactionEvent) => {
+          handle.onTranscript?.({
+            type: "compaction",
+            phase: event.phase,
+            tokensBefore: event.tokensBefore,
+            tokensAfter: event.tokensAfter,
+            tokensReclaimed: event.tokensReclaimed,
+            messagesBefore: event.messagesBefore,
+            messagesAfter: event.messagesAfter,
+            toolOutputsPruned: event.toolOutputsPruned,
+            summary: event.summary,
+          });
+        },
+      });
+
+      return result.compacted ? result.messages as AgentMessage[] : messages;
+    },
     initialState: {
-      systemPrompt: buildSystemPrompt(agentConfig, cwd, ctx?.polpoDir, outputDir, effectiveAllowedPaths),
+      systemPrompt,
       model,
       thinkingLevel,
       maxTokens: model.maxTokens,


### PR DESCRIPTION
## Summary
Two-phase context compaction (OpenCode pattern):
- Phase 1: prune old tool outputs (no LLM call, protects last 40K tokens)
- Phase 2: LLM summarization if pruning isn't enough

Integrated in both paths:
- Task execution: via pi-agent-core `transformContext` hook
- Chat completions: before each `streamLLM` call

Trigger at 85% of context window. Zero overhead when under threshold.
24 new tests.