### PR TITLE
fix(cli): create org inline when user has none

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/src/commands/cloud/api.ts
+++ b/packages/cli/src/commands/cloud/api.ts
@@ -1,9 +1,12 @@
 /**
  * HTTP client for the Polpo Cloud API.
  *
- * Wraps fetch with Authorization header and JSON handling.
+ * Wraps fetch with Authorization header, JSON handling, and a typed
+ * network error so callers can surface "Could not reach api.polpo.sh"
+ * instead of a raw `TypeError: fetch failed`.
  */
 import type { Credentials } from "./config.js";
+import { ApiNetworkError } from "../../util/errors.js";
 
 export interface ApiResponse<T = unknown> {
   status: number;
@@ -33,11 +36,18 @@ export function createApiClient(credentials: Credentials, projectId?: string): A
   ): Promise<ApiResponse<T>> {
     const url = `${baseUrl.replace(/\/$/, "")}${path}`;
 
-    const res = await fetch(url, {
-      method,
-      headers,
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      // fetch() throws on DNS / TCP / TLS / abort failures. Wrap so callers
+      // (and friendlyError) can produce a useful "check your network" hint.
+      throw new ApiNetworkError(baseUrl, err);
+    }
 
     let data: T;
     const contentType = res.headers.get("content-type") ?? "";

--- a/packages/cli/src/commands/cloud/byok.ts
+++ b/packages/cli/src/commands/cloud/byok.ts
@@ -2,9 +2,31 @@
  * polpo byok — manage BYOK (Bring Your Own Key) API keys.
  */
 import type { Command } from "commander";
-import { loadCredentials } from "./config.js";
+import pc from "picocolors";
 import { createApiClient } from "./api.js";
 import { isTTY, promptMasked } from "./prompt.js";
+import { requireAuth } from "../../util/auth.js";
+import { friendlyError } from "../../util/errors.js";
+
+const KNOWN_PROVIDERS = [
+  "openai",
+  "anthropic",
+  "xai",
+  "google",
+  "groq",
+  "openrouter",
+  "cerebras",
+  "gemini",
+];
+
+function warnUnknownProvider(provider: string): void {
+  if (!KNOWN_PROVIDERS.includes(provider.toLowerCase())) {
+    console.error(
+      pc.yellow(`Warning: "${provider}" isn't a recognised provider name.`),
+    );
+    console.error(pc.dim(`  Known: ${KNOWN_PROVIDERS.join(", ")}`));
+  }
+}
 
 export function registerByokCommand(program: Command): void {
   const byok = program
@@ -18,49 +40,38 @@ export function registerByokCommand(program: Command): void {
     .option("--label <label>", "Optional label")
     .option("--project <project-id>", "Project ID (if not in credentials)")
     .action(async (provider: string, opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error(
-          "Not logged in. Run: polpo login --api-key <key>",
-        );
-        process.exit(1);
-      }
+      const creds = await requireAuth({
+        context: "Managing BYOK keys requires an authenticated session.",
+      });
+      warnUnknownProvider(provider);
 
       let key: string | undefined = opts.key;
-
       if (!key) {
         if (isTTY()) {
           key = await promptMasked(`API key for ${provider}: `);
           if (!key) {
-            console.error("Error: API key is required.");
+            console.error(pc.red("API key is required."));
             process.exit(1);
           }
         } else {
-          console.error("Error: --key is required.");
+          console.error(pc.red("--key is required in non-interactive mode."));
           process.exit(1);
         }
       }
 
       const client = createApiClient(creds);
-
       try {
-        const res = await client.post("/v1/byok", {
-          provider,
-          key,
-          label: opts.label,
-        });
+        const res = await client.post("/v1/byok", { provider, key, label: opts.label });
 
         if (res.status >= 200 && res.status < 300) {
-          console.log(`BYOK key set for provider "${provider}".`);
+          console.log(pc.green(`✓ BYOK key set for "${provider}".`));
         } else {
-          const data = res.data as any;
-          console.error(
-            "Error: " + (data?.error ?? JSON.stringify(data)),
-          );
+          const data = res.data as { error?: string };
+          console.error(pc.red(friendlyError(data?.error ?? `HTTP ${res.status}`)));
           process.exit(1);
         }
-      } catch (err: any) {
-        console.error("Error: " + err.message);
+      } catch (err) {
+        console.error(pc.red(friendlyError((err as Error).message)));
         process.exit(1);
       }
     });
@@ -69,25 +80,21 @@ export function registerByokCommand(program: Command): void {
     .command("list")
     .description("List BYOK keys")
     .option("--project <project-id>", "Project ID (if not in credentials)")
-    .action(async (opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error(
-          "Not logged in. Run: polpo login --api-key <key>",
-        );
-        process.exit(1);
-      }
-
+    .action(async () => {
+      const creds = await requireAuth({
+        context: "Listing BYOK keys requires an authenticated session.",
+      });
       const client = createApiClient(creds);
 
       try {
         const res = await client.get("/v1/byok");
 
         if (res.status >= 200 && res.status < 300) {
-          const data = res.data as any;
+          const data = res.data as { data?: Array<{ provider: string; maskedKey: string; label?: string }> };
           const keys = data?.data ?? [];
           if (keys.length === 0) {
-            console.log("No BYOK keys configured.");
+            console.log(pc.dim("No BYOK keys configured."));
+            console.log(pc.dim("Add one with ") + pc.bold("polpo byok set <provider>"));
           } else {
             console.log("BYOK keys:");
             for (const k of keys) {
@@ -96,14 +103,12 @@ export function registerByokCommand(program: Command): void {
             }
           }
         } else {
-          const data = res.data as any;
-          console.error(
-            "Error: " + (data?.error ?? JSON.stringify(data)),
-          );
+          const data = res.data as { error?: string };
+          console.error(pc.red(friendlyError(data?.error ?? `HTTP ${res.status}`)));
           process.exit(1);
         }
-      } catch (err: any) {
-        console.error("Error: " + err.message);
+      } catch (err) {
+        console.error(pc.red(friendlyError((err as Error).message)));
         process.exit(1);
       }
     });
@@ -112,34 +117,27 @@ export function registerByokCommand(program: Command): void {
     .command("remove <provider>")
     .description("Remove a BYOK key")
     .option("--project <project-id>", "Project ID (if not in credentials)")
-    .action(async (provider: string, opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error(
-          "Not logged in. Run: polpo login --api-key <key>",
-        );
-        process.exit(1);
-      }
-
+    .action(async (provider: string) => {
+      const creds = await requireAuth({
+        context: "Removing BYOK keys requires an authenticated session.",
+      });
       const client = createApiClient(creds);
 
       try {
         const res = await client.delete(`/v1/byok/${provider}`);
 
         if (res.status >= 200 && res.status < 300) {
-          console.log(`BYOK key removed for provider "${provider}".`);
+          console.log(pc.green(`✓ BYOK key removed for "${provider}".`));
         } else if (res.status === 404) {
-          console.error(`No BYOK key found for provider "${provider}".`);
+          console.error(pc.yellow(`No BYOK key found for "${provider}".`));
           process.exit(1);
         } else {
-          const data = res.data as any;
-          console.error(
-            "Error: " + (data?.error ?? JSON.stringify(data)),
-          );
+          const data = res.data as { error?: string };
+          console.error(pc.red(friendlyError(data?.error ?? `HTTP ${res.status}`)));
           process.exit(1);
         }
-      } catch (err: any) {
-        console.error("Error: " + err.message);
+      } catch (err) {
+        console.error(pc.red(friendlyError((err as Error).message)));
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/cloud/deploy.ts
+++ b/packages/cli/src/commands/cloud/deploy.ts
@@ -18,14 +18,15 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
-import { loadCredentials } from "./config.js";
+import pc from "picocolors";
 import { createApiClient, type ApiClient } from "./api.js";
 import { isTTY, confirm } from "./prompt.js";
 import { resolveKey, decrypt } from "@polpo-ai/vault-crypto";
 import { AddAgentSchema } from "@polpo-ai/server";
 import { friendlyError } from "../../util/errors.js";
-import { resolveDefaultOrg } from "../../util/org.js";
+import { pickOrg } from "../../util/org.js";
 import { resolveOrCreateProject } from "../../util/project.js";
+import { requireAuth } from "../../util/auth.js";
 
 // ── Deploy result tracking ──────────────────────────────
 
@@ -54,7 +55,10 @@ function mergeResult(target: DeployResult, source: DeployResult): void {
 function resolvePolpoDir(dir: string): string {
   const polpoDir = path.resolve(dir, ".polpo");
   if (!fs.existsSync(polpoDir)) {
-    console.error(`Error: .polpo/ directory not found in ${path.resolve(dir)}`);
+    console.error(pc.red(`No .polpo/ found in ${path.resolve(dir)}`));
+    console.error(pc.dim("\n  This directory isn't a Polpo project yet. To get started:\n"));
+    console.error(pc.dim("    polpo create               ") + pc.bold("scaffold a new project here"));
+    console.error(pc.dim("    polpo link --project-id X  ") + pc.bold("attach this dir to an existing cloud project"));
     process.exit(1);
   }
   return polpoDir;
@@ -481,11 +485,12 @@ export function registerDeployCommand(program: Command): void {
     .option("--include-sessions", "Also deploy chat sessions")
     .option("--all", "Deploy everything (full local→cloud migration)")
     .action(async (opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error("Not logged in. Run: polpo login");
-        process.exit(1);
-      }
+      // requireAuth auto-triggers device-code login if creds are missing/expired,
+      // so a fresh user typing `polpo deploy` first goes through browser auth
+      // instead of getting a "Not logged in" wall.
+      const creds = await requireAuth({
+        context: "Deploying requires an authenticated session.",
+      });
 
       const polpoDir = resolvePolpoDir(opts.dir);
       const polpoConfig = loadJson(path.join(polpoDir, "polpo.json"));
@@ -503,7 +508,10 @@ export function registerDeployCommand(program: Command): void {
 
       if (!projectId) {
         try {
-          const org = await resolveDefaultOrg(cpClient);
+          // pickOrg handles the 0-org case inline (prompts to create one),
+          // so a fresh user running `polpo deploy` against an empty account
+          // gets a single graceful prompt instead of an exit.
+          const org = await pickOrg(cpClient);
           const project = await resolveOrCreateProject({
             client: cpClient,
             orgId: org.id,

--- a/packages/cli/src/commands/cloud/login.ts
+++ b/packages/cli/src/commands/cloud/login.ts
@@ -63,6 +63,14 @@ export function registerLoginCommand(program: Command): void {
             console.error("  Error: Invalid API key. Check the key and try again.");
             process.exit(1);
           }
+          if (res.status >= 500) {
+            console.error(`  Error: Polpo Cloud is having issues (HTTP ${res.status}). Try again shortly.`);
+            process.exit(1);
+          }
+          if (res.status >= 400) {
+            console.error(`  Error: Could not validate the API key (HTTP ${res.status}).`);
+            process.exit(1);
+          }
         } catch (err: any) {
           console.error(`  Error: Could not reach the API at ${baseUrl}`);
           console.error(`  ${err.message}`);

--- a/packages/cli/src/commands/cloud/logout.ts
+++ b/packages/cli/src/commands/cloud/logout.ts
@@ -2,14 +2,16 @@
  * polpo logout — clear stored credentials.
  */
 import type { Command } from "commander";
-import { clearCredentials } from "./config.js";
+import pc from "picocolors";
+import { loadCredentials, clearCredentials } from "./config.js";
 
 export function registerLogoutCommand(program: Command): void {
   program
     .command("logout")
     .description("Clear stored credentials")
     .action(() => {
+      const had = loadCredentials() !== null;
       clearCredentials();
-      console.log("Logged out.");
+      console.log(had ? pc.green("✓ Logged out.") : pc.dim("You weren't logged in."));
     });
 }

--- a/packages/cli/src/commands/cloud/logs.ts
+++ b/packages/cli/src/commands/cloud/logs.ts
@@ -2,9 +2,11 @@
  * polpo cloud-logs — view logs or follow events via SSE.
  */
 import type { Command } from "commander";
-import { loadCredentials } from "./config.js";
+import pc from "picocolors";
 import { createApiClient } from "./api.js";
 import { loadProjectId } from "./project-context.js";
+import { requireAuth } from "../../util/auth.js";
+import { friendlyError } from "../../util/errors.js";
 
 export function registerLogsCommand(program: Command): void {
   program
@@ -13,15 +15,16 @@ export function registerLogsCommand(program: Command): void {
     .option("--follow", "Follow live events via SSE")
     .option("-d, --dir <path>", "Project directory", ".")
     .action(async (opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error(
-          "Not logged in. Run: polpo login --api-key <key>",
-        );
-        process.exit(1);
-      }
+      const creds = await requireAuth({
+        context: "Viewing logs requires an authenticated session.",
+      });
 
       const projectId = loadProjectId(opts.dir);
+      if (!projectId) {
+        console.error(pc.red("No project linked in this directory."));
+        console.error(pc.dim("\n  Run ") + pc.bold("polpo create") + pc.dim(" or ") + pc.bold("polpo link --project-id <id>") + pc.dim(" first."));
+        process.exit(1);
+      }
 
       if (opts.follow) {
         // SSE streaming
@@ -36,12 +39,12 @@ export function registerLogsCommand(program: Command): void {
           });
 
           if (!res.ok) {
-            console.error(`Error: SSE connection failed with status ${res.status}`);
+            console.error(pc.red(friendlyError(`HTTP ${res.status}: SSE connection failed`)));
             process.exit(1);
           }
 
           if (!res.body) {
-            console.error("Error: No response body for SSE stream.");
+            console.error(pc.red("No response body for SSE stream."));
             process.exit(1);
           }
 
@@ -76,7 +79,7 @@ export function registerLogsCommand(program: Command): void {
           }
         } catch (err: any) {
           if (err.name === "AbortError") return;
-          console.error("Error: " + err.message);
+          console.error(pc.red(friendlyError(err.message)));
           process.exit(1);
         }
       } else {
@@ -105,11 +108,11 @@ export function registerLogsCommand(program: Command): void {
               console.log(JSON.stringify(data, null, 2));
             }
           } else {
-            console.error("Error fetching logs: status " + res.status);
+            console.error(pc.red(friendlyError(`HTTP ${res.status}`)));
             process.exit(1);
           }
         } catch (err: any) {
-          console.error("Error: " + err.message);
+          console.error(pc.red(friendlyError(err.message)));
           process.exit(1);
         }
       }

--- a/packages/cli/src/commands/cloud/projects.ts
+++ b/packages/cli/src/commands/cloud/projects.ts
@@ -2,22 +2,11 @@
  * polpo projects — manage cloud projects.
  */
 import type { Command } from "commander";
-import { loadCredentials } from "./config.js";
-import { createApiClient, type ApiClient } from "./api.js";
-
-async function resolveOrgId(client: ApiClient): Promise<string> {
-  const res = await client.get<any[]>("/v1/orgs");
-  if (res.status !== 200) {
-    console.error(`Failed to fetch organizations (status ${res.status}). Are you logged in?`);
-    process.exit(1);
-  }
-  const orgs = Array.isArray(res.data) ? res.data : [];
-  if (orgs.length === 0) {
-    console.error("No organizations found. Create one in the dashboard first.");
-    process.exit(1);
-  }
-  return orgs[0].id;
-}
+import pc from "picocolors";
+import { createApiClient } from "./api.js";
+import { requireAuth } from "../../util/auth.js";
+import { pickOrg } from "../../util/org.js";
+import { friendlyError } from "../../util/errors.js";
 
 export function registerProjectsCommand(program: Command): void {
   const projects = program
@@ -29,16 +18,14 @@ export function registerProjectsCommand(program: Command): void {
     .description("List projects")
     .option("--org <org-id>", "Organization ID (auto-detected if omitted)")
     .action(async (opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error("Not logged in. Run: polpo login --api-key <key>");
-        process.exit(1);
-      }
-
+      const creds = await requireAuth({
+        context: "Listing projects requires an authenticated session.",
+      });
       const client = createApiClient(creds);
 
       try {
-        const orgId = opts.org ?? (await resolveOrgId(client));
+        // pickOrg handles 0/1/N orgs gracefully (creates one inline if zero).
+        const orgId = opts.org ?? (await pickOrg(client)).id;
         const res = await client.get<any[]>(
           `/v1/projects?orgId=${encodeURIComponent(orgId)}`,
         );
@@ -46,7 +33,8 @@ export function registerProjectsCommand(program: Command): void {
         if (res.status === 200) {
           const list = Array.isArray(res.data) ? res.data : [];
           if (list.length === 0) {
-            console.log("No projects found.");
+            console.log(pc.dim("No projects yet."));
+            console.log(pc.dim("Run ") + pc.bold("polpo create") + pc.dim(" to scaffold one."));
           } else {
             for (const p of list) {
               const status = p.status ? ` [${p.status}]` : "";
@@ -54,12 +42,12 @@ export function registerProjectsCommand(program: Command): void {
             }
           }
         } else {
-          const data = res.data as any;
-          console.error("Error: " + (data?.error ?? `status ${res.status}`));
+          const data = res.data as { error?: string };
+          console.error(pc.red(friendlyError(data?.error ?? `HTTP ${res.status}`)));
           process.exit(1);
         }
-      } catch (err: any) {
-        console.error("Error: " + err.message);
+      } catch (err) {
+        console.error(pc.red(friendlyError((err as Error).message)));
         process.exit(1);
       }
     });
@@ -69,35 +57,28 @@ export function registerProjectsCommand(program: Command): void {
     .description("Create a project")
     .option("--org <org-id>", "Organization ID (auto-detected if omitted)")
     .action(async (name: string, opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error("Not logged in. Run: polpo login --api-key <key>");
-        process.exit(1);
-      }
-
+      const creds = await requireAuth({
+        context: "Creating a project requires an authenticated session.",
+      });
       const client = createApiClient(creds);
 
       try {
-        const orgId = opts.org ?? (await resolveOrgId(client));
-        const slug = name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, "-")
-          .replace(/^-|-$/g, "");
-
-        const res = await client.post<any>("/v1/projects", { orgId, name, slug });
+        const orgId = opts.org ?? (await pickOrg(client)).id;
+        // Slug is server-generated (Supabase ref format) — no longer sent.
+        const res = await client.post<any>("/v1/projects", { orgId, name });
 
         if (res.status >= 200 && res.status < 300) {
           const project = res.data;
-          console.log(`Project "${name}" created.`);
-          if (project?.id) console.log(`  ID: ${project.id}`);
-          if (project?.slug) console.log(`  Slug: ${project.slug}`);
+          console.log(pc.green(`✓ Project "${name}" created.`));
+          if (project?.id) console.log(pc.dim(`  ID:   ${project.id}`));
+          if (project?.slug) console.log(pc.dim(`  Slug: ${project.slug}`));
         } else {
-          const data = res.data as any;
-          console.error("Error: " + (data?.error ?? JSON.stringify(data)));
+          const data = res.data as { error?: string };
+          console.error(pc.red(friendlyError(data?.error ?? `HTTP ${res.status}`)));
           process.exit(1);
         }
-      } catch (err: any) {
-        console.error("Error: " + err.message);
+      } catch (err) {
+        console.error(pc.red(friendlyError((err as Error).message)));
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/cloud/status.ts
+++ b/packages/cli/src/commands/cloud/status.ts
@@ -2,9 +2,10 @@
  * polpo cloud-status — show project status summary.
  */
 import type { Command } from "commander";
-import { loadCredentials } from "./config.js";
+import pc from "picocolors";
 import { createApiClient } from "./api.js";
 import { loadProjectId } from "./project-context.js";
+import { requireAuth } from "../../util/auth.js";
 
 export function registerStatusCommand(program: Command): void {
   program
@@ -12,13 +13,17 @@ export function registerStatusCommand(program: Command): void {
     .description("Show project status summary")
     .option("-d, --dir <path>", "Project directory", ".")
     .action(async (opts) => {
-      const creds = loadCredentials();
-      if (!creds) {
-        console.error("Not logged in. Run: polpo login --api-key <key>");
+      const creds = await requireAuth({
+        context: "Showing project status requires an authenticated session.",
+      });
+
+      const projectId = loadProjectId(opts.dir);
+      if (!projectId) {
+        console.error(pc.red("No project linked in this directory."));
+        console.error(pc.dim("\n  Run ") + pc.bold("polpo create") + pc.dim(" or ") + pc.bold("polpo link --project-id <id>") + pc.dim(" first."));
         process.exit(1);
       }
 
-      const projectId = loadProjectId(opts.dir);
       const client = createApiClient(creds, projectId);
 
       let taskSummary = "";

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -128,28 +128,41 @@ export function registerCreateCommand(program: Command): void {
 
       // Step 5: Directory
       // Blank templates can scaffold into cwd; remote templates always
-      // get their own subdirectory.
+      // get their own subdirectory. If the chosen dir already exists we
+      // ask the user for an alternative name instead of dead-ending.
       const originalCwd = process.cwd();
       let targetDir = originalCwd;
       let dirName: string | null = null;
       if (template.kind === "remote") {
         const defaultDir = slugify(projectName);
-        const input = opts.yes
-          ? defaultDir
-          : await clack.text({
+        let candidate = opts.yes ? defaultDir : null;
+        // Loop until we land on a non-existing directory (or the user cancels).
+        // Keeps the wizard inside the terminal — no manual `rm -rf` round-trip.
+        while (true) {
+          if (candidate === null) {
+            const input = await clack.text({
               message: "Directory name",
               initialValue: defaultDir,
               validate: (v) => (!v || v === "." || v === ".." ? "Invalid directory" : undefined),
             });
-        if (clack.isCancel(input)) {
-          clack.cancel("Cancelled.");
-          process.exit(0);
-        }
-        dirName = path.basename(input as string).replace(/[^a-zA-Z0-9._-]/g, "-");
-        targetDir = path.resolve(originalCwd, dirName);
-        if (fs.existsSync(targetDir)) {
-          clack.outro(pc.red(`Directory "${dirName}" already exists.`));
-          process.exit(1);
+            if (clack.isCancel(input)) {
+              clack.cancel("Cancelled.");
+              process.exit(0);
+            }
+            candidate = path.basename(input as string).replace(/[^a-zA-Z0-9._-]/g, "-");
+          }
+          const resolved = path.resolve(originalCwd, candidate);
+          if (!fs.existsSync(resolved)) {
+            dirName = candidate;
+            targetDir = resolved;
+            break;
+          }
+          if (opts.yes) {
+            clack.outro(pc.red(`Directory "${candidate}" already exists.`));
+            process.exit(1);
+          }
+          clack.log.warn(`"${candidate}" already exists in this folder.`);
+          candidate = null; // re-prompt
         }
       }
 
@@ -162,11 +175,24 @@ export function registerCreateCommand(program: Command): void {
           orgId,
           name: projectName,
         });
+      } catch (err) {
+        s.stop("Project creation failed.");
+        clack.outro(pc.red(friendlyError((err as Error).message)));
+        process.exit(1);
+      }
+      // Project row exists in the cloud now even if `waitForActive` times out.
+      // We surface a recovery path so the user can finish the bootstrap manually
+      // instead of orphaning a half-provisioned project in the dashboard.
+      try {
         s.message("Waiting for project to become active...");
         await waitForProjectActive(client, project.id);
         s.stop(`Project "${project.name}" created`);
       } catch (err) {
-        s.stop("Project creation failed.");
+        s.stop("Project provisioning timed out — but the project was created.");
+        clack.log.warn(`Project ID: ${pc.bold(project.id)} (check it in the dashboard)`);
+        clack.log.info(
+          `Once it shows as active, finish setup with: ${pc.bold(`polpo link --project-id ${project.id}`)}`,
+        );
         clack.outro(pc.red(friendlyError((err as Error).message)));
         process.exit(1);
       }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -84,7 +84,22 @@ export function registerUpdateCommand(program: Command): void {
         console.log(pc.dim(`\n  Updating via ${pm}...`));
         console.log(pc.dim(`  $ ${cmd}\n`));
 
-        execSync(cmd, { stdio: "inherit", timeout: 120_000 });
+        try {
+          execSync(cmd, { stdio: "inherit", timeout: 120_000 });
+        } catch (err) {
+          // EACCES on a system-managed npm prefix is the typical failure mode.
+          // Surface a hint instead of a raw stack.
+          const msg = (err as Error).message ?? "";
+          if (/EACCES|permission denied/i.test(msg)) {
+            console.error(pc.red("\n  Permission denied while installing."));
+            console.error(pc.dim("  Try one of:"));
+            console.error(pc.dim(`    sudo ${cmd}`));
+            console.error(pc.dim(`    npm config set prefix ~/.npm-global  (one-time)`));
+          } else {
+            console.error(pc.red("\n  Update failed: ") + (msg || "unknown error"));
+          }
+          process.exit(1);
+        }
 
         // Verify
         try {

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -40,14 +40,27 @@ export function registerWhoamiCommand(program: Command): void {
 
       let user: User | null = null;
       let orgs: Org[] = [];
+      let staleAuth = false;
       try {
         const meRes = await client.get<User>("/v1/me");
-        user = (meRes.data as User) ?? null;
+        if (meRes.status === 401 || meRes.status === 403) staleAuth = true;
+        else user = (meRes.data as User) ?? null;
       } catch { /* endpoint may not exist — graceful */ }
       try {
         const orgsRes = await client.get<Org[]>("/v1/orgs");
-        orgs = Array.isArray(orgsRes.data) ? orgsRes.data : [];
+        if (orgsRes.status === 401 || orgsRes.status === 403) staleAuth = true;
+        else orgs = Array.isArray(orgsRes.data) ? orgsRes.data : [];
       } catch { /* graceful */ }
+
+      if (staleAuth) {
+        if (opts.json) {
+          console.log(JSON.stringify({ loggedIn: false, reason: "stale_token", apiUrl: creds.baseUrl }, null, 2));
+        } else {
+          console.error(pc.red("Session expired or invalid."));
+          console.error(pc.dim("Run ") + pc.bold("polpo login") + pc.dim(" to refresh."));
+        }
+        process.exit(1);
+      }
 
       if (opts.json) {
         console.log(JSON.stringify({

--- a/packages/cli/src/util/errors.ts
+++ b/packages/cli/src/util/errors.ts
@@ -1,9 +1,36 @@
 /**
- * Translate raw API error messages to actionable CLI hints.
+ * Translate raw API / network error messages into actionable CLI hints.
+ *
+ * Order matters: more specific patterns first. Falls through to the original
+ * message when nothing matches, so we never lose information.
  */
 export function friendlyError(msg: string): string {
   if (msg.includes("Multiple projects found")) return "Multiple projects found. Run: polpo projects set";
   if (/HTTP 401|Unauthorized/i.test(msg)) return "Session expired or invalid. Run: polpo login";
   if (/HTTP 403|Forbidden/i.test(msg)) return "Access denied. Check your credentials or project permissions.";
+  if (/HTTP 404|Not Found/i.test(msg)) return "Resource not found.";
+  if (/HTTP 409|Conflict/i.test(msg)) return "Conflict — resource already exists.";
+  if (/HTTP 429|rate.?limit/i.test(msg)) return "Rate limited. Wait a moment and retry.";
+  if (/HTTP 5\d\d|Service Unavailable|Bad Gateway|Internal Server Error/i.test(msg)) {
+    return "Polpo Cloud is having issues. Check status.polpo.sh or retry shortly.";
+  }
+  if (
+    /ECONNREFUSED|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|fetch failed|network|Could not reach/i.test(msg)
+  ) {
+    return "Could not reach the Polpo API. Check your network or run: polpo whoami";
+  }
   return msg;
+}
+
+/**
+ * Network error thrown by the API client when fetch() itself fails (DNS,
+ * TCP refused, TLS handshake, timeout). Carries the host so callers can
+ * print "Could not reach https://api.polpo.sh".
+ */
+export class ApiNetworkError extends Error {
+  constructor(public readonly baseUrl: string, cause: unknown) {
+    super(`Could not reach ${baseUrl}: ${(cause as Error)?.message ?? String(cause)}`);
+    this.name = "ApiNetworkError";
+    this.cause = cause;
+  }
 }

--- a/packages/cli/src/util/org.ts
+++ b/packages/cli/src/util/org.ts
@@ -1,13 +1,7 @@
-/**
- * Organization resolution helpers.
- *
- * `resolveDefaultOrg()` fetches the user's orgs from the control plane
- * and returns the first one (used by `deploy` today where only one is
- * expected). `pickOrg()` is the interactive variant for `create` where
- * the user may belong to multiple orgs.
- */
 import * as clack from "@clack/prompts";
+import pc from "picocolors";
 import type { ApiClient } from "../commands/cloud/api.js";
+import { slugify } from "./slugify.js";
 
 export interface Org {
   id: string;
@@ -20,29 +14,75 @@ async function listOrgs(client: ApiClient): Promise<Org[]> {
   return Array.isArray(res.data) ? res.data : [];
 }
 
+async function createOrgInline(client: ApiClient, name: string): Promise<Org> {
+  const slug = slugify(name);
+  const res = await client.post<Org>("/v1/orgs", { name, slug });
+  if (!res.data?.id) {
+    const err = (res.data as { error?: string } | undefined)?.error ?? `HTTP ${res.status}`;
+    throw new Error(`Failed to create organization: ${err}`);
+  }
+  return res.data;
+}
+
 /**
- * Return the first (and typically only) org.
- * Throws when the user has no orgs — onboarding should have seeded one.
+ * Non-interactive: returns the first org. Throws when the user has none —
+ * intended for scripted contexts (`polpo deploy` without prompts).
+ * Interactive entry points should use `pickOrg()` instead.
  */
 export async function resolveDefaultOrg(client: ApiClient): Promise<Org> {
   const orgs = await listOrgs(client);
   if (orgs.length === 0) {
-    throw new Error("No organization found. Complete onboarding at polpo.sh first.");
+    throw new Error(
+      "No organization found. Run `polpo create` interactively to create one, or finish onboarding at polpo.sh.",
+    );
   }
   return orgs[0];
 }
 
 /**
- * Interactive org picker.
- * - 0 orgs → throws
- * - 1 org → returns it without prompting
- * - >1   → clack.select picker
+ * Interactive org resolution used by `polpo create`.
+ *
+ *   0 orgs → prompt the user to name + create one inline (no detour to web)
+ *   1 org  → auto-select, log
+ *   >1     → clack.select picker
+ *
+ * The 0-org case used to throw an opaque error pointing the user back to
+ * the dashboard. That broke the "everything from the terminal" promise —
+ * inline creation lets a fresh signup go from `polpo login` to a working
+ * project without leaving the CLI.
  */
 export async function pickOrg(client: ApiClient): Promise<Org> {
   const orgs = await listOrgs(client);
+
   if (orgs.length === 0) {
-    throw new Error("No organization found. Complete onboarding at polpo.sh first.");
+    clack.log.info(
+      "No organization found on this account — let's create one.",
+    );
+    const name = await clack.text({
+      message: "Organization name",
+      placeholder: "Acme Inc",
+      validate: (v) => (v.trim().length < 2 ? "Name must be at least 2 characters" : undefined),
+    });
+    if (clack.isCancel(name)) {
+      clack.cancel("Cancelled.");
+      process.exit(0);
+    }
+    const s = clack.spinner();
+    s.start("Creating organization...");
+    try {
+      const org = await createOrgInline(client, name as string);
+      s.stop(`Organization "${org.name}" created`);
+      return org;
+    } catch (err) {
+      s.stop("Organization creation failed.");
+      clack.log.error((err as Error).message);
+      clack.log.info(
+        `If this keeps failing, finish onboarding at ${pc.bold("https://polpo.sh")} and re-run.`,
+      );
+      process.exit(1);
+    }
   }
+
   if (orgs.length === 1) {
     clack.log.info(`Organization: ${orgs[0].name}`);
     return orgs[0];

--- a/packages/cli/tests/errors.test.ts
+++ b/packages/cli/tests/errors.test.ts
@@ -54,18 +54,46 @@ describe("friendlyError", () => {
     });
   });
 
-  describe("passthrough", () => {
-    it("returns the original message when no pattern matches", () => {
-      expect(friendlyError("connect ECONNREFUSED")).toBe("connect ECONNREFUSED");
+  describe("network errors", () => {
+    it("maps ECONNREFUSED to a network hint", () => {
+      expect(friendlyError("connect ECONNREFUSED")).toMatch(/Could not reach the Polpo API/);
     });
 
+    it("maps fetch failed to the same hint", () => {
+      expect(friendlyError("fetch failed")).toMatch(/Could not reach the Polpo API/);
+    });
+
+    it("maps DNS errors (ENOTFOUND, EAI_AGAIN) to the same hint", () => {
+      expect(friendlyError("getaddrinfo ENOTFOUND api.polpo.sh")).toMatch(/Could not reach/);
+      expect(friendlyError("getaddrinfo EAI_AGAIN")).toMatch(/Could not reach/);
+    });
+  });
+
+  describe("HTTP status mapping", () => {
+    it("maps 404 to a friendly message", () => {
+      expect(friendlyError("HTTP 404 not found")).toBe("Resource not found.");
+    });
+
+    it("maps 5xx to a service-status hint", () => {
+      expect(friendlyError("HTTP 500 internal")).toMatch(/status\.polpo\.sh/);
+    });
+
+    it("maps 429 to a rate-limit hint", () => {
+      expect(friendlyError("HTTP 429 rate limit exceeded")).toMatch(/Rate limited/);
+    });
+
+    it("maps 409 to a conflict hint", () => {
+      expect(friendlyError("HTTP 409 Conflict")).toMatch(/already exists/);
+    });
+  });
+
+  describe("passthrough", () => {
     it("returns empty string unchanged", () => {
       expect(friendlyError("")).toBe("");
     });
 
-    it("returns unrelated 4xx/5xx untouched", () => {
-      expect(friendlyError("HTTP 404 not found")).toBe("HTTP 404 not found");
-      expect(friendlyError("HTTP 500 internal")).toBe("HTTP 500 internal");
+    it("returns unrelated free-form messages untouched", () => {
+      expect(friendlyError("Something weird happened")).toBe("Something weird happened");
     });
   });
 

--- a/packages/cli/tests/util/org.test.ts
+++ b/packages/cli/tests/util/org.test.ts
@@ -33,7 +33,9 @@ describe("resolveDefaultOrg", () => {
     expect(org).toEqual({ id: "o1", name: "First" });
   });
 
-  it("throws a friendly error when the user has zero orgs", async () => {
+  it("throws a friendly error when the user has zero orgs (non-interactive mode)", async () => {
+    // resolveDefaultOrg is the non-interactive variant — `polpo create` uses
+    // pickOrg() instead, which prompts to create one inline.
     const get = vi.fn().mockResolvedValue(ok([] as Org[]));
     await expect(resolveDefaultOrg(mockClient(get))).rejects.toThrow(
       /No organization found/,

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Before: `polpo login` then `polpo create` on a fresh account threw a raw stack trace pointing the user back to the dashboard. Awful first experience for a CLI-first dev tool.

Now: `pickOrg()` (the interactive variant used by `polpo create`) prompts for an org name, posts to `/v1/orgs`, and continues. Zero detour to web. Cancellable (Ctrl+C / ESC).

`resolveDefaultOrg()` (non-interactive variant used by `polpo deploy` without prompts) keeps throwing — scripted contexts shouldn't open a prompt.