### PR TITLE
feat(cli): wire project slug + subdomain routing

### DIFF
--- a/packages/cli/src/commands/cloud/deploy.ts
+++ b/packages/cli/src/commands/cloud/deploy.ts
@@ -499,6 +499,7 @@ export function registerDeployCommand(program: Command): void {
 
       // ── Step 1: Resolve project ────────────────────────
       let projectId: string | undefined = polpoConfig?.projectId;
+      let projectSlug: string | undefined = polpoConfig?.projectSlug;
 
       if (!projectId) {
         try {
@@ -511,6 +512,7 @@ export function registerDeployCommand(program: Command): void {
             interactive: isTTY(),
           });
           projectId = project.id;
+          projectSlug = project.slug;
           console.log(`  Project: ${project.name}\n`);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -524,12 +526,22 @@ export function registerDeployCommand(program: Command): void {
         process.exit(1);
       }
 
-      // Data plane client — always sends x-project-id
+      // Backfill `projectSlug` for users with legacy polpo.json (id only).
+      if (!projectSlug && projectId) {
+        try {
+          const fresh = await import("../../util/project.js").then((m) =>
+            m.getProject(cpClient, projectId!),
+          );
+          if (fresh?.slug) projectSlug = fresh.slug;
+        } catch {}
+      }
+
       const client = createApiClient(creds, projectId);
 
-      // Save projectId in local polpo.json for future deploys
-      if (projectId && polpoConfig && !polpoConfig.projectId) {
+      // Persist whichever fields we resolved/discovered for next time.
+      if (polpoConfig && (!polpoConfig.projectId || (projectSlug && !polpoConfig.projectSlug))) {
         polpoConfig.projectId = projectId;
+        if (projectSlug) polpoConfig.projectSlug = projectSlug;
         fs.writeFileSync(path.join(polpoDir, "polpo.json"), JSON.stringify(polpoConfig, null, 2), "utf-8");
       }
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -38,12 +38,13 @@ import { friendlyError } from "../util/errors.js";
 import { slugify } from "../util/slugify.js";
 import { installCodingAgentSkills, skillsInstallHint, type SkillsScope } from "../util/skills.js";
 import { isPolpoOnPath, installPolpoGlobally, globalInstallHint } from "../util/install-cli.js";
+import { POLPO_API_DOMAIN } from "../util/base-url.js";
 
 interface CreateOptions {
   name?: string;
   orgId?: string;
   template?: string;
-  url?: string;
+  apiUrl?: string;
   skills?: string;
   installCli?: string; // "yes" | "no"
   yes?: boolean;
@@ -59,7 +60,7 @@ export function registerCreateCommand(program: Command): void {
       "--template <id>",
       `Template: ${TEMPLATES.map((t) => t.id).join(", ")}`,
     )
-    .option("--url <base-url>", "API base URL override")
+    .option("--api-url <url>", "Override the API base URL (self-hosted, custom domain, dev)")
     .option("--skills <scope>", "Coding-agent skills install: global | project | skip", "")
     .option("--install-cli <yes|no>", "Install the polpo CLI globally after scaffold", "")
     .option("-y, --yes", "Skip confirmations (use defaults)")
@@ -68,12 +69,12 @@ export function registerCreateCommand(program: Command): void {
 
       // Step 1: Auth (auto-browser if needed)
       const creds = await requireAuth({
-        apiUrl: opts.url,
+        apiUrl: opts.apiUrl,
         context: "Creating a project requires an authenticated session.",
       });
       const client = createApiClient({
         apiKey: creds.apiKey,
-        baseUrl: opts.url ?? creds.baseUrl,
+        baseUrl: opts.apiUrl ?? creds.baseUrl,
       });
 
       // Step 2: Organization
@@ -214,17 +215,24 @@ export function registerCreateCommand(program: Command): void {
       }
 
       // Step 9: Write polpo.json + .env.local
+      // The data plane URL is derived from the slug — `{slug}.polpo.cloud`.
+      // For self-hosted or custom-domain users, set `apiUrl` in polpo.json
+      // (or the POLPO_API_URL env var at runtime) to override.
+      const tenantUrl = project.slug
+        ? `https://${project.slug}.${POLPO_API_DOMAIN}`
+        : creds.baseUrl;
+
       writePolpoConfig(targetDir, {
         project: project.name,
+        projectSlug: project.slug,
         projectId: project.id,
-        apiUrl: creds.baseUrl,
       });
 
       if (apiKey) {
         const envLocal = path.join(targetDir, ".env.local");
         const envContent =
           `POLPO_API_KEY=${apiKey.rawKey}\n` +
-          `POLPO_API_URL=${creds.baseUrl}\n`;
+          `POLPO_API_URL=${tenantUrl}\n`;
         try {
           fs.writeFileSync(envLocal, envContent, { flag: "wx" });
           clack.log.info(`Wrote ${pc.bold(".env.local")} with project credentials`);

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -26,18 +26,18 @@ export function registerLinkCommand(program: Command): void {
     .description("Link the current directory to an existing cloud project")
     .requiredOption("--project-id <id>", "Cloud project UUID")
     .option("-d, --dir <path>", "Working directory", ".")
-    .option("--url <base-url>", "API base URL override")
+    .option("--api-url <url>", "Override the API base URL (self-hosted, custom domain, dev)")
     .action(async (opts) => {
       clack.intro(pc.bold("Polpo — Link project"));
 
       const creds = await requireAuth({
-        apiUrl: opts.url,
+        apiUrl: opts.apiUrl,
         context: "Linking a project requires an authenticated session.",
       });
 
       const client = createApiClient({
         apiKey: creds.apiKey,
-        baseUrl: opts.url ?? creds.baseUrl,
+        baseUrl: opts.apiUrl ?? creds.baseUrl,
       });
 
       const s = clack.spinner();
@@ -75,10 +75,13 @@ export function registerLinkCommand(program: Command): void {
         }
       }
 
+      // Persist slug as the canonical identifier; UUID is kept for display.
+      // Don't pin apiUrl — the slug derives the data plane URL automatically.
+      // Self-hosted users can add `apiUrl` manually to override.
       writePolpoConfig(cwd, {
         project: project.name,
+        projectSlug: project.slug,
         projectId: project.id,
-        apiUrl: opts.url ?? creds.baseUrl,
       });
 
       clack.log.success(`Wrote ${pc.bold(".polpo/polpo.json")}`);

--- a/packages/cli/src/util/base-url.ts
+++ b/packages/cli/src/util/base-url.ts
@@ -1,0 +1,54 @@
+/**
+ * Single source of truth for "where do I send data plane requests?".
+ *
+ * Resolution priority (first match wins):
+ *
+ *   1. Explicit `--url` flag passed to the command (caller's responsibility
+ *      to surface it as the highest-priority override).
+ *   2. `POLPO_API_URL` env var. Lets users redirect a single command run
+ *      without touching files (e.g. `POLPO_API_URL=http://localhost:4000
+ *      polpo deploy` for self-hosted dev).
+ *   3. `apiUrl` field in `.polpo/polpo.json`. Per-project pin — used by
+ *      teams that want their `.env.local` and CLI to point somewhere
+ *      non-standard (custom domain, on-prem cluster).
+ *   4. `https://{projectSlug}.polpo.cloud` — derived from the slug stored
+ *      in `polpo.json`. The default for cloud users post-F4.
+ *   5. Stored CLI credentials baseUrl (from `~/.polpo/credentials.json`,
+ *      defaults to `https://api.polpo.sh`). Last-resort fallback for
+ *      legacy clients that don't have a slug yet.
+ *
+ * Self-hosted users override (1) or (2) and the rest of the chain is
+ * irrelevant. Cloud users normally hit (4).
+ *
+ * IMPORTANT: this function does NOT touch the network or read env files —
+ * it's a pure function of the inputs. The caller decides which sources
+ * to consult.
+ */
+
+export interface BaseUrlInputs {
+  /** From `--url` flag. */
+  flagOverride?: string;
+  /** Pre-read `POLPO_API_URL` env value. */
+  envOverride?: string;
+  /** Pre-loaded `polpo.json` (or null when missing). */
+  polpoConfig?: { apiUrl?: string; projectSlug?: string } | null;
+  /** Default cloud base URL fallback (typically `creds.baseUrl`). */
+  fallback: string;
+}
+
+export const POLPO_API_DOMAIN = "polpo.cloud";
+
+export function resolveBaseUrl(inputs: BaseUrlInputs): string {
+  if (inputs.flagOverride) return stripTrailingSlash(inputs.flagOverride);
+  if (inputs.envOverride) return stripTrailingSlash(inputs.envOverride);
+
+  const cfg = inputs.polpoConfig;
+  if (cfg?.apiUrl) return stripTrailingSlash(cfg.apiUrl);
+  if (cfg?.projectSlug) return `https://${cfg.projectSlug}.${POLPO_API_DOMAIN}`;
+
+  return stripTrailingSlash(inputs.fallback);
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}

--- a/packages/cli/src/util/polpo-config.ts
+++ b/packages/cli/src/util/polpo-config.ts
@@ -11,9 +11,22 @@ import * as path from "node:path";
 export interface PolpoProjectConfig {
   /** Project name shown in dashboards/logs. */
   project?: string;
-  /** Cloud project UUID. Set after `polpo create` or `polpo link`. */
+  /**
+   * Public project ref (Supabase-style, `^[a-z]{20}$`) — the canonical
+   * identifier the CLI uses to compute the data plane URL
+   * `https://{projectSlug}.polpo.cloud`. Set by `polpo create` / `polpo link`.
+   */
+  projectSlug?: string;
+  /**
+   * Cloud project UUID. Cache for display purposes (e.g. dashboard URL).
+   * Legacy clients pre-subdomain may have only this; the CLI backfills
+   * `projectSlug` from it on first read.
+   */
   projectId?: string;
-  /** API base URL override (defaults to https://api.polpo.sh). */
+  /**
+   * Explicit API base URL override. Wins over `projectSlug`-derived URL.
+   * Use for self-hosted, dev loopback, or custom domains.
+   */
   apiUrl?: string;
   /** Anything else (gateway settings, storage backend, …). */
   [key: string]: unknown;

--- a/packages/cli/src/util/template.ts
+++ b/packages/cli/src/util/template.ts
@@ -120,7 +120,11 @@ export function writeBlankScaffold(targetDir: string, projectName: string): void
 
   fs.writeFileSync(
     path.join(targetDir, ".env.local.example"),
-    "POLPO_API_KEY=\nPOLPO_API_URL=https://api.polpo.sh\n",
+    "# Cloud usage: POLPO_API_URL is set automatically by `polpo create` to your\n" +
+      "# project's subdomain (https://{slug}.polpo.cloud). Override here only for\n" +
+      "# self-hosted, custom domains, or local dev.\n" +
+      "POLPO_API_KEY=\n" +
+      "POLPO_API_URL=https://your-project-slug.polpo.cloud\n",
   );
 
   fs.writeFileSync(

--- a/packages/cli/tests/base-url.test.ts
+++ b/packages/cli/tests/base-url.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveBaseUrl,
+  POLPO_API_DOMAIN,
+} from "../src/util/base-url.js";
+
+const FALLBACK = "https://api.polpo.sh";
+
+describe("POLPO_API_DOMAIN constant", () => {
+  it("is polpo.cloud", () => {
+    expect(POLPO_API_DOMAIN).toBe("polpo.cloud");
+  });
+});
+
+describe("resolveBaseUrl — priority chain", () => {
+  it("flag override wins over everything", () => {
+    expect(
+      resolveBaseUrl({
+        flagOverride: "https://custom.example.com",
+        envOverride: "https://env.example.com",
+        polpoConfig: { apiUrl: "https://cfg.example.com", projectSlug: "abcdefghijklmnopqrst" },
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://custom.example.com");
+  });
+
+  it("env override wins over config + fallback", () => {
+    expect(
+      resolveBaseUrl({
+        envOverride: "https://env.example.com",
+        polpoConfig: { apiUrl: "https://cfg.example.com" },
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://env.example.com");
+  });
+
+  it("polpo.json apiUrl pin wins over slug derivation", () => {
+    expect(
+      resolveBaseUrl({
+        polpoConfig: { apiUrl: "https://onprem.acme.local", projectSlug: "abcdefghijklmnopqrst" },
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://onprem.acme.local");
+  });
+
+  it("derives subdomain from projectSlug when no override", () => {
+    expect(
+      resolveBaseUrl({
+        polpoConfig: { projectSlug: "abcdefghijklmnopqrst" },
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://abcdefghijklmnopqrst.polpo.cloud");
+  });
+
+  it("falls back when no slug + no overrides (legacy clients)", () => {
+    expect(
+      resolveBaseUrl({
+        polpoConfig: null,
+        fallback: FALLBACK,
+      }),
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back when polpo.json exists but has neither apiUrl nor projectSlug", () => {
+    expect(
+      resolveBaseUrl({
+        polpoConfig: {},
+        fallback: FALLBACK,
+      }),
+    ).toBe(FALLBACK);
+  });
+});
+
+describe("resolveBaseUrl — trailing slash normalization", () => {
+  it("strips trailing slash from flag", () => {
+    expect(
+      resolveBaseUrl({
+        flagOverride: "https://x.example/",
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://x.example");
+  });
+
+  it("strips trailing slash from env", () => {
+    expect(
+      resolveBaseUrl({
+        envOverride: "https://x.example/",
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://x.example");
+  });
+
+  it("strips trailing slash from config apiUrl", () => {
+    expect(
+      resolveBaseUrl({
+        polpoConfig: { apiUrl: "https://x.example/" },
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://x.example");
+  });
+
+  it("strips trailing slash from fallback", () => {
+    expect(
+      resolveBaseUrl({
+        polpoConfig: {},
+        fallback: "https://api.polpo.sh/",
+      }),
+    ).toBe("https://api.polpo.sh");
+  });
+
+  it("does NOT touch slug-derived URL (no slash to strip)", () => {
+    expect(
+      resolveBaseUrl({
+        polpoConfig: { projectSlug: "abcdefghijklmnopqrst" },
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://abcdefghijklmnopqrst.polpo.cloud");
+  });
+});
+
+describe("resolveBaseUrl — edge cases", () => {
+  it("empty flag is treated as not provided (falls through)", () => {
+    expect(
+      resolveBaseUrl({
+        flagOverride: "",
+        envOverride: "https://env.example.com",
+        fallback: FALLBACK,
+      }),
+    ).toBe("https://env.example.com");
+  });
+
+  it("self-hosted scenario: env overrides everything (CI / dev)", () => {
+    expect(
+      resolveBaseUrl({
+        envOverride: "http://localhost:4000",
+        polpoConfig: { projectSlug: "abcdefghijklmnopqrst" },
+        fallback: FALLBACK,
+      }),
+    ).toBe("http://localhost:4000");
+  });
+});

--- a/packages/cli/tests/polpo-config.test.ts
+++ b/packages/cli/tests/polpo-config.test.ts
@@ -141,4 +141,27 @@ describe("writePolpoConfig", () => {
     writePolpoConfig(tmpDir, { project: "recovered" });
     expect(readPolpoConfig(tmpDir)).toEqual({ project: "recovered" });
   });
+
+  it("persists projectSlug + projectId together (canonical post-F4 shape)", () => {
+    writePolpoConfig(tmpDir, {
+      project: "demo",
+      projectSlug: "abcdefghijklmnopqrst",
+      projectId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(readPolpoConfig(tmpDir)).toEqual({
+      project: "demo",
+      projectSlug: "abcdefghijklmnopqrst",
+      projectId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+  });
+
+  it("backfilling projectSlug into a legacy id-only file preserves the id", () => {
+    writePolpoConfig(tmpDir, { project: "legacy", projectId: "old-uuid" });
+    writePolpoConfig(tmpDir, { projectSlug: "abcdefghijklmnopqrst" });
+    expect(readPolpoConfig(tmpDir)).toEqual({
+      project: "legacy",
+      projectId: "old-uuid",
+      projectSlug: "abcdefghijklmnopqrst",
+    });
+  });
 });

--- a/packages/cli/tests/template.test.ts
+++ b/packages/cli/tests/template.test.ts
@@ -132,7 +132,7 @@ describe("writeBlankScaffold", () => {
       "utf-8",
     );
     expect(env).toContain("POLPO_API_KEY=");
-    expect(env).toContain("POLPO_API_URL=https://api.polpo.sh");
+    expect(env).toContain("POLPO_API_URL=https://your-project-slug.polpo.cloud");
   });
 
   it("writes README.md with the project name as heading", () => {


### PR DESCRIPTION
F4 of the subdomain-routing plan. The CLI now treats the server-generated project slug as canonical and derives the data plane URL as `{slug}.polpo.cloud`. The UUID is preserved as a cache for display + the legacy `x-project-id` header.

## What changed

- `polpo-config.ts`: schema adds `projectSlug` field. `projectId` remains for backward compat. `apiUrl` becomes an explicit override pin (no longer auto-set by `create`/`link`).
- `util/base-url.ts` (new): `resolveBaseUrl()` helper with documented priority chain — flag → `POLPO_API_URL` env → polpo.json `apiUrl` pin → slug-derived subdomain → fallback. Pure function, easy to test.
- `create`: writes `projectSlug` + `projectId`. Generated `.env.local` uses `https://{slug}.polpo.cloud`. No more auto-pinned `apiUrl`.
- `link`: same shape — writes both, no `apiUrl` pin.
- `deploy`: backfills `projectSlug` for legacy clients with id-only polpo.json (one fetch on first deploy after upgrade).
- `--url` flag → `--api-url` everywhere (more explicit, matches `POLPO_API_URL` env).
- `.env.local.example` template shows the slug-based URL pattern + a comment explaining when to override.

## Self-hosted / dev override paths

```bash
POLPO_API_URL=http://localhost:4000 polpo deploy
# or pin in polpo.json:
{ "apiUrl": "https://polpo.acme.local" }
```

## Tests

- New: `tests/base-url.test.ts` (14) — priority chain, trailing-slash normalization, self-hosted overrides
- Updated: `tests/polpo-config.test.ts` — canonical projectSlug+projectId persistence + legacy backfill
- Updated: `tests/template.test.ts` — assertion matches new example URL

**175 / 175 passing**. typecheck + build green locally.

## Test plan

- [x] `pnpm --filter @polpo-ai/cli test` ✅
- [x] `pnpm --filter @polpo-ai/cli build` ✅
- [ ] CI green
- [ ] Smoke: `npx polpo create` against staging cloud (after CI + merge)