### PR TITLE
feat(server): accept mcpServers in agent CRUD payloads

### DIFF
--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -89,6 +89,7 @@ export function agentRoutes(getDeps: () => {
       identity: body.identity,
       reportsTo: body.reportsTo,
       browserProfile: body.browserProfile,
+      mcpServers: body.mcpServers,
     }, teamName);
 
     return c.json({ ok: true, data: { added: true } }, 201);
@@ -386,6 +387,9 @@ export function agentRoutes(getDeps: () => {
       ...(body.emailAllowedDomains !== undefined && { emailAllowedDomains: body.emailAllowedDomains }),
       ...(body.identity && { identity: { ...(existing.identity ?? {}), ...body.identity } }),
       ...(body.team !== undefined && { team: body.team }),
+      // Replace the whole MCP server map. Pass `{}` to clear all servers,
+      // omit the field to leave existing config untouched.
+      ...(body.mcpServers !== undefined && { mcpServers: body.mcpServers }),
     };
 
     await deps.updateAgent(name, updates);

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -252,6 +252,36 @@ const AgentIdentitySchema = z.object({
   socials: z.record(z.string(), z.string()).optional(),
 });
 
+/**
+ * MCP server config attached to an agent. Three transport variants —
+ * mirrors the type union in `@polpo-ai/sdk` (`McpServerConfig`). Validated
+ * here so payloads from the dashboard / CLI / direct API all converge on
+ * the same shape before the agent runtime resolves the actual tools at
+ * completion time. Header values support `${vault:service:key}`
+ * templating, resolved server-side (the regex isn't enforced at this
+ * layer — strings are accepted as-is).
+ */
+const McpServerConfigSchema = z.union([
+  z.object({
+    type: z.literal("stdio").optional(),
+    command: z.string().min(1),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal("sse"),
+    url: z.string().url(),
+    headers: z.record(z.string(), z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal("http"),
+    url: z.string().url(),
+    headers: z.record(z.string(), z.string()).optional(),
+  }),
+]);
+
+const McpServersRecordSchema = z.record(z.string().min(1), McpServerConfigSchema);
+
 export const AddAgentSchema = z.object({
   name: z.string().min(1),
   role: z.string().optional(),
@@ -265,6 +295,9 @@ export const AddAgentSchema = z.object({
   reportsTo: z.string().optional(),
   // Extended tool categories (browser, email, vault, image, video, audio, excel, pdf, docx, search — HTTP is always-on core)
   browserProfile: z.string().optional(),
+  /** External MCP servers — keyed by user-chosen name. Tools from each
+   *  server are namespaced `mcp__<key>__<tool>` at runtime. */
+  mcpServers: McpServersRecordSchema.optional(),
 });
 
 export const UpdateAgentSchema = z.object({
@@ -282,6 +315,8 @@ export const UpdateAgentSchema = z.object({
   browserProfile: z.string().optional(),
   emailAllowedDomains: z.array(z.string()).optional(),
   team: z.string().optional(),
+  /** Replace the agent's MCP server map. Pass an empty object to clear. */
+  mcpServers: McpServersRecordSchema.optional(),
 });
 
 export const RenameTeamSchema = z.object({


### PR DESCRIPTION
Closes the last gap of the MCP-for-agents cycle.

## The problem
The runtime side shipped in 0.6.26 (resolveAgentMcpTools, OSS shell wiring, cleanup plumbing). But the agent CRUD route's Zod schemas didn't include \`mcpServers\` — so payloads containing it were silently stripped before persistence. End-to-end no-op until now.

## The fix
- New \`McpServerConfigSchema\`: discriminated union of stdio / sse / http transports, mirrors the \`@polpo-ai/sdk\` type union.
- \`mcpServers: McpServersRecordSchema.optional()\` on both \`AddAgentSchema\` (POST \`/v1/agents\`) and \`UpdateAgentSchema\` (PATCH \`/v1/agents/:name\`).
- Route handlers in \`routes/agents.ts\` thread \`body.mcpServers\` through to \`deps.addAgent\` and the \`updates\` record.

## Storage
No migration. The agents table stores config as JSONB (\`agents.config\`), so \`mcpServers\` rides along with the rest of \`AgentConfig\` transparently.

## Update semantics
- Omit \`mcpServers\` on PATCH → existing config untouched.
- Pass \`{}\` → clears all configured servers.
- Pass \`{ name: { ... } }\` → replaces the whole map.

## Test plan
- [x] \`pnpm --filter @polpo-ai/server build\` clean
- [x] Full vitest suite: 1364 passed | 102 skipped (no regressions)
- [ ] Once published as 0.6.27 + bumped in cloud: a manual smoke test where an agent is created with \`mcpServers\` via API → chat completion fires → server logs show MCP client connecting and tools merging into the palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)