### PR TITLE
feat: session store preserves ContentPart[] in messages

### DIFF
--- a/packages/client-sdk/src/client/types.ts
+++ b/packages/client-sdk/src/client/types.ts
@@ -1196,7 +1196,7 @@ export interface ChatSession {
 export interface ChatMessage {
   id: string;
   role: "user" | "assistant";
-  content: string;
+  content: string | ContentPart[];
   ts: string;
   /** Tool calls executed during this assistant message (only for role=assistant) */
   toolCalls?: ToolCallEvent[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,7 @@ export type { ConfigStore } from "./config-store.js";
 export type { MemoryStore } from "./memory-store.js";
 export { agentMemoryScope } from "./memory-store.js";
 export type { LogStore, LogEntry, SessionInfo } from "./log-store.js";
-export type { SessionStore, Session, Message, MessageRole, ToolCallInfo, ToolCallState } from "./session-store.js";
+export type { SessionStore, Session, Message, MessageRole, ToolCallInfo, ToolCallState, SessionContentPart } from "./session-store.js";
 export type { ApprovalStore } from "./approval-store.js";
 export type { TeamStore } from "./team-store.js";
 export type { AgentStore } from "./agent-store.js";

--- a/packages/core/src/session-store.ts
+++ b/packages/core/src/session-store.ts
@@ -5,6 +5,12 @@
 
 export type MessageRole = "user" | "assistant";
 
+/** Multimodal content parts — mirrors OpenAI content-part format. */
+export type SessionContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string; detail?: string } }
+  | { type: "file"; file_id: string };
+
 export type ToolCallState = "preparing" | "calling" | "completed" | "error" | "interrupted";
 
 export interface ToolCallInfo {
@@ -23,7 +29,7 @@ export interface ToolCallInfo {
 export interface Message {
   id: string;              // nanoid(10)
   role: MessageRole;
-  content: string;
+  content: string | SessionContentPart[];
   ts: string;              // ISO timestamp
   /** Tool calls executed during this assistant message (only for role=assistant) */
   toolCalls?: ToolCallInfo[];
@@ -41,9 +47,9 @@ export interface Session {
 
 export interface SessionStore {
   create(title?: string, agent?: string): Promise<string>;
-  addMessage(sessionId: string, role: MessageRole, content: string): Promise<Message>;
+  addMessage(sessionId: string, role: MessageRole, content: string | SessionContentPart[]): Promise<Message>;
   /** Update the content of an existing message (e.g. finalize a streaming response). */
-  updateMessage(sessionId: string, messageId: string, content: string, toolCalls?: ToolCallInfo[]): Promise<boolean>;
+  updateMessage(sessionId: string, messageId: string, content: string | SessionContentPart[], toolCalls?: ToolCallInfo[]): Promise<boolean>;
   getMessages(sessionId: string): Promise<Message[]>;
   getRecentMessages(sessionId: string, limit: number): Promise<Message[]>;
   listSessions(): Promise<Session[]>;

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -626,6 +626,45 @@ describe("DrizzleSessionStore", () => {
     const msgs = await stores.sessionStore.getMessages(sid);
     expect(msgs[0].content).toBe("final");
   });
+
+  it("addMessage with ContentPart[] round-trips correctly", async () => {
+    const sid = await stores.sessionStore.create();
+    const parts = [
+      { type: "text" as const, text: "Check this image" },
+      { type: "image_url" as const, image_url: { url: "https://example.com/img.png", detail: "auto" } },
+      { type: "file" as const, file_id: "att_abc123" },
+    ];
+    const msg = await stores.sessionStore.addMessage(sid, "user", parts);
+    expect(msg.content).toEqual(parts);
+
+    const msgs = await stores.sessionStore.getMessages(sid);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toEqual(parts);
+    expect(Array.isArray(msgs[0].content)).toBe(true);
+  });
+
+  it("updateMessage with ContentPart[] round-trips correctly", async () => {
+    const sid = await stores.sessionStore.create();
+    const msg = await stores.sessionStore.addMessage(sid, "assistant", "draft");
+    const parts = [
+      { type: "text" as const, text: "Updated with parts" },
+      { type: "file" as const, file_id: "att_xyz789" },
+    ];
+    const ok = await stores.sessionStore.updateMessage(sid, msg.id, parts);
+    expect(ok).toBe(true);
+
+    const msgs = await stores.sessionStore.getMessages(sid);
+    expect(msgs[0].content).toEqual(parts);
+  });
+
+  it("plain string content still reads back as string", async () => {
+    const sid = await stores.sessionStore.create();
+    await stores.sessionStore.addMessage(sid, "user", "just a string");
+
+    const msgs = await stores.sessionStore.getMessages(sid);
+    expect(msgs[0].content).toBe("just a string");
+    expect(typeof msgs[0].content).toBe("string");
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/drizzle/src/stores/session-store.ts
+++ b/packages/drizzle/src/stores/session-store.ts
@@ -1,6 +1,6 @@
 import { eq, desc, asc, count as drizzleCount, isNull, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import type { SessionStore, Session, Message, MessageRole, ToolCallInfo } from "@polpo-ai/core/session-store";
+import type { SessionStore, Session, Message, MessageRole, ToolCallInfo, SessionContentPart } from "@polpo-ai/core/session-store";
 import { type Dialect, deserializeJson, extractAffectedRows } from "../utils.js";
 
 type AnyTable = any;
@@ -12,6 +12,20 @@ export class DrizzleSessionStore implements SessionStore {
     private messages: AnyTable,
     private dialect: Dialect,
   ) {}
+
+  /** Serialize content for DB TEXT column: arrays → JSON string, plain strings → as-is. */
+  private serializeContent(content: string | SessionContentPart[]): string {
+    return Array.isArray(content) ? JSON.stringify(content) : content;
+  }
+
+  /** Deserialize content from DB TEXT column: try JSON parse → array, fallback to plain string. */
+  private deserializeContent(raw: string): string | SessionContentPart[] {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed as SessionContentPart[];
+    } catch { /* plain string — not JSON */ }
+    return raw;
+  }
 
   private rowToSession(row: any, messageCount: number): Session {
     return {
@@ -28,7 +42,7 @@ export class DrizzleSessionStore implements SessionStore {
     return {
       id: row.id,
       role: row.role as MessageRole,
-      content: row.content,
+      content: this.deserializeContent(row.content),
       ts: row.ts,
       toolCalls: deserializeJson<ToolCallInfo[] | undefined>(row.toolCalls, undefined, this.dialect),
     };
@@ -47,14 +61,15 @@ export class DrizzleSessionStore implements SessionStore {
     return id;
   }
 
-  async addMessage(sessionId: string, role: MessageRole, content: string): Promise<Message> {
+  async addMessage(sessionId: string, role: MessageRole, content: string | SessionContentPart[]): Promise<Message> {
     const id = nanoid();
     const ts = new Date().toISOString();
+    const serialized = this.serializeContent(content);
     await this.db.insert(this.messages).values({
       id,
       sessionId,
       role,
-      content,
+      content: serialized,
       ts,
       toolCalls: null,
     });
@@ -65,12 +80,13 @@ export class DrizzleSessionStore implements SessionStore {
     return { id, role, content, ts };
   }
 
-  async updateMessage(sessionId: string, messageId: string, content: string, toolCalls?: ToolCallInfo[]): Promise<boolean> {
+  async updateMessage(sessionId: string, messageId: string, content: string | SessionContentPart[], toolCalls?: ToolCallInfo[]): Promise<boolean> {
     const now = new Date().toISOString();
     const tcValue = toolCalls ? JSON.stringify(toolCalls) : null;
+    const serialized = this.serializeContent(content);
 
     const result = await this.db.update(this.messages)
-      .set({ content, toolCalls: tcValue })
+      .set({ content: serialized, toolCalls: tcValue })
       .where(eq(this.messages.id, messageId));
 
     const changed = extractAffectedRows(result) > 0;

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -546,7 +546,7 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
       // Persist user message (only the last one — earlier messages are already persisted)
       const lastUserMsg = [...body.messages].reverse().find(m => m.role === "user");
       if (lastUserMsg && sessionId) {
-        await sessionStore.addMessage(sessionId, "user", extractText(lastUserMsg.content));
+        await sessionStore.addMessage(sessionId, "user", lastUserMsg.content);
       }
     }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -7,7 +7,7 @@ export type { RunStore, RunRecord, RunStatus } from "./run-store.js";
 export type { ConfigStore } from "./config-store.js";
 export type { MemoryStore } from "./memory-store.js";
 export type { LogStore, LogEntry, SessionInfo } from "./log-store.js";
-export type { SessionStore, Session, Message, MessageRole, ToolCallInfo, ToolCallState } from "./session-store.js";
+export type { SessionStore, Session, Message, MessageRole, ToolCallInfo, ToolCallState, SessionContentPart } from "./session-store.js";
 export type { ApprovalStore } from "./approval-store.js";
 export { Orchestrator, buildRetryPrompt } from "./orchestrator.js";
 export type { OrchestratorOptions, AssessFn } from "./orchestrator.js";

--- a/src/stores/file-session-store.ts
+++ b/src/stores/file-session-store.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { nanoid } from "nanoid";
-import type { SessionStore, Session, Message, MessageRole, ToolCallInfo } from "../core/session-store.js";
+import type { SessionStore, Session, Message, MessageRole, ToolCallInfo, SessionContentPart } from "../core/session-store.js";
 
 /**
  * File-backed SessionStore.
@@ -45,7 +45,7 @@ export class FileSessionStore implements SessionStore {
     return sessionId;
   }
 
-  async addMessage(sessionId: string, role: MessageRole, content: string): Promise<Message> {
+  async addMessage(sessionId: string, role: MessageRole, content: string | SessionContentPart[]): Promise<Message> {
     const message: Message = {
       id: nanoid(10),
       role,
@@ -60,7 +60,7 @@ export class FileSessionStore implements SessionStore {
     return message;
   }
 
-  async updateMessage(sessionId: string, messageId: string, content: string, toolCalls?: ToolCallInfo[]): Promise<boolean> {
+  async updateMessage(sessionId: string, messageId: string, content: string | SessionContentPart[], toolCalls?: ToolCallInfo[]): Promise<boolean> {
     const file = this.sessionFile(sessionId);
     if (!existsSync(file)) return false;
     try {


### PR DESCRIPTION
## Summary

Messages in the session store now preserve multimodal content (file attachments, images) instead of flattening to plain text.

### Changes
- `Message.content` → `string | SessionContentPart[]`
- Drizzle store: JSON serialize in TEXT column (backward compatible, old string messages still work)
- Completions route: saves original user content instead of `extractText()`
- Client SDK: `ChatMessage.content` → `string | ContentPart[]`
- 3 new tests for content parts round-trip

### How it works
- User sends: `[{ type: "text", text: "Analyze" }, { type: "file", file_id: "workspace/report.pdf" }]`
- Server saves the full array in session store
- Client reads it back and renders: text + file attachment icon
- Old messages (plain string) still parse correctly

### No DB migration needed
Content column stays TEXT. Arrays are JSON-serialized. Strings are stored as-is.

## Test plan
- [x] 1196 tests pass, zero failures
- [x] ContentPart[] round-trip via addMessage
- [x] ContentPart[] round-trip via updateMessage
- [x] Plain string backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)