### PR TITLE
fix(cli): chmod credentials file to 0600

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/src/commands/cloud/config.ts
+++ b/packages/cli/src/commands/cloud/config.ts
@@ -22,7 +22,8 @@ export function saveCredentials(
   baseUrl?: string,
 ): void {
   if (!fs.existsSync(CONFIG_DIR)) {
-    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    // 0o700: only the owner can read/write/execute this directory.
+    fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
   }
 
   const creds: Credentials = {
@@ -31,6 +32,12 @@ export function saveCredentials(
   };
 
   fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), "utf-8");
+  // 0o600: owner read/write only. Matches the standard CLI credential pattern
+  // (Nia `~/.config/nia/api_key`, Stripe `~/.config/stripe/config.toml`,
+  // AWS `~/.aws/credentials`). Applied as an explicit chmod after write
+  // because the `mode:` flag on writeFileSync doesn't downgrade existing
+  // permissions if the file already existed.
+  fs.chmodSync(CREDENTIALS_FILE, 0o600);
 }
 
 export function loadCredentials(): Credentials | null {

--- a/packages/cli/tests/cloud/config.test.ts
+++ b/packages/cli/tests/cloud/config.test.ts
@@ -139,3 +139,30 @@ describe("clearCredentials", () => {
     expect(fs.existsSync(path.join(homeHolder.path, ".polpo"))).toBe(true);
   });
 });
+
+// Skip on Windows — POSIX permission bits aren't meaningful there.
+const isPosix = process.platform !== "win32";
+
+describe.skipIf(!isPosix)("file permissions (POSIX)", () => {
+  it("writes credentials with 0600 (owner-only read/write)", () => {
+    config.saveCredentials("sk_live_abc");
+    const mode = fs.statSync(credsFile()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("creates the .polpo dir with 0700 (owner-only)", () => {
+    config.saveCredentials("sk_live_abc");
+    const mode = fs.statSync(path.join(homeHolder.path, ".polpo")).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
+  it("downgrades permissions on an existing overly-permissive file", () => {
+    // Simulate a credentials file that predates the chmod fix
+    // (e.g. written by a previous CLI version with default umask 0644).
+    fs.mkdirSync(path.join(homeHolder.path, ".polpo"), { recursive: true });
+    fs.writeFileSync(credsFile(), "{}", { mode: 0o644 });
+    config.saveCredentials("sk_live_abc");
+    const mode = fs.statSync(credsFile()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
saveCredentials wrote `~/.polpo/credentials.json` with the default umask (typically 0644 = world-readable). Harmless on a single-user laptop, risky on any shared host (CI runners, multi-user boxes, containers) — another user could just `cat ~alessio/.polpo/credentials.json`.

Fix: explicit `chmod 0600` + `mkdir 0700` for `.polpo/`. Applied as chmod after write (not writeFileSync mode) so it also downgrades existing overly-permissive files from older CLI versions.

Matches Nia / Stripe CLI / AWS CLI patterns.

**3 new POSIX tests** (skipped on Windows). 184/184 passing.

Bumps all packages to 0.6.3 in lockstep.