### PR TITLE
feat(skills): POST /skills/add accepts optional assignTo

### DIFF
--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -307,6 +307,7 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
                 source: z.string().min(1).describe("GitHub owner/repo, full URL, or local path"),
                 skillNames: z.array(z.string()).optional().describe("Only install specific skill names"),
                 force: z.boolean().optional().describe("Overwrite existing skills"),
+                assignTo: z.string().optional().describe("Agent name to assign the installed skills to. If provided, the agent's `skills` list is updated with the newly installed skill names."),
               }),
             },
           },
@@ -318,12 +319,12 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       },
     }),
     async (c: any) => {
-      const { fs, shell, polpoDir } = getDeps();
+      const { fs, shell, polpoDir, getAgents, updateAgentSkills } = getDeps();
       if (!shell) {
         return c.json({ ok: false, error: "Skill installation not available (no shell)" }, 400);
       }
 
-      const { source, skillNames, force } = await c.req.json();
+      const { source, skillNames, force, assignTo } = await c.req.json();
 
       // Parse source
       let cloneUrl: string | null = null;
@@ -446,7 +447,30 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       // Cleanup cloned repo
       if (cloneUrl) await shell.execute(`rm -rf "${sourceDir}"`).catch(() => {});
 
-      return c.json({ ok: true, data: { installed, skipped, errors, source } });
+      // Optional: assign installed skills to an agent. Closes the onboarding
+      // "install + assign" loop in a single call. Silent no-op if the agent
+      // doesn't exist or the deps don't expose updateAgentSkills.
+      let assigned: string[] = [];
+      if (assignTo && installed.length > 0 && getAgents && updateAgentSkills) {
+        try {
+          const agents = await getAgents();
+          const agent = agents.find((a: any) => a.name === assignTo);
+          if (agent) {
+            const current: string[] = (agent.skills as string[] | undefined) ?? [];
+            const toAdd = installed.filter((name) => !current.includes(name));
+            if (toAdd.length > 0) {
+              await updateAgentSkills(assignTo, [...current, ...toAdd]);
+              assigned = toAdd;
+            }
+          } else {
+            errors.push(`assignTo: agent "${assignTo}" not found`);
+          }
+        } catch (err) {
+          errors.push(`assignTo: ${(err as Error).message}`);
+        }
+      }
+
+      return c.json({ ok: true, data: { installed, skipped, errors, source, assigned } });
     },
   );
 


### PR DESCRIPTION
## Summary

Closes the install → assign onboarding gap in one API call.

Before: \`POST /v1/skills/add\` cloned + copied the skill into \`polpoDir/skills/\` but left the agent's \`skills\` list unchanged. To actually make the agent use the installed skill the caller had to hit \`POST /v1/skills/:name/assign\` separately. First-time users saw no behaviour change after install and assumed they'd done something wrong.

After: one optional \`assignTo\` field on the install body wires the two together:

\`\`\`bash
curl -X POST {endpoint}/v1/skills/add \\
  -H \"Authorization: Bearer \$POLPO_API_KEY\" \\
  -H \"Content-Type: application/json\" \\
  -d '{
    \"source\": \"anthropics/skills\",
    \"skillNames\": [\"frontend-design\"],
    \"assignTo\": \"assistant\"
  }'
\`\`\`

## Behaviour

- If \`assignTo\` matches an existing agent, the installed skill names are merged into its \`skills\` list (dedup'd) via the existing \`updateAgentSkills\` dep.
- Response gains a sibling \`assigned: string[]\` listing the newly-assigned skills, so callers can confirm.
- If \`assignTo\` doesn't resolve, returns successfully but surfaces a non-blocking error in the \`errors\` array (\"assignTo: agent X not found\").
- Silently no-ops when the deps don't expose \`updateAgentSkills\` (e.g. install-only environments).

## Back-compat

\`assignTo\` is optional. Existing callers keep working unchanged; response shape just gains an empty \`assigned\` array.

## Why

Used on the cloud onboarding checklist's \"Add skill to your agent\" step. The curl tab previously shipped \`/skills/add\` alone and the checklist step flipped to \"done\" — but the agent was unchanged. Users wondered why chat didn't reflect the new skill. With this change, one curl does the right thing end-to-end.

## Test plan

- [x] \`pnpm test\` — 1317/1317 green
- [x] \`npx tsc --noEmit\` — clean in packages/server
- [ ] Manually: install + assign with \`assignTo\` set, verify agent config now lists the skill
- [ ] Manually: install with no \`assignTo\` — old behaviour preserved, \`assigned\` is \`[]\`
- [ ] Manually: \`assignTo\` pointing at a non-existent agent — returns 200 with install done + error noted