### PR TITLE
feat(skill-store): SkillStore port + File/Drizzle impls + skillRoutes fast-path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/attachment-store.d.ts",
       "import": "./dist/attachment-store.js"
     },
+    "./skill-store": {
+      "types": "./dist/skill-store.d.ts",
+      "import": "./dist/skill-store.js"
+    },
     "./adapter": {
       "types": "./dist/adapter.d.ts",
       "import": "./dist/adapter.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export type { SessionStore, Session, Message, MessageRole, ToolCallInfo, ToolCal
 export type { ApprovalStore } from "./approval-store.js";
 export type { TeamStore } from "./team-store.js";
 export type { AgentStore } from "./agent-store.js";
+export type { SkillStore, SkillRecord } from "./skill-store.js";
 export type { VaultStore } from "./vault-store.js";
 export type { PlaybookStore } from "./playbook-store.js";
 export type { AttachmentStore, Attachment } from "./attachment-store.js";

--- a/packages/core/src/skill-store.ts
+++ b/packages/core/src/skill-store.ts
@@ -1,0 +1,40 @@
+/**
+ * Persistent per-project skill catalog — name + description + source +
+ * optional tags/category kept in a store so that `GET /skills` can be
+ * answered without walking the filesystem. The filesystem (polpoDir/
+ * skills/<name>/SKILL.md + assets) remains the source of truth for
+ * skill CONTENT; the store indexes metadata.
+ *
+ * Shape is additive to the legacy `SkillIndexEntry` (tags + category)
+ * which used to live in a standalone `skills-index.json` — the new
+ * record absorbs those fields so callers have a single source.
+ */
+export interface SkillRecord {
+  /** Canonical skill name (matches directory name on disk). */
+  name: string;
+  /** Short description from SKILL.md frontmatter. */
+  description: string;
+  /** Where the skill came from: "anthropics/skills", "github.com/…",
+   *  "local", etc. Useful for reinstall / update flows. */
+  source?: string;
+  /** ISO timestamp of the first install. */
+  installedAt: string;
+  /** Tool names from SKILL.md frontmatter. Cached to avoid re-parsing
+   *  SKILL.md on every list. */
+  allowedTools?: string[];
+  /** User-assigned tags (free-form). */
+  tags?: string[];
+  /** User-assigned category (single). */
+  category?: string;
+}
+
+export interface SkillStore {
+  /** Return all recorded skills, unordered. */
+  list(): Promise<SkillRecord[]>;
+  /** Return a single record by name, or undefined. */
+  get(name: string): Promise<SkillRecord | undefined>;
+  /** Insert or replace a record. `name` is the primary key. */
+  upsert(record: SkillRecord): Promise<void>;
+  /** Remove a record. Returns true if something was removed. */
+  remove(name: string): Promise<boolean>;
+}

--- a/packages/drizzle/src/__tests__/stores-pg.test.ts
+++ b/packages/drizzle/src/__tests__/stores-pg.test.ts
@@ -37,6 +37,7 @@ const ALL_TABLES = [
   "teams",
   "vault",
   "playbooks",
+  "skills",
 ] as const;
 
 // ── Connection check ──────────────────────────────────────────────────
@@ -1168,6 +1169,67 @@ describe.skipIf(!canConnect)("PostgreSQL Drizzle stores", () => {
   // Factory function
   // ═══════════════════════════════════════════════════════════════════════
 
+  describe("DrizzleSkillStore", () => {
+    const baseRecord = {
+      description: "A test skill",
+      installedAt: "2026-04-19T00:00:00.000Z",
+    };
+
+    it("list() returns [] when the table is empty", async () => {
+      expect(await stores.skillStore.list()).toEqual([]);
+    });
+
+    it("get() returns undefined for unknown names", async () => {
+      expect(await stores.skillStore.get("nope")).toBeUndefined();
+    });
+
+    it("upsert + get round-trip", async () => {
+      await stores.skillStore.upsert({ name: "alpha", ...baseRecord });
+      const got = await stores.skillStore.get("alpha");
+      expect(got).toBeDefined();
+      expect(got?.description).toBe("A test skill");
+    });
+
+    it("upsert overwrites existing record by name", async () => {
+      await stores.skillStore.upsert({ name: "x", ...baseRecord, description: "first" });
+      await stores.skillStore.upsert({ name: "x", ...baseRecord, description: "second" });
+      expect((await stores.skillStore.get("x"))?.description).toBe("second");
+      expect((await stores.skillStore.list()).length).toBe(1);
+    });
+
+    it("remove returns true/false correctly", async () => {
+      await stores.skillStore.upsert({ name: "rm", ...baseRecord });
+      expect(await stores.skillStore.remove("rm")).toBe(true);
+      expect(await stores.skillStore.remove("rm")).toBe(false);
+    });
+
+    it("round-trips optional fields including JSONB arrays", async () => {
+      await stores.skillStore.upsert({
+        name: "full",
+        description: "Everything set",
+        source: "anthropics/skills",
+        installedAt: "2026-04-19T12:34:56.000Z",
+        allowedTools: ["read", "write"],
+        tags: ["ui"],
+        category: "frontend",
+      });
+      const got = await stores.skillStore.get("full");
+      expect(got?.source).toBe("anthropics/skills");
+      expect(got?.allowedTools).toEqual(["read", "write"]);
+      expect(got?.tags).toEqual(["ui"]);
+      expect(got?.category).toBe("frontend");
+    });
+
+    it("null optional fields are preserved", async () => {
+      await stores.skillStore.upsert({ name: "minimal", ...baseRecord });
+      const got = await stores.skillStore.get("minimal");
+      expect(got?.source).toBeUndefined();
+      expect(got?.allowedTools).toBeUndefined();
+      expect(got?.tags).toBeUndefined();
+      expect(got?.category).toBeUndefined();
+    });
+  });
+
   describe("createPgStores", () => {
     it("returns all stores", () => {
       expect(stores.taskStore).toBeDefined();
@@ -1184,6 +1246,7 @@ describe.skipIf(!canConnect)("PostgreSQL Drizzle stores", () => {
       expect(stores.vaultStore).toBeDefined();
       expect(stores.playbookStore).toBeDefined();
       expect(stores.attachmentStore).toBeDefined();
+      expect(stores.skillStore).toBeDefined();
     });
   });
 });

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -216,6 +216,15 @@ function createTables(raw: InstanceType<typeof Database>) {
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS skills (
+      name TEXT PRIMARY KEY,
+      description TEXT NOT NULL DEFAULT '',
+      source TEXT,
+      installed_at TEXT NOT NULL,
+      allowed_tools TEXT,
+      tags TEXT,
+      category TEXT
+    );
     PRAGMA foreign_keys = ON;
   `);
 }
@@ -1277,6 +1286,105 @@ describe("DrizzlePlaybookStore", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════
+// SkillStore
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("DrizzleSkillStore (SQLite)", () => {
+  const baseRecord = {
+    description: "A test skill",
+    installedAt: "2026-04-19T00:00:00.000Z",
+  };
+
+  it("list() returns [] when table is empty", async () => {
+    expect(await stores.skillStore.list()).toEqual([]);
+  });
+
+  it("get() returns undefined for unknown name", async () => {
+    expect(await stores.skillStore.get("nope")).toBeUndefined();
+  });
+
+  it("upsert + get round-trip", async () => {
+    await stores.skillStore.upsert({ name: "alpha", ...baseRecord });
+    const got = await stores.skillStore.get("alpha");
+    expect(got).toBeDefined();
+    expect(got?.description).toBe("A test skill");
+    expect(got?.installedAt).toBe("2026-04-19T00:00:00.000Z");
+  });
+
+  it("upsert overwrites the existing record (by name)", async () => {
+    await stores.skillStore.upsert({ name: "x", ...baseRecord, description: "first" });
+    await stores.skillStore.upsert({ name: "x", ...baseRecord, description: "second" });
+    expect((await stores.skillStore.get("x"))?.description).toBe("second");
+    expect((await stores.skillStore.list()).length).toBe(1);
+  });
+
+  it("list returns all upserted records", async () => {
+    await stores.skillStore.upsert({ name: "a", ...baseRecord });
+    await stores.skillStore.upsert({ name: "b", ...baseRecord });
+    const names = (await stores.skillStore.list()).map((r) => r.name).sort();
+    expect(names).toEqual(["a", "b"]);
+  });
+
+  it("remove returns true when the record existed", async () => {
+    await stores.skillStore.upsert({ name: "rm", ...baseRecord });
+    expect(await stores.skillStore.remove("rm")).toBe(true);
+    expect(await stores.skillStore.get("rm")).toBeUndefined();
+  });
+
+  it("remove returns false when the record did not exist", async () => {
+    expect(await stores.skillStore.remove("never-existed")).toBe(false);
+  });
+
+  it("round-trips all optional fields (source, tags, category, allowedTools)", async () => {
+    await stores.skillStore.upsert({
+      name: "full",
+      description: "Everything set",
+      source: "anthropics/skills",
+      installedAt: "2026-04-19T12:34:56.000Z",
+      allowedTools: ["read", "write", "http_fetch"],
+      tags: ["ui", "react"],
+      category: "frontend",
+    });
+    const got = await stores.skillStore.get("full");
+    expect(got?.source).toBe("anthropics/skills");
+    expect(got?.allowedTools).toEqual(["read", "write", "http_fetch"]);
+    expect(got?.tags).toEqual(["ui", "react"]);
+    expect(got?.category).toBe("frontend");
+  });
+
+  it("null/undefined optional fields are preserved across upsert", async () => {
+    await stores.skillStore.upsert({ name: "minimal", ...baseRecord });
+    const got = await stores.skillStore.get("minimal");
+    expect(got?.source).toBeUndefined();
+    expect(got?.allowedTools).toBeUndefined();
+    expect(got?.tags).toBeUndefined();
+    expect(got?.category).toBeUndefined();
+  });
+
+  it("upsert updates tags without touching other fields", async () => {
+    await stores.skillStore.upsert({
+      name: "mutate",
+      ...baseRecord,
+      tags: ["old"],
+    });
+    await stores.skillStore.upsert({
+      name: "mutate",
+      ...baseRecord,
+      tags: ["new", "fresh"],
+    });
+    const got = await stores.skillStore.get("mutate");
+    expect(got?.tags).toEqual(["new", "fresh"]);
+  });
+
+  it("remove preserves unrelated records", async () => {
+    await stores.skillStore.upsert({ name: "keep", ...baseRecord });
+    await stores.skillStore.upsert({ name: "drop", ...baseRecord });
+    await stores.skillStore.remove("drop");
+    expect((await stores.skillStore.list()).map((r) => r.name)).toEqual(["keep"]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
 // Factory function
 // ═══════════════════════════════════════════════════════════════════════
 
@@ -1295,5 +1403,6 @@ describe("createSqliteStores", () => {
     expect(stores.agentStore).toBeDefined();
     expect(stores.vaultStore).toBeDefined();
     expect(stores.playbookStore).toBeDefined();
+    expect(stores.skillStore).toBeDefined();
   });
 });

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -38,6 +38,7 @@ import {
 import { vaultPg, vaultSqlite } from "./schema/vault.js";
 import { playbooksPg, playbooksSqlite } from "./schema/playbooks.js";
 import { attachmentsPg, attachmentsSqlite } from "./schema/attachments.js";
+import { skillsPg, skillsSqlite } from "./schema/skills.js";
 
 // ── Store classes ─────────────────────────────────────────────────────
 
@@ -55,6 +56,7 @@ import { DrizzleAgentStore } from "./stores/agent-store.js";
 import { DrizzleVaultStore } from "./stores/vault-store.js";
 import { DrizzlePlaybookStore } from "./stores/playbook-store.js";
 import { DrizzleAttachmentStore } from "./stores/attachment-store.js";
+import { DrizzleSkillStore } from "./stores/skill-store.js";
 
 // ── Store bundle type ─────────────────────────────────────────────────
 
@@ -72,6 +74,7 @@ import type { AgentStore } from "@polpo-ai/core/agent-store";
 import type { VaultStore } from "@polpo-ai/core/vault-store";
 import type { PlaybookStore } from "@polpo-ai/core/playbook-store";
 import type { AttachmentStore } from "@polpo-ai/core/attachment-store";
+import type { SkillStore } from "@polpo-ai/core/skill-store";
 
 export interface DrizzleStores {
   taskStore: TaskStore;
@@ -88,6 +91,7 @@ export interface DrizzleStores {
   vaultStore: VaultStore;
   playbookStore: PlaybookStore;
   attachmentStore: AttachmentStore;
+  skillStore: SkillStore;
 }
 
 // ── PostgreSQL factory ────────────────────────────────────────────────
@@ -115,6 +119,7 @@ export function createPgStores(db: any): DrizzleStores {
     vaultStore: new DrizzleVaultStore(db, vaultPg),
     playbookStore: new DrizzlePlaybookStore(db, playbooksPg, "pg"),
     attachmentStore: new DrizzleAttachmentStore(db, attachmentsPg, "pg"),
+    skillStore: new DrizzleSkillStore(db, skillsPg, "pg"),
   };
 }
 
@@ -143,6 +148,7 @@ export function createSqliteStores(db: any): DrizzleStores {
     vaultStore: new DrizzleVaultStore(db, vaultSqlite),
     playbookStore: new DrizzlePlaybookStore(db, playbooksSqlite, "sqlite"),
     attachmentStore: new DrizzleAttachmentStore(db, attachmentsSqlite, "sqlite"),
+    skillStore: new DrizzleSkillStore(db, skillsSqlite, "sqlite"),
   };
 }
 
@@ -165,6 +171,7 @@ export const pgSchema = {
   vault: vaultPg,
   playbooks: playbooksPg,
   attachments: attachmentsPg,
+  skills: skillsPg,
 };
 
 export const sqliteSchema = {
@@ -184,4 +191,5 @@ export const sqliteSchema = {
   vault: vaultSqlite,
   playbooks: playbooksSqlite,
   attachments: attachmentsSqlite,
+  skills: skillsSqlite,
 };

--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -229,4 +229,14 @@ export async function ensurePgSchema(db: any): Promise<void> {
       END IF;
     END $$
   `);
+
+  await db.execute(sql`CREATE TABLE IF NOT EXISTS skills (
+    name          TEXT PRIMARY KEY,
+    description   TEXT NOT NULL DEFAULT '',
+    source        TEXT,
+    installed_at  TEXT NOT NULL,
+    allowed_tools JSONB,
+    tags          JSONB,
+    category      TEXT
+  )`);
 }

--- a/packages/drizzle/src/schema/index.ts
+++ b/packages/drizzle/src/schema/index.ts
@@ -11,6 +11,7 @@ export { teamsSqlite, agentsSqlite } from "./teams.js";
 export { vaultSqlite } from "./vault.js";
 export { playbooksSqlite } from "./playbooks.js";
 export { attachmentsSqlite } from "./attachments.js";
+export { skillsSqlite } from "./skills.js";
 
 // PostgreSQL schemas
 export {
@@ -25,3 +26,4 @@ export { teamsPg, agentsPg } from "./teams.js";
 export { vaultPg } from "./vault.js";
 export { playbooksPg } from "./playbooks.js";
 export { attachmentsPg } from "./attachments.js";
+export { skillsPg } from "./skills.js";

--- a/packages/drizzle/src/schema/skills.ts
+++ b/packages/drizzle/src/schema/skills.ts
@@ -1,0 +1,32 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { pgTable, text as pgText, jsonb } from "drizzle-orm/pg-core";
+
+/**
+ * Skills catalog — one row per installed skill for the project.
+ *
+ * Mirrors the fields in `@polpo-ai/core`'s `SkillRecord`. `tags` and
+ * `allowedTools` are stored as JSON (jsonb on PG, JSON-stringified text
+ * on SQLite) so we can re-emit them as arrays without a join table.
+ *
+ * `name` is the primary key since a project cannot have two skills
+ * with the same canonical name (the directory collides anyway).
+ */
+export const skillsSqlite = sqliteTable("skills", {
+  name: text("name").primaryKey(),
+  description: text("description").notNull().default(""),
+  source: text("source"),
+  installedAt: text("installed_at").notNull(),
+  allowedTools: text("allowed_tools"), // JSON-serialized string[]
+  tags: text("tags"),                   // JSON-serialized string[]
+  category: text("category"),
+});
+
+export const skillsPg = pgTable("skills", {
+  name: pgText("name").primaryKey(),
+  description: pgText("description").notNull().default(""),
+  source: pgText("source"),
+  installedAt: pgText("installed_at").notNull(),
+  allowedTools: jsonb("allowed_tools"), // string[]
+  tags: jsonb("tags"),                   // string[]
+  category: pgText("category"),
+});

--- a/packages/drizzle/src/stores/index.ts
+++ b/packages/drizzle/src/stores/index.ts
@@ -13,3 +13,4 @@ export { DrizzleAgentStore } from "./agent-store.js";
 export { DrizzleVaultStore } from "./vault-store.js";
 export { DrizzlePlaybookStore } from "./playbook-store.js";
 export { DrizzleAttachmentStore } from "./attachment-store.js";
+export { DrizzleSkillStore } from "./skill-store.js";

--- a/packages/drizzle/src/stores/skill-store.ts
+++ b/packages/drizzle/src/stores/skill-store.ts
@@ -1,0 +1,76 @@
+import { eq } from "drizzle-orm";
+import type { SkillStore, SkillRecord } from "@polpo-ai/core";
+import { type Dialect, serializeJson, deserializeJson } from "../utils.js";
+
+type AnyTable = any;
+
+/**
+ * Drizzle-backed SkillStore.
+ *
+ * Same table schema on PG and SQLite, just different column types for
+ * the JSON fields (jsonb on PG, text on SQLite). `serializeJson` /
+ * `deserializeJson` handle both transparently.
+ */
+export class DrizzleSkillStore implements SkillStore {
+  constructor(
+    private db: any,
+    private table: AnyTable,
+    private dialect: Dialect,
+  ) {}
+
+  async list(): Promise<SkillRecord[]> {
+    const rows: any[] = await this.db.select().from(this.table);
+    return rows.map((r) => this.rowToRecord(r));
+  }
+
+  async get(name: string): Promise<SkillRecord | undefined> {
+    const rows: any[] = await this.db.select().from(this.table)
+      .where(eq(this.table.name, name));
+    if (rows.length === 0) return undefined;
+    return this.rowToRecord(rows[0]);
+  }
+
+  async upsert(record: SkillRecord): Promise<void> {
+    const values = {
+      name: record.name,
+      description: record.description,
+      source: record.source ?? null,
+      installedAt: record.installedAt,
+      allowedTools: serializeJson(record.allowedTools, this.dialect),
+      tags: serializeJson(record.tags, this.dialect),
+      category: record.category ?? null,
+    };
+    await this.db.insert(this.table).values(values)
+      .onConflictDoUpdate({
+        target: this.table.name,
+        set: {
+          description: values.description,
+          source: values.source,
+          installedAt: values.installedAt,
+          allowedTools: values.allowedTools,
+          tags: values.tags,
+          category: values.category,
+        },
+      });
+  }
+
+  async remove(name: string): Promise<boolean> {
+    const rows: any[] = await this.db.select({ name: this.table.name }).from(this.table)
+      .where(eq(this.table.name, name));
+    if (rows.length === 0) return false;
+    await this.db.delete(this.table).where(eq(this.table.name, name));
+    return true;
+  }
+
+  private rowToRecord(row: any): SkillRecord {
+    return {
+      name: row.name,
+      description: row.description ?? "",
+      source: row.source ?? undefined,
+      installedAt: row.installedAt ?? new Date(0).toISOString(),
+      allowedTools: deserializeJson<string[] | undefined>(row.allowedTools, undefined, this.dialect),
+      tags: deserializeJson<string[] | undefined>(row.tags, undefined, this.dialect),
+      category: row.category ?? undefined,
+    };
+  }
+}

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -45,6 +45,13 @@ export interface SkillRouteDeps {
   getAgents: () => Promise<Array<{ name: string; skills?: string[] }>>;
   /** Update an agent's skills list. Used for assign/unassign. */
   updateAgentSkills?: (agentName: string, skills: string[]) => Promise<void>;
+  /**
+   * Optional metadata store. When provided, list/get/install/remove
+   * write through to the store so GET /skills can answer from a fast
+   * lookup without scanning the filesystem. Falls back to fs scan
+   * when absent (back-compat with deployments that don't wire it).
+   */
+  skillStore?: import("@polpo-ai/core").SkillStore;
 }
 
 // ── Helpers ──
@@ -86,13 +93,35 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       responses: { 200: { content: { "application/json": { schema: z.object({ ok: z.boolean(), data: z.array(z.any()) }) } }, description: "Skills list" } },
     }),
     async (c) => {
-      const { fs, polpoDir, getAgents } = getDeps();
+      const { fs, polpoDir, getAgents, skillStore } = getDeps();
       const agents = await getAgents();
       const agentNames = agents.map((a) => a.name);
       const configSkills = new Map<string, string[]>();
       for (const a of agents) {
         if (a.skills?.length) configSkills.set(a.name, a.skills);
       }
+
+      // Fast path: read from the indexed SkillStore and compute
+      // per-agent assignments from `agent.skills[]` (single query).
+      if (skillStore) {
+        const records = await skillStore.list();
+        const data = records.map((r) => ({
+          name: r.name,
+          description: r.description,
+          source: "project" as const,
+          path: resolve(polpoDir, "skills", r.name),
+          allowedTools: r.allowedTools,
+          tags: r.tags,
+          category: r.category,
+          assignedTo: agentNames.filter(
+            (n) => configSkills.get(n)?.includes(r.name),
+          ),
+        }));
+        return c.json({ ok: true, data });
+      }
+
+      // Fallback: walk the filesystem (back-compat for deployments
+      // that don't wire a skillStore).
       const core = await coreImport();
       const skills = await core.listSkillsWithAssignments(fs, polpoDir, agentNames, configSkills);
       return c.json({ ok: true, data: skills });
@@ -146,9 +175,21 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       responses: { 200: { content: { "application/json": { schema: z.object({ ok: z.boolean(), data: z.any() }) } }, description: "Updated" } },
     }),
     async (c: any) => {
-      const { fs, polpoDir } = getDeps();
+      const { fs, polpoDir, skillStore } = getDeps();
       const name = c.req.param("name");
       const body = await c.req.json();
+
+      // Mirror the update into skillStore if wired.
+      if (skillStore) {
+        const existing = await skillStore.get(name);
+        if (existing) {
+          const next = { ...existing };
+          if ("tags" in body) next.tags = body.tags?.length ? body.tags : undefined;
+          if ("category" in body) next.category = body.category || undefined;
+          await skillStore.upsert(next);
+        }
+      }
+
       const index = (await loadSkillIndex(fs, polpoDir)) ?? {};
       index[name] = { ...index[name], ...body };
       if (index[name].tags?.length === 0) delete index[name].tags;
@@ -183,7 +224,7 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       },
     }),
     async (c: any) => {
-      const { fs, polpoDir } = getDeps();
+      const { fs, polpoDir, skillStore } = getDeps();
       const { name, description, content, allowedTools } = await c.req.json();
 
       const targetDir = join(polpoDir, "skills", name);
@@ -201,6 +242,16 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       fmLines.push(`---`, ``);
 
       await fs.writeFile(join(targetDir, "SKILL.md"), fmLines.join("\n") + content);
+
+      // Mirror to skillStore if wired.
+      await skillStore?.upsert({
+        name,
+        description,
+        source: "local",
+        installedAt: new Date().toISOString(),
+        allowedTools,
+      });
+
       return c.json({ ok: true, data: { name, path: targetDir } });
     },
   );
