### PR TITLE
fix(cli): correct version detection path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,9 +13,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 
-// Read version from package.json at build time fallback
 const __dirname_cli = dirname(fileURLToPath(import.meta.url));
-const pkgPath = resolve(__dirname_cli, "..", "..", "package.json");
+const pkgPath = resolve(__dirname_cli, "..", "package.json");
 const PKG_VERSION = existsSync(pkgPath)
   ? JSON.parse(readFileSync(pkgPath, "utf-8")).version
   : "0.0.0";

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
The CLI computed its `package.json` path with two `..` segments from `dist/index.js`, landing one directory above the actual package and falling back to `0.0.0` silently.

Fix: one `..` is correct — both for npm installs (`node_modules/@polpo-ai/cli/dist/index.js` → `../package.json`) and local dev.

Bump to **0.6.1** so the fix ships.

## Verified

```bash
$ pnpm --filter @polpo-ai/cli build
$ node packages/cli/dist/index.js --version
0.6.1
```

## Test plan

- [x] Local smoke: `--version` returns `0.6.1`
- [ ] CI green
- [ ] After release: `npx @polpo-ai/cli@latest --version` returns `0.6.1`