### PR TITLE
feat(core): add EVENT_CATALOG for webhook subscription UIs

### DIFF
--- a/packages/core/src/__tests__/events-catalog.test.ts
+++ b/packages/core/src/__tests__/events-catalog.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { EVENT_CATALOG } from "../events-catalog.js";
+
+/**
+ * Drift guard for the public event catalog.
+ *
+ * The catalog is intentionally narrower than `PolpoEventMap` (which
+ * includes types for events the cloud doesn't yet forward). Instead of
+ * cross-checking against `PolpoEventMap`, this test pins:
+ *
+ *  1. Shape — every entry has a non-empty namespace, label, description,
+ *     and at least one event with both `key` and `description`.
+ *  2. Uniqueness — fully-qualified `${ns}:${key}` names never collide.
+ *  3. Stability — the count of fully-qualified keys is asserted; if the
+ *     catalog grows or shrinks, this test fails so the change is
+ *     intentional and visible in the PR.
+ *
+ * When you wire a new event through the cloud `cloud:event` bus (or
+ * remove one), update both the catalog and the count below in the same
+ * PR.
+ */
+describe("EVENT_CATALOG", () => {
+  it("has a well-formed shape for every group", () => {
+    expect(EVENT_CATALOG.length).toBeGreaterThan(0);
+    for (const group of EVENT_CATALOG) {
+      expect(group.ns).toMatch(/^[a-z][a-z_]*$/);
+      expect(group.label.length).toBeGreaterThan(0);
+      expect(group.description.length).toBeGreaterThan(0);
+      expect(group.events.length).toBeGreaterThan(0);
+      for (const ev of group.events) {
+        expect(ev.key.length).toBeGreaterThan(0);
+        expect(ev.description.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("never duplicates fully-qualified event names", () => {
+    const seen = new Set<string>();
+    for (const group of EVENT_CATALOG) {
+      for (const ev of group.events) {
+        const fq = `${group.ns}:${ev.key}`;
+        expect(seen.has(fq), `duplicate event ${fq}`).toBe(false);
+        seen.add(fq);
+      }
+    }
+  });
+
+  it("publishes a stable, intentional count of events", () => {
+    // Pin the total. Bump this number in the same PR that adds/removes
+    // events from the catalog so reviewers can spot drift.
+    const EXPECTED_TOTAL = 12;
+    const actual = EVENT_CATALOG.reduce((sum, g) => sum + g.events.length, 0);
+    expect(actual).toBe(EXPECTED_TOTAL);
+  });
+});

--- a/packages/core/src/events-catalog.ts
+++ b/packages/core/src/events-catalog.ts
@@ -1,0 +1,70 @@
+/**
+ * Hierarchical, end-user-facing catalog of every event the Polpo runtime
+ * actually emits on the public webhook bus today. Used by webhook
+ * subscription UIs and the OpenAPI metadata endpoint to enumerate
+ * subscribable events without hardcoding the list at the consumer.
+ *
+ * Source of truth — this catalog is intentionally narrower than
+ * `PolpoEventMap` in `events.ts`: it lists *only* events that are wired
+ * end-to-end (emitted somewhere AND forwarded to the cloud event bus).
+ * `PolpoEventMap` includes types for events that exist on the in-process
+ * emitter but are not yet exposed as webhook subscriptions (mission
+ * lifecycle, agent process events, assessments, approvals, escalations,
+ * SLAs, schedules, checkpoints, delays, peers, notifications, gateway
+ * lifecycle). Add them to this catalog only when they're wired through
+ * `cloud:event`.
+ *
+ * Coverage assertion lives at `events-catalog.test.ts` so the count is
+ * pinned and grows intentionally.
+ */
+
+export interface EventCatalogEntry {
+  /** Suffix after the namespace, e.g. `created` for `task:created`. */
+  key: string;
+  description: string;
+}
+
+export interface EventCatalogGroup {
+  /** Namespace prefix (`task`, `completion`, `session`). */
+  ns: string;
+  /** Human label for UI grouping. */
+  label: string;
+  description: string;
+  events: ReadonlyArray<EventCatalogEntry>;
+}
+
+export const EVENT_CATALOG: ReadonlyArray<EventCatalogGroup> = [
+  {
+    ns: "task",
+    label: "Tasks",
+    description: "Lifecycle of individual tasks.",
+    events: [
+      { key: "created", description: "A task was created." },
+      { key: "transition", description: "Task status changed (e.g. running → done)." },
+      { key: "updated", description: "Task metadata was edited." },
+      { key: "removed", description: "Task was deleted." },
+      { key: "timeout", description: "Task exceeded its time budget." },
+      { key: "retry", description: "Task is being retried." },
+      { key: "fix", description: "Self-fix attempt after assessment failure." },
+      { key: "question", description: "Agent is asking the user a question." },
+      { key: "answered", description: "User answered an agent's question." },
+      { key: "recovered", description: "Task recovered from a stuck state." },
+    ],
+  },
+  {
+    ns: "completion",
+    label: "Completions",
+    description: "Chat-completion API events.",
+    events: [
+      { key: "finished", description: "A /v1/chat/completions call finished." },
+    ],
+  },
+  {
+    ns: "session",
+    label: "Sessions",
+    description: "Chat session lifecycle.",
+    events: [
+      { key: "started", description: "First message of a new chat session." },
+    ],
+  },
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,3 +138,6 @@ export type {
   CompactionInput,
   CompactionResult,
 } from "./context-compactor.js";
+
+export { EVENT_CATALOG } from "./events-catalog.js";
+export type { EventCatalogGroup, EventCatalogEntry } from "./events-catalog.js";


### PR DESCRIPTION
## Summary
- Adds `EVENT_CATALOG` to `@polpo-ai/core`: hierarchical, end-user-facing list of events with descriptions, exported as the source of truth for subscription UIs (cloud webhook dashboard, future `GET /v1/events/catalog` endpoint).
- Coherence-first scope: only `task:*`, `completion:finished`, `session:started` — exactly what the cloud handler forwards to `cloud:event` today. `PolpoEventMap` declares many more types (mission, agent, assessment, approval, escalation, sla, schedule, checkpoint, delay, message, peer, notification, gateway), but those aren't wired through the cloud bus yet. Surfacing them in the catalog would let users subscribe to webhooks that never fire.
- Drift guard: `events-catalog.test.ts` pins shape, uniqueness, and total count (12). Any add/remove shows up in the PR diff.

## Test plan
- [x] `npx vitest run packages/core/src/__tests__/events-catalog.test.ts` — 3/3 pass
- [x] `pnpm --filter @polpo-ai/core build` — clean
- [ ] After merge: bump `@polpo-ai/core` version, publish, then point `@polpo-cloud/server` and dashboard at the canonical export (currently they keep a temporary inline copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)