### PR TITLE
fix(react-sdk): useAgent accepts nullable name, no-ops cleanly

### DIFF
--- a/packages/react-sdk/src/hooks/use-agent.ts
+++ b/packages/react-sdk/src/hooks/use-agent.ts
@@ -11,14 +11,21 @@ export interface UseAgentReturn {
 
 /**
  * Fetch a single agent by name from the `/agents/:name` endpoint.
+ *
+ * Pass `undefined` or `null` when the name is not yet known (e.g. a session
+ * without an associated agent, or data still loading) and the hook will
+ * no-op — no HTTP request, no spurious 404s. Previously consumers had
+ * to invent sentinel strings like `"__none__"` to avoid the call; that
+ * pattern is no longer necessary.
  */
-export function useAgent(name: string): UseAgentReturn {
+export function useAgent(name: string | undefined | null): UseAgentReturn {
   const { client } = usePolpoContext();
   const [agent, setAgent] = useState<AgentConfig | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(!!name);
   const [error, setError] = useState<Error | null>(null);
 
   const fetchAgent = useCallback(async () => {
+    if (!name) return;
     try {
       setError(null);
       const data = await client.getAgent(name);
@@ -32,6 +39,7 @@ export function useAgent(name: string): UseAgentReturn {
   useEffect(() => {
     if (!name) {
       setAgent(null);
+      setError(null);
       setIsLoading(false);
       return;
     }


### PR DESCRIPTION
## Summary

Make \`useAgent\` accept \`string | undefined | null\` and no-op when the name is falsy.

## Why

The current signature forces \`name: string\`, so consumers invent sentinel strings like \`useAgent(agentName || \"__none__\")\` to avoid calling it when the name isn't known yet. The sentinel then hits \`GET /v1/agents/__none__\` on the server and 404s, surfacing as a noisy \"Agent not found\" error in the browser console.

Saw this in production for every user opening a session whose \`session.agent\` field wasn't set.

## What changes

- Signature: \`useAgent(name: string): …\` → \`useAgent(name: string | undefined | null): …\`
- When \`name\` is falsy (\`undefined\`, \`null\`, or \`\"\"\`): no HTTP call, \`agent = null\`, \`isLoading = false\`, \`error = null\`.
- When \`name\` is a real string: identical behaviour to before.

## Not a breaking change

Every existing call site continues to compile and behave identically. The change only widens the accepted type.

## Follow-up in polpo-ui (separate PR)

polpo-ui/pull/10 already updates the \`examples/chat\` and \`examples/multi-agent\` pages to use the proper pattern — dropping the \`__none__\` sentinel entirely and using a local \`find\` over the already-loaded \`useAgents()\` list. With this SDK change, TypeScript accepts \`useAgent(undefined)\` as a legitimate no-fetch call, which was the real root cause of the sentinel hack.

## Test plan

- [x] \`pnpm --filter @polpo-ai/react build\` — clean
- [x] \`pnpm --filter @polpo-ai/react test\` — 48/48
- [x] \`cd packages/react-sdk && npx tsc --noEmit\` — clean
- [ ] Verify browser console in the dashboard playground / polpo-ui chat example: no more \"Agent not found\" error when opening a session.