@@ -216,13 +267,14 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       },
     }),
     async (c: any) => {
-      const { fs, polpoDir } = getDeps();
+      const { fs, polpoDir, skillStore } = getDeps();
       const name = c.req.param("name");
       const targetDir = join(polpoDir, "skills", name);
       if (!(await fs.exists(targetDir))) {
         return c.json({ ok: false, error: "Skill not found" }, 404);
       }
       await fs.remove(targetDir);
+      await skillStore?.remove(name);
       return c.json({ ok: true, data: { removed: true, name } });
     },
   );
@@ -319,7 +371,7 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
       },
     }),
     async (c: any) => {
-      const { fs, shell, polpoDir, getAgents, updateAgentSkills } = getDeps();
+      const { fs, shell, polpoDir, getAgents, updateAgentSkills, skillStore } = getDeps();
       if (!shell) {
         return c.json({ ok: false, error: "Skill installation not available (no shell)" }, 400);
       }
@@ -439,6 +491,14 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
         const cpResult = await shell.execute(`cp -r "${skill.path}" "${targetDir}"`);
         if (cpResult.exitCode === 0) {
           installed.push(skill.name);
+          // Mirror to skillStore for fast-path list reads.
+          await skillStore?.upsert({
+            name: skill.name,
+            description: skill.description,
+            source,
+            installedAt: new Date().toISOString(),
+            allowedTools: (skill as any).allowedTools,
+          }).catch(() => { /* best-effort — fs write already succeeded */ });
         } else {
           errors.push(`${skill.name}: ${cpResult.stderr}`);
         }

--- a/src/__tests__/file-skill-store.test.ts
+++ b/src/__tests__/file-skill-store.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { FileSkillStore } from "../stores/file-skill-store.js";
+import type { SkillRecord } from "@polpo-ai/core";
+
+const TEST_DIR = join(process.cwd(), ".test-skill-store");
+const INDEX_PATH = join(TEST_DIR, "skills-index.json");
+
+function recordOf(overrides: Partial<SkillRecord> & { name: string }): SkillRecord {
+  return {
+    description: "",
+    installedAt: "2026-04-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("FileSkillStore", () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it("list() returns [] when the file does not exist yet", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    expect(await store.list()).toEqual([]);
+  });
+
+  it("get() returns undefined when the file does not exist yet", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    expect(await store.get("frontend-design")).toBeUndefined();
+  });
+
+  it("upsert() creates the directory and writes the file", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({
+      name: "frontend-design",
+      description: "Build distinctive UIs",
+      source: "anthropics/skills",
+    }));
+
+    expect(existsSync(INDEX_PATH)).toBe(true);
+    const raw = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+    expect(raw["frontend-design"].description).toBe("Build distinctive UIs");
+    expect(raw["frontend-design"].source).toBe("anthropics/skills");
+  });
+
+  it("get() returns the record after upsert", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({ name: "pdf", description: "PDF tools" }));
+    const got = await store.get("pdf");
+    expect(got).toBeDefined();
+    expect(got?.description).toBe("PDF tools");
+  });
+
+  it("list() returns all upserted records", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({ name: "a", description: "A" }));
+    await store.upsert(recordOf({ name: "b", description: "B" }));
+    const all = await store.list();
+    expect(all.map((s) => s.name).sort()).toEqual(["a", "b"]);
+  });
+
+  it("upsert() overwrites an existing record by name", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({ name: "x", description: "first" }));
+    await store.upsert(recordOf({ name: "x", description: "second" }));
+    const got = await store.get("x");
+    expect(got?.description).toBe("second");
+    expect((await store.list()).length).toBe(1);
+  });
+
+  it("remove() returns true when the record existed", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({ name: "docx" }));
+    expect(await store.remove("docx")).toBe(true);
+    expect(await store.get("docx")).toBeUndefined();
+  });
+
+  it("remove() returns false when the record did not exist", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    expect(await store.remove("never-installed")).toBe(false);
+  });
+
+  it("preserves unrelated records on remove", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({ name: "keep" }));
+    await store.upsert(recordOf({ name: "drop" }));
+    await store.remove("drop");
+    expect((await store.list()).map((s) => s.name)).toEqual(["keep"]);
+  });
+
+  it("reads legacy `{ tags?, category? }` file shape transparently", async () => {
+    // Simulate the old skills-index.json format from before SkillStore
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(
+      INDEX_PATH,
+      JSON.stringify({
+        "legacy-skill": { tags: ["io"], category: "utility" },
+      }),
+      "utf-8",
+    );
+
+    const store = new FileSkillStore(TEST_DIR);
+    const got = await store.get("legacy-skill");
+    expect(got).toBeDefined();
+    expect(got?.tags).toEqual(["io"]);
+    expect(got?.category).toBe("utility");
+    // Missing fields default to safe values
+    expect(got?.description).toBe("");
+    expect(typeof got?.installedAt).toBe("string");
+  });
+
+  it("ignores corrupt JSON and returns []", async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(INDEX_PATH, "not valid json {{{", "utf-8");
+    const store = new FileSkillStore(TEST_DIR);
+    expect(await store.list()).toEqual([]);
+  });
+
+  it("ignores empty file and returns []", async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(INDEX_PATH, "", "utf-8");
+    const store = new FileSkillStore(TEST_DIR);
+    expect(await store.list()).toEqual([]);
+  });
+
+  it("upsert() writes atomically via tmp + rename (no half-written file on crash)", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({ name: "a" }));
+    // Check no leftover .tmp file
+    expect(existsSync(INDEX_PATH + ".tmp")).toBe(false);
+  });
+
+  it("round-trips tags and category end-to-end", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({
+      name: "tagged",
+      description: "",
+      tags: ["ui", "react"],
+      category: "frontend",
+    }));
+    const got = await store.get("tagged");
+    expect(got?.tags).toEqual(["ui", "react"]);
+    expect(got?.category).toBe("frontend");
+  });
+
+  it("round-trips allowedTools", async () => {
+    const store = new FileSkillStore(TEST_DIR);
+    await store.upsert(recordOf({
+      name: "with-tools",
+      description: "",
+      allowedTools: ["read", "http_fetch"],
+    }));
+    const got = await store.get("with-tools");
+    expect(got?.allowedTools).toEqual(["read", "http_fetch"]);
+  });
+
+  it("two stores on the same polpoDir see the same data", async () => {
+    const a = new FileSkillStore(TEST_DIR);
+    const b = new FileSkillStore(TEST_DIR);
+    await a.upsert(recordOf({ name: "shared" }));
+    expect(await b.get("shared")).toBeDefined();
+  });
+});

