### PR TITLE
feat: configurable LLM gateway via polpo.json

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -710,6 +710,15 @@ export interface PolpoSettings {
   defaultQualityThreshold?: number;
   /** Allowed recipient email domains — applies to all agents (can be overridden per-agent). */
   emailAllowedDomains?: string[];
+  /** LLM gateway configuration. */
+  gateway?: {
+    /** Gateway endpoint URL (e.g. "https://ai-gateway.vercel.sh/v1", "http://localhost:11434/v1") */
+    url: string;
+    /** Environment variable name containing the API key (e.g. "AI_GATEWAY_API_KEY"). The key itself is NOT stored in config. */
+    apiKeyEnv?: string;
+    /** Custom headers to send with every request (e.g. OpenRouter requires HTTP-Referer). */
+    headers?: Record<string, string>;
+  };
 }
 
 // === Polpo State (persisted in .polpo/state.json) ===

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -21,12 +21,13 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@polpo-ai/core": "workspace:*",
-    "@ai-sdk/openai": "^3.0.48"
+    "@ai-sdk/openai": "^3.0.48",
+    "@ai-sdk/openai-compatible": "^2.0.37",
+    "@polpo-ai/core": "workspace:*"
   },
   "peerDependencies": {
-    "ai": ">=6.0.0",
-    "@ai-sdk/gateway": ">=3.0.0"
+    "@ai-sdk/gateway": ">=3.0.0",
+    "ai": ">=6.0.0"
   },
   "license": "MIT",
   "repository": {

--- a/packages/llm/src/gateway-config.ts
+++ b/packages/llm/src/gateway-config.ts
@@ -1,0 +1,33 @@
+/**
+ * Gateway configuration — configurable LLM gateway support.
+ *
+ * Allows users to route LLM calls through any OpenAI-compatible gateway
+ * (Vercel AI Gateway, OpenRouter, LiteLLM, Ollama, etc.) by setting
+ * `settings.gateway` in polpo.json.
+ */
+
+export interface GatewayConfig {
+  /** Gateway endpoint URL. */
+  url: string;
+  /** Resolved API key (not env var name). */
+  apiKey?: string;
+  /** Custom headers to send with every request. */
+  headers?: Record<string, string>;
+}
+
+let gatewayConfig: GatewayConfig | null = null;
+
+/** Configure the LLM gateway. Called by the orchestrator at boot from polpo.json settings. */
+export function configureGateway(config: GatewayConfig): void {
+  gatewayConfig = config;
+}
+
+/** Get the current gateway configuration, or null if not configured. */
+export function getGatewayConfig(): GatewayConfig | null {
+  return gatewayConfig;
+}
+
+/** Reset gateway configuration (useful for tests). */
+export function resetGatewayConfig(): void {
+  gatewayConfig = null;
+}

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -39,7 +39,15 @@ export {
 } from "./model-resolver.js";
 export type { ResolvedModel, ParsedModelSpec, ProviderValidationResult } from "./model-resolver.js";
 
-// ─── Provider Factory ──────���─────────────────────────
+// ─── Gateway Config ─────────────────────────────────
+export {
+  configureGateway,
+  getGatewayConfig,
+  resetGatewayConfig,
+} from "./gateway-config.js";
+export type { GatewayConfig } from "./gateway-config.js";
+
+// ─── Provider Factory ─────────────────────────────────
 export {
   createCustomProviderModel,
   createGatewayModel,

--- a/packages/llm/src/model-resolver.ts
+++ b/packages/llm/src/model-resolver.ts
@@ -12,6 +12,7 @@ export type { ParsedModelSpec } from "@polpo-ai/core";
 import { getCatalogSync, type GatewayLanguageModelEntry, type ModelInfo } from "./gateway-catalog.js";
 import { createCustomProviderModel, createGatewayModel } from "./provider-factory.js";
 import { resolveApiKey, resolveApiKeyAsync, hasOAuthProfiles, PROVIDER_ENV_MAP } from "./api-keys.js";
+import { getGatewayConfig } from "./gateway-config.js";
 
 // ─── ResolvedModel ───────────────────────────────────
 
@@ -148,7 +149,22 @@ export function resolveModel(spec?: string): ResolvedModel {
     };
   }
 
-  // Standard provider -> route through AI Gateway
+  // Validate that some gateway or provider key is available
+  const hasGateway = !!getGatewayConfig();
+  const hasVercelGatewayKey = !!process.env.AI_GATEWAY_API_KEY;
+  const hasProviderKey = !!resolveApiKey(provider) || hasOAuthProfiles(provider);
+
+  if (!hasGateway && !hasVercelGatewayKey && !hasProviderKey) {
+    throw new Error(
+      `No LLM gateway configured and no API key found for provider "${provider}". ` +
+      `Set settings.gateway in polpo.json, ` +
+      `or set AI_GATEWAY_API_KEY env var for Vercel AI Gateway, ` +
+      `or set ${PROVIDER_ENV_MAP[provider] ?? `the API key env var for "${provider}"`} for direct provider access. ` +
+      `See: https://docs.polpo.sh/docs/quickstart`,
+    );
+  }
+
+  // Standard provider -> route through configured gateway (or Vercel AI Gateway fallback)
   const aiModel = createGatewayModel(provider, modelId);
 
   // Try to get metadata from cached catalog

--- a/packages/llm/src/provider-factory.ts
+++ b/packages/llm/src/provider-factory.ts
@@ -8,8 +8,10 @@
 import type { LanguageModel } from "ai";
 import { gateway } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { ProviderConfig, ReasoningLevel } from "@polpo-ai/core";
 import { resolveApiKey } from "./api-keys.js";
+import { getGatewayConfig } from "./gateway-config.js";
 
 /**
  * Create an AI SDK LanguageModel for a custom (non-gateway) provider.
@@ -35,12 +37,35 @@ export function createCustomProviderModel(
 }
 
 /**
- * Create an AI SDK LanguageModel via the AI Gateway.
- * The gateway expects "provider/modelId" format.
+ * Create an AI SDK LanguageModel via the configured gateway, or fall back to
+ * the Vercel AI Gateway when no custom gateway is configured.
+ *
+ * When a gateway is configured in polpo.json (`settings.gateway`), uses
+ * @ai-sdk/openai-compatible to route through any OpenAI-compatible endpoint
+ * (OpenRouter, LiteLLM, Ollama, etc.).
+ *
+ * The gateway expects "provider/modelId" format for model identifiers.
  */
 export function createGatewayModel(provider: string, modelId: string): LanguageModel {
-  const gatewayModelId = `${provider}/${modelId}`;
-  return gateway(gatewayModelId as any) as unknown as LanguageModel;
+  const config = getGatewayConfig();
+
+  if (!config) {
+    // No gateway configured — use Vercel AI Gateway as default
+    const gatewayModelId = `${provider}/${modelId}`;
+    return gateway(gatewayModelId as any) as unknown as LanguageModel;
+  }
+
+  // Use configured gateway via OpenAI-compatible provider
+  const gatewayProvider = createOpenAICompatible({
+    baseURL: config.url,
+    name: "gateway",
+    apiKey: config.apiKey,
+    headers: config.headers,
+  });
+
+  // Most gateways use provider/model format
+  const modelSpec = `${provider}/${modelId}`;
+  return gatewayProvider.languageModel(modelSpec);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.48
         version: 3.0.48(zod@4.3.6)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.37
+        version: 2.0.37(zod@4.3.6)
       '@polpo-ai/core':
         specifier: workspace:*
         version: link:../core
@@ -277,6 +280,12 @@ packages:
 
   '@ai-sdk/gateway@3.0.83':
     resolution: {integrity: sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.37':
+    resolution: {integrity: sha512-+POSFVcgiu47BK64dhsI6OpcDC0/VAE2ZSaXdXGNNhpC/ava++uSRJYks0k2bpfY0wwCTgpAWZsXn/dG2Yppiw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2755,6 +2764,12 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
+  '@ai-sdk/openai-compatible@2.0.37(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/openai@3.0.48(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -3471,14 +3486,14 @@ snapshots:
       msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
       vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@25.2.3)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5110,7 +5125,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -43,7 +43,7 @@ import {
   sleep,
 } from "./assessment-prompts.js";
 import type { AssessFn } from "./orchestrator-context.js";
-import { setProviderOverrides, validateProviderKeys, setModelAllowlist } from "../llm/pi-client.js";
+import { setProviderOverrides, validateProviderKeys, setModelAllowlist, configureGateway } from "../llm/pi-client.js";
 import { HookRegistry } from "./hooks.js";
 import { ApprovalManager } from "./approval-manager.js";
 import { FileApprovalStore } from "../stores/file-approval-store.js";
@@ -232,6 +232,16 @@ export class Orchestrator extends TypedEmitter {
     // Apply model allowlist from settings
     if (this.config.settings.modelAllowlist) {
       setModelAllowlist(this.config.settings.modelAllowlist);
+    }
+
+    // Configure LLM gateway from settings
+    const gatewaySettings = this.config.settings.gateway;
+    if (gatewaySettings) {
+      configureGateway({
+        url: gatewaySettings.url,
+        apiKey: gatewaySettings.apiKeyEnv ? process.env[gatewaySettings.apiKeyEnv] : undefined,
+        headers: gatewaySettings.headers,
+      });
     }
 
     const stores = this.injectedStore
@@ -583,6 +593,16 @@ export class Orchestrator extends TypedEmitter {
     }
     if (this.config.settings.modelAllowlist) {
       setModelAllowlist(this.config.settings.modelAllowlist);
+    }
+
+    // Configure LLM gateway from settings
+    const gatewaySettings = this.config.settings.gateway;
+    if (gatewaySettings) {
+      configureGateway({
+        url: gatewaySettings.url,
+        apiKey: gatewaySettings.apiKeyEnv ? process.env[gatewaySettings.apiKeyEnv] : undefined,
+        headers: gatewaySettings.headers,
+      });
     }
 
     await this.initManagers();
@@ -984,6 +1004,15 @@ export class Orchestrator extends TypedEmitter {
     }
     if (newSettings.modelAllowlist) {
       setModelAllowlist(newSettings.modelAllowlist);
+    }
+
+    // Re-configure LLM gateway from updated settings
+    if (newSettings.gateway) {
+      configureGateway({
+        url: newSettings.gateway.url,
+        apiKey: newSettings.gateway.apiKeyEnv ? process.env[newSettings.gateway.apiKeyEnv] : undefined,
+        headers: newSettings.gateway.headers,
+      });
     }
 
     // Re-sync config.teams from TeamStore/AgentStore (authoritative source)


### PR DESCRIPTION
## Summary

Users configure their LLM gateway in `polpo.json` — no hardcoded Vercel dependency.

```json
{
  "settings": {
    "gateway": {
      "url": "https://ai-gateway.vercel.sh/v1",
      "apiKeyEnv": "AI_GATEWAY_API_KEY",
      "headers": {}
    }
  }
}
```

Supports any OpenAI-compatible gateway: Vercel, OpenRouter, LiteLLM, Ollama.

### Changes
- `PolpoSettings.gateway` type in `@polpo-ai/core`
- `configureGateway()` / `getGatewayConfig()` in `@polpo-ai/llm`
- `createGatewayModel()` uses `@ai-sdk/openai-compatible` when configured
- Falls back to Vercel AI Gateway if no config (needs `AI_GATEWAY_API_KEY`)
- Clear error when no gateway configured
- Orchestrator calls `configureGateway()` at boot

### Why
- No vendor lock-in — user chooses their gateway
- OSS works without Vercel account
- Cloud sets gateway in data-plane (transparent to user)

## Test plan
- [x] 1182 tests pass
- [x] TypeScript compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)