### PR TITLE
feat: FileEntry metadata — eliminate N+1 stat calls on S3/R2

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -47,6 +47,10 @@ export interface FileEntry {
   name: string;
   isDirectory: boolean;
   isFile: boolean;
+  /** File size in bytes (optional — populated when available from listing) */
+  size?: number;
+  /** Last modified date (optional — populated when available from listing) */
+  modifiedAt?: Date;
 }
 
 export interface FileStat {

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -252,18 +252,30 @@ export function fileRoutes(getDeps: () => FileRouteDeps): OpenAPIHono {
     const entries = [];
     for (const d of rawEntries) {
       if (d.name.startsWith(".") && d.name !== ".agent") continue;
-      const fullPath = resolve(resolved, d.name);
       const isDir = d.isDirectory;
-      let fileStat;
-      try { fileStat = await fs.stat(fullPath); } catch { /* skip */ }
-      entries.push({
-        name: d.name,
-        type: isDir ? "directory" : "file",
-        ...(fileStat ? {
-          ...(isDir ? {} : { size: fileStat.size, mimeType: guessMime(d.name) }),
-          modifiedAt: fileStat.modifiedAt?.toISOString(),
-        } : {}),
-      });
+
+      // Use metadata from readdir when available (avoids per-file stat calls)
+      if (d.size != null || d.modifiedAt != null) {
+        entries.push({
+          name: d.name,
+          type: isDir ? "directory" : "file",
+          ...(isDir ? {} : { size: d.size, mimeType: guessMime(d.name) }),
+          modifiedAt: d.modifiedAt?.toISOString(),
+        });
+      } else {
+        // Fallback: stat each file (local filesystem doesn't include metadata in readdir)
+        const fullPath = resolve(resolved, d.name);
+        let fileStat;
+        try { fileStat = await fs.stat(fullPath); } catch { /* skip */ }
+        entries.push({
+          name: d.name,
+          type: isDir ? "directory" : "file",
+          ...(fileStat ? {
+            ...(isDir ? {} : { size: fileStat.size, mimeType: guessMime(d.name) }),
+            modifiedAt: fileStat.modifiedAt?.toISOString(),
+          } : {}),
+        });
+      }
     }
 
     entries.sort((a: any, b: any) => {

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -1,14 +1,10 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { resolve, relative, extname, basename, dirname } from "node:path";
-import type { FileSystem } from "@polpo-ai/core";
+import type { FileSystem, FileEntry } from "@polpo-ai/core";
 
 const POLPO_DIR_NAME = ".polpo";
 
-// ── FS helpers for optional methods ──────────────────────────────────────────
-// Optional methods use `as any` cast because they're defined with `?` on the interface.
-// At runtime, implementations (NodeFileSystem, SandboxProxyFS) always provide them.
-
-interface FileEntry { name: string; isDirectory: boolean; isFile: boolean; }
+// ── FS helpers ──────────────────────────────────────────────────────────────
 
 async function readdirTyped(fs: FileSystem, path: string): Promise<FileEntry[]> {
   if ((fs as any).readdirWithTypes) return (fs as any).readdirWithTypes(path);


### PR DESCRIPTION
## Summary

### Problem
`files/list` route does `stat()` for every file in a directory to get size and modifiedAt. On S3/R2 backends this means N extra HeadObject calls per directory listing — ~50 files = ~50 extra API calls, each adding 50-100ms latency.

### Fix
- `FileEntry` (core) now has optional `size` and `modifiedAt` fields
- S3/R2 `readdirWithTypes` populates them from ListObjectsV2 response (already available, was being discarded)
- `files/list` route uses FileEntry metadata when available, falls back to stat only for local filesystem

### Impact
Directory listing on R2: from N+1 calls to 1 call. ~50x faster for typical project directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)