--- a/src/stores/file-skill-store.ts
+++ b/src/stores/file-skill-store.ts
@@ -1,0 +1,100 @@
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  renameSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import type { SkillStore, SkillRecord } from "@polpo-ai/core";
+
+/**
+ * File-backed SkillStore.
+ *
+ * Persists the full catalog to `${polpoDir}/skills-index.json` as a
+ * JSON object keyed by skill name. Writes are atomic (tmp + rename).
+ *
+ * Legacy compatibility: the old `skills-index.json` format contained
+ * only `{ tags?, category? }` per skill. This store reads those files
+ * transparently (treating them as partial records) and the caller —
+ * typically the upsert triggered by skills/add — fills in the full
+ * record on next write.
+ */
+export class FileSkillStore implements SkillStore {
+  private readonly filePath: string;
+
+  constructor(polpoDir: string) {
+    this.filePath = join(polpoDir, "skills-index.json");
+  }
+
+  async list(): Promise<SkillRecord[]> {
+    const all = this.readAll();
+    return Object.values(all);
+  }
+
+  async get(name: string): Promise<SkillRecord | undefined> {
+    const all = this.readAll();
+    return all[name];
+  }
+
+  async upsert(record: SkillRecord): Promise<void> {
+    const all = this.readAll();
+    all[record.name] = record;
+    this.writeAll(all);
+  }
+
+  async remove(name: string): Promise<boolean> {
+    const all = this.readAll();
+    if (!(name in all)) return false;
+    delete all[name];
+    this.writeAll(all);
+    return true;
+  }
+
+  /** Read the JSON file, normalising legacy shapes. */
+  private readAll(): Record<string, SkillRecord> {
+    if (!existsSync(this.filePath)) return {};
+    let raw: string;
+    try {
+      raw = readFileSync(this.filePath, "utf-8");
+    } catch {
+      return {};
+    }
+    if (!raw.trim()) return {};
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return {};
+    }
+    if (!parsed || typeof parsed !== "object") return {};
+
+    const out: Record<string, SkillRecord> = {};
+    for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!value || typeof value !== "object") continue;
+      const v = value as Partial<SkillRecord>;
+      out[name] = {
+        name,
+        description: typeof v.description === "string" ? v.description : "",
+        source: typeof v.source === "string" ? v.source : undefined,
+        installedAt:
+          typeof v.installedAt === "string"
+            ? v.installedAt
+            : new Date(0).toISOString(),
+        allowedTools: Array.isArray(v.allowedTools) ? v.allowedTools : undefined,
+        tags: Array.isArray(v.tags) ? v.tags : undefined,
+        category: typeof v.category === "string" ? v.category : undefined,
+      };
+    }
+    return out;
+  }
+
+  /** Write the full catalog atomically (tmp + rename). */
+  private writeAll(all: Record<string, SkillRecord>): void {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const tmp = this.filePath + ".tmp";
+    writeFileSync(tmp, JSON.stringify(all, null, 2) + "\n", "utf-8");
+    renameSync(tmp, this.filePath);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new store port for per-project skill metadata so \`GET /v1/skills\` can stop walking the filesystem on every call. The FS stays the source of truth for skill CONTENT; the store indexes metadata.

**Motivation**: on self-hosted local fs the scan is cheap, but in polpo-cloud (mount-s3 over R2) each list is a Daytona sandbox acquire + FUSE ops + N× object reads — ~1-3s per call, plus the FUSE edge cases recently flushed out (stale mount, auto-stop). A store-backed list collapses to a single DB query on cloud and a single JSON read on self-hosted.

## What's in this PR (step 1/3)

- \`packages/core/src/skill-store.ts\` — \`SkillStore\` interface + \`SkillRecord\` type. Re-exported from the core barrel.
- \`src/stores/file-skill-store.ts\` — FS-backed impl persisting to \`\${polpoDir}/skills-index.json\`. Atomic writes (tmp + rename). Reads legacy \`{ tags?, category? }\` entries transparently, so projects migrating from the old \`SkillIndex\` shape keep working without manual migration.
- \`src/__tests__/file-skill-store.test.ts\` — 16 tests: empty state, upsert/get/list/remove, overwrite-by-name, legacy shape read, corrupt/empty JSON, atomic write, tags/category/allowedTools round-trip, multi-instance consistency.

## Follow-ups (separate PRs)

1. \`@polpo-ai/drizzle\`: \`DrizzleSkillStore\` (PG + SQLite) with matching tests.
2. \`@polpo-ai/server\`: accept \`skillStore\` as optional dep on \`skillRoutes()\`; use it for list/add/remove with fallback to the current fs scan when the dep is absent (back-compat).
3. Root orchestrator: wire the appropriate impl based on storage config.

## Test plan

- [x] \`pnpm test src/__tests__/file-skill-store.test.ts\` — 16/16 green
- [x] \`pnpm test\` — 1333/1333 green (no regressions)
- [x] \`npx tsc --noEmit\` (root) — clean