### PR TITLE
feat(react-sdk): fetch + apiPrefix passthrough on PolpoProvider

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/src/provider/polpo-provider.tsx
+++ b/packages/react-sdk/src/provider/polpo-provider.tsx
@@ -11,6 +11,22 @@ export interface PolpoProviderProps {
   /** @deprecated No longer used. Kept for backwards compatibility. */
   projectId?: string;
   apiKey?: string;
+  /**
+   * Override the fetch implementation used by the underlying `PolpoClient`.
+   * Useful for cookie-auth scenarios (`credentials: "include"`), request
+   * logging/tracing, injecting custom headers, retry middleware, or mocking
+   * in tests.
+   *
+   * If omitted, the default uses `globalThis.fetch`.
+   */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Override the API path prefix. Defaults to `/v1` for `*.polpo.sh` /
+   * `*.polpo.cloud`, `/api/v1` otherwise. Set explicitly when the request
+   * target is a proxy (e.g. a session-auth dashboard proxy that already
+   * includes the full `/v1/...` path downstream).
+   */
+  apiPrefix?: string;
   children: ReactNode;
   autoConnect?: boolean;
   eventFilter?: string[];
@@ -19,18 +35,22 @@ export interface PolpoProviderProps {
 export function PolpoProvider({
   baseUrl,
   apiKey,
+  fetch,
+  apiPrefix,
   children,
   autoConnect = true,
   eventFilter,
 }: PolpoProviderProps) {
-  const configKey = `${baseUrl}|${apiKey ?? ""}`;
+  // Config key includes fetch identity + apiPrefix so that swapping either
+  // rebuilds the client (same reasoning as baseUrl/apiKey today).
+  const configKey = `${baseUrl}|${apiKey ?? ""}|${apiPrefix ?? ""}|${fetch ? "custom-fetch" : "default-fetch"}`;
   const storeRef = useRef<PolpoStore>(null as unknown as PolpoStore);
   const clientRef = useRef<PolpoClient>(null as unknown as PolpoClient);
   const lastConfigKey = useRef("");
 
   if (lastConfigKey.current !== configKey) {
     lastConfigKey.current = configKey;
-    clientRef.current = new PolpoClient({ baseUrl, apiKey });
+    clientRef.current = new PolpoClient({ baseUrl, apiKey, fetch, apiPrefix });
     storeRef.current = new PolpoStore();
   }
 


### PR DESCRIPTION
## Summary

Expose two optional props on \`<PolpoProvider>\` — \`fetch\` and \`apiPrefix\` — that were already supported by the underlying \`PolpoClient\` but swallowed by the Provider.

- \`fetch\` — custom fetch implementation. Main driver: cookie-auth scenarios (\`credentials: \"include\"\`). Secondary drivers: logging/tracing middleware, custom headers (multi-tenant proxies), retry, testing mocks.
- \`apiPrefix\` — override the URL path prefix when pointing the client at a proxy that already includes the downstream \`/v1/...\` path.

Both are optional; existing consumers keep working with zero changes.

## Why

Polpo Cloud's upcoming in-dashboard chat playground will reuse the public \`@polpo-ai/chat\` UI against the session-authenticated proxy at \`/v1/projects/:id/data/*\` — without shipping a Bearer API key to the browser. That's the pattern OpenAI / Stripe / Supabase use for their own in-dashboard tools. To reuse the existing React UI we need the Provider to forward \`fetch\` (for \`credentials: include\`) and \`apiPrefix\` (so the client hits the proxy URL instead of the tenant subdomain).

## Version

Bumped to \`0.6.16\` (patch — additive, no breaking changes).

## Test plan

- [x] \`pnpm --filter @polpo-ai/react build\` — clean tsc pass
- [x] \`pnpm --filter @polpo-ai/react test\` — 48/48 passing
- [ ] Manual smoke: construct \`<PolpoProvider fetch={cookieFetch} apiPrefix=\"/v1\" baseUrl=\"...\" />\` and verify network request uses cookie + correct path (to be done when wiring the dashboard playground)