### PR TITLE
fix(tools): route extended tools through FileSystem abstraction

### DIFF
--- a/packages/tools/src/audio-tools.ts
+++ b/packages/tools/src/audio-tools.ts
@@ -27,11 +27,12 @@
  *   ELEVENLABS_API_KEY — elevenlabs provider (TTS)
  */
 
-import { readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { resolve, dirname, extname } from "node:path";
 import { execFile } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 
 // Re-export with concrete generic to avoid "requires 1 type argument" errors
 type ToolResult = AgentToolResult<any>;
@@ -94,7 +95,7 @@ const AudioTranscribeSchema = Type.Object({
   prompt: Type.Optional(Type.String({ description: "Optional context/prompt to guide transcription (OpenAI only)" })),
 });
 
-function createTranscribeTool(cwd: string, sandbox: string[], vault?: ResolvedVault): AgentTool<typeof AudioTranscribeSchema> {
+function createTranscribeTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault): AgentTool<typeof AudioTranscribeSchema> {
   return {
     name: "audio_transcribe",
     label: "Transcribe Audio",
@@ -108,9 +109,18 @@ function createTranscribeTool(cwd: string, sandbox: string[], vault?: ResolvedVa
       assertPathAllowed(filePath, sandbox, "audio_transcribe");
 
       const provider = params.provider ?? "openai";
+
+      if (!fs.readFileBuffer) {
+        return {
+          content: [{ type: "text", text: "FileSystem implementation does not support readFileBuffer (required for binary reads)." }],
+          details: { error: "unsupported_filesystem" },
+        };
+      }
+
       let fileBuffer: Buffer;
       try {
-        fileBuffer = readFileSync(filePath);
+        const bytes = await fs.readFileBuffer(filePath);
+        fileBuffer = Buffer.from(bytes);
       } catch (err: any) {
         return {
           content: [{ type: "text", text: `Error reading audio file: ${err.message}` }],
@@ -295,7 +305,7 @@ const AudioSpeakSchema = Type.Object({
   instructions: Type.Optional(Type.String({ description: "Voice style instructions (OpenAI gpt-4o-mini-tts only, e.g. 'Speak in a cheerful tone')" })),
 });
 
-function createSpeakTool(cwd: string, sandbox: string[], vault?: ResolvedVault): AgentTool<typeof AudioSpeakSchema> {
+function createSpeakTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault): AgentTool<typeof AudioSpeakSchema> {
   return {
     name: "audio_speak",
     label: "Text to Speech",
@@ -314,6 +324,12 @@ function createSpeakTool(cwd: string, sandbox: string[], vault?: ResolvedVault):
 
       // Direct edge-tts request — no fallback needed
       if (provider === "edge") {
+        if (!edgeTtsAvailable()) {
+          return {
+            content: [{ type: "text", text: "Edge TTS not available in this environment. Use openai/deepgram/elevenlabs instead." }],
+            details: { provider: "edge", error: "edge_tts_unavailable" },
+          };
+        }
         try {
           return await speakEdgeTts(filePath, params, signal);
         } catch (err: any) {
@@ -327,11 +343,11 @@ function createSpeakTool(cwd: string, sandbox: string[], vault?: ResolvedVault):
       // Provider with edge-tts fallback
       try {
         if (provider === "openai") {
-          return await speakOpenAI(filePath, params, vault, signal);
+          return await speakOpenAI(filePath, params, fs, vault, signal);
         } else if (provider === "deepgram") {
-          return await speakDeepgram(filePath, params, vault, signal);
+          return await speakDeepgram(filePath, params, fs, vault, signal);
         } else {
-          return await speakElevenLabs(filePath, params, vault, signal);
+          return await speakElevenLabs(filePath, params, fs, vault, signal);
         }
       } catch (err: any) {
         // Automatic fallback to edge-tts if available
@@ -364,6 +380,7 @@ function createSpeakTool(cwd: string, sandbox: string[], vault?: ResolvedVault):
 async function speakOpenAI(
   filePath: string,
   params: { text: string; model?: string; voice?: string; speed?: number; instructions?: string },
+  fs: FileSystem,
   vault?: ResolvedVault,
   signal?: AbortSignal,
 ): Promise<ToolResult> {
@@ -408,8 +425,11 @@ async function speakOpenAI(
   }
 
   const buffer = Buffer.from(await response.arrayBuffer());
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, buffer);
+  if (!fs.writeFileBuffer) {
+    throw new Error("FileSystem implementation does not support writeFileBuffer (required for binary writes).");
+  }
+  await fs.mkdir(dirname(filePath));
+  await fs.writeFileBuffer(filePath, new Uint8Array(buffer));
 
   return {
     content: [{ type: "text", text: `Speech audio saved: ${filePath} (${(buffer.byteLength / 1024).toFixed(1)} KB, ${responseFormat}, voice: ${voice}, model: ${model})` }],
@@ -428,6 +448,7 @@ async function speakOpenAI(
 async function speakDeepgram(
   filePath: string,
   params: { text: string; model?: string },
+  fs: FileSystem,
   vault?: ResolvedVault,
   signal?: AbortSignal,
 ): Promise<ToolResult> {
@@ -459,8 +480,11 @@ async function speakDeepgram(
   }
 
   const buffer = Buffer.from(await response.arrayBuffer());
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, buffer);
+  if (!fs.writeFileBuffer) {
+    throw new Error("FileSystem implementation does not support writeFileBuffer (required for binary writes).");
+  }
+  await fs.mkdir(dirname(filePath));
+  await fs.writeFileBuffer(filePath, new Uint8Array(buffer));
 
   return {
     content: [{ type: "text", text: `Speech audio saved: ${filePath} (${(buffer.byteLength / 1024).toFixed(1)} KB, model: ${model})` }],
@@ -478,6 +502,7 @@ async function speakDeepgram(
 async function speakElevenLabs(
   filePath: string,
   params: { text: string; model?: string; voice?: string },
+  fs: FileSystem,
   vault?: ResolvedVault,
   signal?: AbortSignal,
 ): Promise<ToolResult> {
@@ -520,8 +545,11 @@ async function speakElevenLabs(
   }
 
   const buffer = Buffer.from(await response.arrayBuffer());
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, buffer);
+  if (!fs.writeFileBuffer) {
+    throw new Error("FileSystem implementation does not support writeFileBuffer (required for binary writes).");
+  }
+  await fs.mkdir(dirname(filePath));
+  await fs.writeFileBuffer(filePath, new Uint8Array(buffer));
 
   return {
     content: [{ type: "text", text: `Speech audio saved: ${filePath} (${(buffer.byteLength / 1024).toFixed(1)} KB, voice: ${voiceId}, model: ${model})` }],
@@ -578,6 +606,8 @@ function resolveEdgeVoice(voice?: string, language?: string, gender?: "male" | "
 
 /** Check if edge-tts CLI is available on the system. */
 function isEdgeTtsAvailable(): boolean {
+  // Allow operators (e.g. cloud chat-completion path) to opt out explicitly.
+  if (process.env.POLPO_DISABLE_EDGE_TTS === "1") return false;
   try {
     const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
     execFileSync("edge-tts", ["--version"], { stdio: "pipe", timeout: 5000 });
@@ -604,7 +634,10 @@ async function speakEdgeTts(
   }
 
   const voice = resolveEdgeVoice(params.voice, params.language, params.gender);
-  mkdirSync(dirname(filePath), { recursive: true });
+  // edge-tts is a local Node-only path — direct node:fs is acceptable here
+  // since the provider is gated by isEdgeTtsAvailable() which already requires Node.
+  const nodeFs = require("node:fs") as typeof import("node:fs");
+  nodeFs.mkdirSync(dirname(filePath), { recursive: true });
 
   // Determine rate from speed if present
   const args = [
@@ -622,7 +655,7 @@ async function speakEdgeTts(
 
       let bytes = 0;
       try {
-        bytes = statSync(filePath).size;
+        bytes = nodeFs.statSync(filePath).size;
       } catch { /* ignore */ }
 
       resolvePromise({
@@ -662,12 +695,14 @@ export function createAudioTools(
   allowedPaths?: string[],
   allowedTools?: string[],
   vault?: ResolvedVault,
+  fs?: FileSystem,
 ): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<AudioToolName, () => AgentTool<any>> = {
-    audio_transcribe: () => createTranscribeTool(cwd, sandbox, vault),
-    audio_speak: () => createSpeakTool(cwd, sandbox, vault),
+    audio_transcribe: () => createTranscribeTool(cwd, sandbox, _fs, vault),
+    audio_speak: () => createSpeakTool(cwd, sandbox, _fs, vault),
   };
 
   const names = allowedTools

--- a/packages/tools/src/docx-tools.ts
+++ b/packages/tools/src/docx-tools.ts
@@ -9,10 +9,11 @@
  * All file operations enforce path sandboxing.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 
 const MAX_TEXT_OUTPUT = 50_000;
@@ -58,7 +59,7 @@ const DocxReadSchema = Type.Object({
   ], { description: "Output format: 'text' (plain), 'markdown', or 'html'. Default: 'text'" })),
 });
 
-function createDocxReadTool(cwd: string, sandbox: string[]): AgentTool<typeof DocxReadSchema> {
+function createDocxReadTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof DocxReadSchema> {
   return {
     name: "docx_read",
     label: "Read DOCX",
@@ -70,19 +71,29 @@ function createDocxReadTool(cwd: string, sandbox: string[]): AgentTool<typeof Do
       assertPathAllowed(filePath, sandbox, "docx_read");
 
       try {
+        if (!fs.readFileBuffer) {
+          return {
+            content: [{ type: "text", text: "DOCX read error: Binary read not supported by injected FileSystem" }],
+            details: { error: "binary_read_unsupported" },
+          };
+        }
         const mammoth = await import("mammoth");
         const format = params.format ?? "text";
 
+        const bytes = await fs.readFileBuffer(filePath);
+        // mammoth expects a Node Buffer; convert from Uint8Array
+        const buffer = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
         let result;
         if (format === "html") {
-          result = await mammoth.convertToHtml({ path: filePath });
+          result = await mammoth.convertToHtml({ buffer });
         } else if (format === "markdown") {
           // mammoth doesn't export convertToMarkdown in all versions — use HTML + basic conversion
-          const htmlResult = await mammoth.convertToHtml({ path: filePath });
+          const htmlResult = await mammoth.convertToHtml({ buffer });
           const md = htmlToBasicMarkdown(htmlResult.value);
           result = { value: md, messages: htmlResult.messages };
         } else {
-          result = await mammoth.extractRawText({ path: filePath });
+          result = await mammoth.extractRawText({ buffer });
         }
 
         const text = result.value;
@@ -134,7 +145,7 @@ const DocxCreateSchema = Type.Object({
   ),
 });
 
-function createDocxCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof DocxCreateSchema> {
+function createDocxCreateTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof DocxCreateSchema> {
   return {
     name: "docx_create",
     label: "Create DOCX",
@@ -144,9 +155,15 @@ function createDocxCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof 
     async execute(_id, params) {
       const filePath = resolve(cwd, params.path);
       assertPathAllowed(filePath, sandbox, "docx_create");
-      mkdirSync(dirname(filePath), { recursive: true });
+      await fs.mkdir(dirname(filePath));
 
       try {
+        if (!fs.writeFileBuffer) {
+          return {
+            content: [{ type: "text", text: "DOCX create error: Binary write not supported by injected FileSystem" }],
+            details: { error: "binary_write_unsupported" },
+          };
+        }
         const docxModule = await import("docx");
         const {
           Document, Paragraph, TextRun, HeadingLevel, Packer,
@@ -227,7 +244,8 @@ function createDocxCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof 
         });
 
         const buffer = await Packer.toBuffer(doc);
-        writeFileSync(filePath, buffer);
+        const u8 = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+        await fs.writeFileBuffer(filePath, u8);
 
         return {
           content: [{ type: "text", text: `DOCX created: ${filePath} (${params.content.length} blocks, ${buffer.byteLength} bytes)` }],
@@ -256,12 +274,13 @@ export const ALL_DOCX_TOOL_NAMES: DocxToolName[] = ["docx_read", "docx_create"];
  * @param allowedPaths - Sandbox paths
  * @param allowedTools - Optional filter
  */
-export function createDocxTools(cwd: string, allowedPaths?: string[], allowedTools?: string[]): AgentTool<any>[] {
+export function createDocxTools(cwd: string, allowedPaths?: string[], allowedTools?: string[], fs?: FileSystem): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<DocxToolName, () => AgentTool<any>> = {
-    docx_read: () => createDocxReadTool(cwd, sandbox),
-    docx_create: () => createDocxCreateTool(cwd, sandbox),
+    docx_read: () => createDocxReadTool(cwd, sandbox, _fs),
+    docx_create: () => createDocxCreateTool(cwd, sandbox, _fs),
   };
 
   const names = allowedTools

--- a/packages/tools/src/email-tools.ts
+++ b/packages/tools/src/email-tools.ts
@@ -17,11 +17,12 @@
  * IMAP env vars: IMAP_HOST, IMAP_PORT, IMAP_USER, IMAP_PASS
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { resolve, basename, join, dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import type { ResolvedVault } from "./types.js";
 
 // ─── Tool: email_send ───
@@ -96,7 +97,7 @@ function validateRecipientDomains(addresses: string | string[], allowedDomains: 
   }
 }
 
-function createEmailSendTool(cwd: string, sandbox: string[], vault?: ResolvedVault, emailAllowedDomains?: string[]): AgentTool<typeof EmailSendSchema> {
+function createEmailSendTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault, emailAllowedDomains?: string[]): AgentTool<typeof EmailSendSchema> {
   return {
     name: "email_send",
     label: "Send Email",
@@ -135,13 +136,17 @@ function createEmailSendTool(cwd: string, sandbox: string[], vault?: ResolvedVau
       // Process attachments
       const attachments: Array<{ filename: string; content: Buffer }> = [];
       if (params.attachments) {
+        if (!fs.readFileBuffer) {
+          throw new Error("Binary read not supported by injected FileSystem; cannot read email attachments");
+        }
         for (const att of params.attachments) {
           const attPath = resolve(cwd, att.path);
           assertPathAllowed(attPath, sandbox, "email_send");
-          if (!existsSync(attPath)) throw new Error(`Attachment not found: ${att.path}`);
+          if (!(await fs.exists(attPath))) throw new Error(`Attachment not found: ${att.path}`);
+          const data = await fs.readFileBuffer(attPath);
           attachments.push({
             filename: att.filename ?? basename(attPath),
-            content: readFileSync(attPath),
+            content: Buffer.from(data),
           });
         }
       }
@@ -185,7 +190,7 @@ function createEmailSendTool(cwd: string, sandbox: string[], vault?: ResolvedVau
   };
 }
 
-function createEmailDraftTool(cwd: string, sandbox: string[], vault?: ResolvedVault, emailAllowedDomains?: string[]): AgentTool<typeof EmailDraftSchema> {
+function createEmailDraftTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault, emailAllowedDomains?: string[]): AgentTool<typeof EmailDraftSchema> {
   return {
     name: "email_draft",
     label: "Save Draft Email",
@@ -205,13 +210,17 @@ function createEmailDraftTool(cwd: string, sandbox: string[], vault?: ResolvedVa
 
       const attachments: Array<{ filename: string; content: Buffer }> = [];
       if (params.attachments) {
+        if (!fs.readFileBuffer) {
+          throw new Error("Binary read not supported by injected FileSystem; cannot read email attachments");
+        }
         for (const att of params.attachments) {
           const attPath = resolve(cwd, att.path);
           assertPathAllowed(attPath, sandbox, "email_draft");
-          if (!existsSync(attPath)) throw new Error(`Attachment not found: ${att.path}`);
+          if (!(await fs.exists(attPath))) throw new Error(`Attachment not found: ${att.path}`);
+          const data = await fs.readFileBuffer(attPath);
           attachments.push({
             filename: att.filename ?? basename(attPath),
-            content: readFileSync(attPath),
+            content: Buffer.from(data),
           });
         }
       }
@@ -488,7 +497,7 @@ const EmailReadSchema = Type.Object({
   download_attachments: Type.Optional(Type.Boolean({ description: "Download all attachments to the output directory (default: false). Use email_download_attachment for selective download." })),
 });
 
-function createEmailReadTool(vault?: ResolvedVault, outputDir?: string, sandbox?: string[]): AgentTool<typeof EmailReadSchema> {
+function createEmailReadTool(fs: FileSystem, vault?: ResolvedVault, outputDir?: string, sandbox?: string[]): AgentTool<typeof EmailReadSchema> {
   return {
     name: "email_read",
     label: "Read Email",
@@ -536,6 +545,9 @@ function createEmailReadTool(vault?: ResolvedVault, outputDir?: string, sandbox?
         // Optionally download all attachments
         const downloadedFiles: string[] = [];
         if (params.download_attachments && attachments.length > 0) {
+          if (!fs.writeFileBuffer) {
+            throw new Error("Binary write not supported by injected FileSystem; cannot download attachments");
+          }
           const downloadDir = outputDir ?? process.cwd();
           for (const att of attachments) {
             const { content } = await client.download(String(params.uid), att.part, { uid: true }) as any;
@@ -545,8 +557,8 @@ function createEmailReadTool(vault?: ResolvedVault, outputDir?: string, sandbox?
             }
             const buffer = Buffer.concat(chunks);
             const filePath = join(downloadDir, att.filename);
-            mkdirSync(dirname(filePath), { recursive: true });
-            writeFileSync(filePath, buffer);
+            await fs.mkdir(dirname(filePath));
+            await fs.writeFileBuffer(filePath, buffer);
             downloadedFiles.push(filePath);
           }
         }
@@ -607,7 +619,7 @@ const EmailDownloadAttachmentSchema = Type.Object({
   output_path: Type.Optional(Type.String({ description: "Custom output path relative to working directory (default: output directory)" })),
 });
 
-function createEmailDownloadAttachmentTool(vault?: ResolvedVault, cwd?: string, outputDir?: string, sandbox?: string[]): AgentTool<typeof EmailDownloadAttachmentSchema> {
+function createEmailDownloadAttachmentTool(fs: FileSystem, vault?: ResolvedVault, cwd?: string, outputDir?: string, sandbox?: string[]): AgentTool<typeof EmailDownloadAttachmentSchema> {
   return {
     name: "email_download_attachment",
     label: "Download Email Attachment",
@@ -658,8 +670,11 @@ function createEmailDownloadAttachmentTool(vault?: ResolvedVault, cwd?: string, 
           assertPathAllowed(filePath, sandbox, "email_download_attachment");
         }
 
-        mkdirSync(dirname(filePath), { recursive: true });
-        writeFileSync(filePath, buffer);
+        if (!fs.writeFileBuffer) {
+          throw new Error("Binary write not supported by injected FileSystem; cannot download attachment");
+        }
+        await fs.mkdir(dirname(filePath));
+        await fs.writeFileBuffer(filePath, buffer);
 
         const contentType = meta?.contentType ?? "application/octet-stream";
         return {
@@ -839,19 +854,21 @@ export const ALL_EMAIL_TOOL_NAMES: EmailToolName[] = ["email_send", "email_draft
  * @param vault - Resolved vault credentials (per-agent SMTP/IMAP)
  * @param emailAllowedDomains - Allowed recipient email domains (omit for unrestricted)
  * @param outputDir - Per-task output directory for downloaded attachments
+ * @param fs - FileSystem implementation (default: NodeFileSystem)
  */
-export function createEmailTools(cwd: string, allowedPaths?: string[], allowedTools?: string[], vault?: ResolvedVault, emailAllowedDomains?: string[], outputDir?: string): AgentTool<any>[] {
+export function createEmailTools(cwd: string, allowedPaths?: string[], allowedTools?: string[], vault?: ResolvedVault, emailAllowedDomains?: string[], outputDir?: string, fs?: FileSystem): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<EmailToolName, () => AgentTool<any>> = {
-    email_send: () => createEmailSendTool(cwd, sandbox, vault, emailAllowedDomains),
-    email_draft: () => createEmailDraftTool(cwd, sandbox, vault, emailAllowedDomains),
+    email_send: () => createEmailSendTool(cwd, sandbox, _fs, vault, emailAllowedDomains),
+    email_draft: () => createEmailDraftTool(cwd, sandbox, _fs, vault, emailAllowedDomains),
     email_verify: () => createEmailVerifyTool(vault),
     email_list: () => createEmailListTool(vault),
-    email_read: () => createEmailReadTool(vault, outputDir, sandbox),
+    email_read: () => createEmailReadTool(_fs, vault, outputDir, sandbox),
     email_search: () => createEmailSearchTool(vault),
     email_count: () => createEmailCountTool(vault),
-    email_download_attachment: () => createEmailDownloadAttachmentTool(vault, cwd, outputDir, sandbox),
+    email_download_attachment: () => createEmailDownloadAttachmentTool(_fs, vault, cwd, outputDir, sandbox),
   };
 
   const names = allowedTools

--- a/packages/tools/src/excel-tools.ts
+++ b/packages/tools/src/excel-tools.ts
@@ -12,10 +12,11 @@
  * All file operations enforce path sandboxing.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname, extname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 
 const MAX_ROWS_OUTPUT = 200;
@@ -34,7 +35,7 @@ const ExcelReadSchema = Type.Object({
   max_rows: Type.Optional(Type.Number({ description: "Max rows to return (default: 200)" })),
 });
 
-function createExcelReadTool(cwd: string, sandbox: string[]): AgentTool<typeof ExcelReadSchema> {
+function createExcelReadTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof ExcelReadSchema> {
   return {
     name: "excel_read",
     label: "Read Spreadsheet",
@@ -50,13 +51,20 @@ function createExcelReadTool(cwd: string, sandbox: string[]): AgentTool<typeof E
 
       try {
         if (ext === ".csv" || ext === ".tsv") {
-          return readCsvFile(filePath, ext === ".tsv" ? "\t" : ",", params.headers ?? true, maxRows);
+          return await readCsvFile(fs, filePath, ext === ".tsv" ? "\t" : ",", params.headers ?? true, maxRows);
         }
 
         // Use exceljs for xlsx
+        if (!fs.readFileBuffer) {
+          return {
+            content: [{ type: "text", text: "Excel read error: Binary read not supported by injected FileSystem" }],
+            details: { error: "binary_read_unsupported" },
+          };
+        }
         const ExcelJS = await import("exceljs");
         const workbook = new ExcelJS.default.Workbook();
-        await workbook.xlsx.readFile(filePath);
+        const buffer = await fs.readFileBuffer(filePath);
+        await workbook.xlsx.load(buffer as any);
 
         // Select sheet
         let worksheet;
@@ -123,13 +131,14 @@ function createExcelReadTool(cwd: string, sandbox: string[]): AgentTool<typeof E
   };
 }
 
-function readCsvFile(
+async function readCsvFile(
+  fs: FileSystem,
   filePath: string,
   delimiter: string,
   hasHeaders: boolean,
   maxRows: number,
-): AgentToolResult<any> {
-  const raw = readFileSync(filePath, "utf-8");
+): Promise<AgentToolResult<any>> {
+  const raw = await fs.readFile(filePath);
   const lines = raw.split("\n").filter(l => l.trim());
 
   const rows: string[][] = lines.slice(0, maxRows + (hasHeaders ? 1 : 0))
@@ -188,7 +197,7 @@ const ExcelWriteSchema = Type.Object({
   sheet_name: Type.Optional(Type.String({ description: "Sheet name (default: 'Sheet1')" })),
 });
 
-function createExcelWriteTool(cwd: string, sandbox: string[]): AgentTool<typeof ExcelWriteSchema> {
+function createExcelWriteTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof ExcelWriteSchema> {
   return {
     name: "excel_write",
     label: "Write Spreadsheet",
@@ -198,7 +207,7 @@ function createExcelWriteTool(cwd: string, sandbox: string[]): AgentTool<typeof 
     async execute(_id, params) {
       const filePath = resolve(cwd, params.path);
       assertPathAllowed(filePath, sandbox, "excel_write");
-      mkdirSync(dirname(filePath), { recursive: true });
+      await fs.mkdir(dirname(filePath));
 
       const ext = extname(filePath).toLowerCase();
 
@@ -211,7 +220,7 @@ function createExcelWriteTool(cwd: string, sandbox: string[]): AgentTool<typeof 
               row.map(v => csvEscape(String(v ?? ""), delimiter)).join(delimiter),
             ),
           ];
-          writeFileSync(filePath, lines.join("\n"), "utf-8");
+          await fs.writeFile(filePath, lines.join("\n"));
           return {
             content: [{ type: "text", text: `CSV written: ${filePath} (${params.rows.length} rows, ${params.headers.length} columns)` }],
             details: { path: filePath, rows: params.rows.length, format: "csv" },
@@ -219,6 +228,12 @@ function createExcelWriteTool(cwd: string, sandbox: string[]): AgentTool<typeof 
         }
 
         // Excel xlsx
+        if (!fs.writeFileBuffer) {
+          return {
+            content: [{ type: "text", text: "Excel write error: Binary write not supported by injected FileSystem" }],
+            details: { error: "binary_write_unsupported" },
+          };
+        }
         const ExcelJS = await import("exceljs");
         const workbook = new ExcelJS.default.Workbook();
         const sheet = workbook.addWorksheet(params.sheet_name ?? "Sheet1");
@@ -238,7 +253,8 @@ function createExcelWriteTool(cwd: string, sandbox: string[]): AgentTool<typeof 
           col.width = maxLen + 2;
         });
 
-        await workbook.xlsx.writeFile(filePath);
+        const xlsxBuffer = await workbook.xlsx.writeBuffer();
+        await fs.writeFileBuffer(filePath, new Uint8Array(xlsxBuffer as ArrayBuffer));
         return {
           content: [{ type: "text", text: `Excel written: ${filePath} (${params.rows.length} rows, ${params.headers.length} columns)` }],
           details: { path: filePath, rows: params.rows.length, format: "xlsx" },
@@ -273,7 +289,7 @@ const ExcelQuerySchema = Type.Object({
   limit: Type.Optional(Type.Number({ description: "Max rows to return" })),
 });
 
-function createExcelQueryTool(cwd: string, sandbox: string[]): AgentTool<typeof ExcelQuerySchema> {
+function createExcelQueryTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof ExcelQuerySchema> {
   return {
     name: "excel_query",
     label: "Query Spreadsheet",
@@ -290,7 +306,7 @@ function createExcelQueryTool(cwd: string, sandbox: string[]): AgentTool<typeof 
         let data: Record<string, string>[] = [];
 
         if (ext === ".csv" || ext === ".tsv") {
-          const raw = readFileSync(filePath, "utf-8");
+          const raw = await fs.readFile(filePath);
           const lines = raw.split("\n").filter(l => l.trim());
           const delimiter = ext === ".tsv" ? "\t" : ",";
           if (lines.length === 0) {
@@ -304,9 +320,16 @@ function createExcelQueryTool(cwd: string, sandbox: string[]): AgentTool<typeof 
             data.push(row);
           }
         } else {
+          if (!fs.readFileBuffer) {
+            return {
+              content: [{ type: "text", text: "Query error: Binary read not supported by injected FileSystem" }],
+              details: { error: "binary_read_unsupported" },
+            };
+          }
           const ExcelJS = await import("exceljs");
           const workbook = new ExcelJS.default.Workbook();
-          await workbook.xlsx.readFile(filePath);
+          const buffer = await fs.readFileBuffer(filePath);
+          await workbook.xlsx.load(buffer as any);
           let ws;
           if (typeof params.sheet === "number") ws = workbook.worksheets[params.sheet];
           else if (typeof params.sheet === "string") ws = workbook.getWorksheet(params.sheet);
@@ -389,7 +412,7 @@ const ExcelInfoSchema = Type.Object({
   path: Type.String({ description: "Path to .xlsx file" }),
 });
 
-function createExcelInfoTool(cwd: string, sandbox: string[]): AgentTool<typeof ExcelInfoSchema> {
+function createExcelInfoTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof ExcelInfoSchema> {
   return {
     name: "excel_info",
     label: "Spreadsheet Info",
@@ -400,9 +423,16 @@ function createExcelInfoTool(cwd: string, sandbox: string[]): AgentTool<typeof E
       assertPathAllowed(filePath, sandbox, "excel_info");
 
       try {
+        if (!fs.readFileBuffer) {
+          return {
+            content: [{ type: "text", text: "Excel info error: Binary read not supported by injected FileSystem" }],
+            details: { error: "binary_read_unsupported" },
+          };
+        }
         const ExcelJS = await import("exceljs");
         const workbook = new ExcelJS.default.Workbook();
-        await workbook.xlsx.readFile(filePath);
+        const buffer = await fs.readFileBuffer(filePath);
+        await workbook.xlsx.load(buffer as any);
 
         const sheets = workbook.worksheets.map(ws => ({
           name: ws.name,
@@ -442,14 +472,15 @@ export const ALL_EXCEL_TOOL_NAMES: ExcelToolName[] = ["excel_read", "excel_write
  * @param allowedPaths - Sandbox paths
  * @param allowedTools - Optional filter
  */
-export function createExcelTools(cwd: string, allowedPaths?: string[], allowedTools?: string[]): AgentTool<any>[] {
+export function createExcelTools(cwd: string, allowedPaths?: string[], allowedTools?: string[], fs?: FileSystem): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<ExcelToolName, () => AgentTool<any>> = {
-    excel_read: () => createExcelReadTool(cwd, sandbox),
-    excel_write: () => createExcelWriteTool(cwd, sandbox),
-    excel_query: () => createExcelQueryTool(cwd, sandbox),
-    excel_info: () => createExcelInfoTool(cwd, sandbox),
+    excel_read: () => createExcelReadTool(cwd, sandbox, _fs),
+    excel_write: () => createExcelWriteTool(cwd, sandbox, _fs),
+    excel_query: () => createExcelQueryTool(cwd, sandbox, _fs),
+    excel_info: () => createExcelInfoTool(cwd, sandbox, _fs),
   };
 
   const names = allowedTools

--- a/packages/tools/src/http-tools.ts
+++ b/packages/tools/src/http-tools.ts
@@ -10,12 +10,13 @@
  * Enforces output size limits and timeout controls.
  */
 
-import { writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 import { assertUrlAllowed } from "./ssrf-guard.js";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 
 const MAX_RESPONSE_BYTES = 100_000;
 const DEFAULT_TIMEOUT = 30_000;
@@ -148,7 +149,7 @@ const HttpDownloadSchema = Type.Object({
   headers: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional request headers" })),
 });
 
-function createHttpDownloadTool(cwd: string, sandbox: string[]): AgentTool<typeof HttpDownloadSchema> {
+function createHttpDownloadTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof HttpDownloadSchema> {
   return {
     name: "http_download",
     label: "HTTP Download",
@@ -198,9 +199,15 @@ function createHttpDownloadTool(cwd: string, sandbox: string[]): AgentTool<typeo
           };
         }
 
-        const buffer = Buffer.from(await response.arrayBuffer());
-        mkdirSync(dirname(filePath), { recursive: true });
-        writeFileSync(filePath, buffer);
+        const buffer = new Uint8Array(await response.arrayBuffer());
+        if (!fs.writeFileBuffer) {
+          return {
+            content: [{ type: "text", text: "Error: FileSystem.writeFileBuffer required for binary downloads" }],
+            details: { url, error: "writeFileBuffer_unavailable" },
+          };
+        }
+        await fs.mkdir(dirname(filePath));
+        await fs.writeFileBuffer(filePath, buffer);
 
         return {
           content: [{ type: "text", text: `Downloaded ${buffer.byteLength} bytes to ${filePath}` }],
@@ -229,17 +236,20 @@ export const ALL_HTTP_TOOL_NAMES: HttpToolName[] = ["http_fetch", "http_download
  * @param cwd - Working directory for resolving download paths
  * @param allowedPaths - Sandbox paths for download destination validation
  * @param allowedTools - Optional filter
+ * @param fs - FileSystem implementation (default: NodeFileSystem). Used for http_download.
  */
 export function createHttpTools(
   cwd: string,
   allowedPaths?: string[],
   allowedTools?: string[],
+  fs?: FileSystem,
 ): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<HttpToolName, () => AgentTool<any>> = {
     http_fetch: () => createHttpFetchTool(),
-    http_download: () => createHttpDownloadTool(cwd, sandbox),
+    http_download: () => createHttpDownloadTool(cwd, sandbox, _fs),
   };
 
   const names = allowedTools

--- a/packages/tools/src/image-tools.ts
+++ b/packages/tools/src/image-tools.ts
@@ -23,10 +23,11 @@
  *   ANTHROPIC_API_KEY   — anthropic vision provider
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname, extname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 import type { ResolvedVault } from "./types.js";
 
@@ -178,7 +179,7 @@ const ImageGenerateSchema = Type.Object({
   })),
 });
 
-function createGenerateTool(cwd: string, sandbox: string[], vault?: ResolvedVault): AgentTool<typeof ImageGenerateSchema> {
+function createGenerateTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault): AgentTool<typeof ImageGenerateSchema> {
   return {
     name: "image_generate",
     label: "Generate Image",
@@ -192,7 +193,7 @@ function createGenerateTool(cwd: string, sandbox: string[], vault?: ResolvedVaul
       assertPathAllowed(filePath, sandbox, "image_generate");
 
       try {
-        return await generateFal(filePath, params, vault, signal);
+        return await generateFal(filePath, params, fs, vault, signal);
       } catch (err: any) {
         return {
           content: [{ type: "text", text: `Image generation error: ${err.message}` }],
@@ -213,6 +214,7 @@ async function generateFal(
     guidance_scale?: number;
     seed?: number;
   },
+  fs: FileSystem,
   vault?: ResolvedVault,
   signal?: AbortSignal,
 ): Promise<ToolResult> {
@@ -251,8 +253,11 @@ async function generateFal(
   if (!imgResp.ok) throw new Error(`Failed to download generated image: ${imgResp.status}`);
   const buffer = Buffer.from(await imgResp.arrayBuffer());
 
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, buffer);
+  if (!fs.writeFileBuffer) {
+    throw new Error("FileSystem implementation does not support writeFileBuffer (required for binary writes).");
+  }
+  await fs.mkdir(dirname(filePath));
+  await fs.writeFileBuffer(filePath, new Uint8Array(buffer));
 
   const info = [
     `Image saved: ${filePath}`,
@@ -299,7 +304,7 @@ const VideoGenerateSchema = Type.Object({
   })),
 });
 
-function createVideoGenerateTool(cwd: string, sandbox: string[], vault?: ResolvedVault): AgentTool<typeof VideoGenerateSchema> {
+function createVideoGenerateTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault): AgentTool<typeof VideoGenerateSchema> {
   return {
     name: "video_generate",
     label: "Generate Video",
@@ -314,7 +319,7 @@ function createVideoGenerateTool(cwd: string, sandbox: string[], vault?: Resolve
       assertPathAllowed(filePath, sandbox, "video_generate");
 
       try {
-        return await generateVideo(filePath, params, vault, signal);
+        return await generateVideo(filePath, params, fs, vault, signal);
       } catch (err: any) {
         return {
           content: [{ type: "text", text: `Video generation error: ${err.message}` }],
@@ -336,6 +341,7 @@ async function generateVideo(
     guidance_scale?: number;
     seed?: number;
   },
+  fs: FileSystem,
   vault?: ResolvedVault,
   signal?: AbortSignal,
 ): Promise<ToolResult> {
@@ -371,8 +377,11 @@ async function generateVideo(
   if (!videoResp.ok) throw new Error(`Failed to download generated video: ${videoResp.status}`);
   const buffer = Buffer.from(await videoResp.arrayBuffer());
 
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, buffer);
+  if (!fs.writeFileBuffer) {
+    throw new Error("FileSystem implementation does not support writeFileBuffer (required for binary writes).");
+  }
+  await fs.mkdir(dirname(filePath));
+  await fs.writeFileBuffer(filePath, new Uint8Array(buffer));
 
   const sizeMB = (buffer.byteLength / 1024 / 1024).toFixed(2);
   const info = [
@@ -405,7 +414,7 @@ const ImageAnalyzeSchema = Type.Object({
   max_tokens: Type.Optional(Type.Number({ description: "Max tokens in response (default: 1024)" })),
 });
 
-function createAnalyzeTool(cwd: string, sandbox: string[], vault?: ResolvedVault): AgentTool<typeof ImageAnalyzeSchema> {
+function createAnalyzeTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault): AgentTool<typeof ImageAnalyzeSchema> {
   return {
     name: "image_analyze",
     label: "Analyze Image",
@@ -418,9 +427,17 @@ function createAnalyzeTool(cwd: string, sandbox: string[], vault?: ResolvedVault
       const filePath = resolve(cwd, params.path);
       assertPathAllowed(filePath, sandbox, "image_analyze");
 
+      if (!fs.readFileBuffer) {
+        return {
+          content: [{ type: "text", text: "FileSystem implementation does not support readFileBuffer (required for binary reads)." }],
+          details: { error: "unsupported_filesystem" },
+        };
+      }
+
       let fileBuffer: Buffer;
       try {
-        fileBuffer = readFileSync(filePath);
+        const bytes = await fs.readFileBuffer(filePath);
+        fileBuffer = Buffer.from(bytes);
       } catch (err: any) {
         return {
           content: [{ type: "text", text: `Error reading image file: ${err.message}` }],
@@ -632,13 +649,15 @@ export function createImageTools(
   allowedPaths?: string[],
   allowedTools?: string[],
   vault?: ResolvedVault,
+  fs?: FileSystem,
 ): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<ImageToolName, () => AgentTool<any>> = {
-    image_generate: () => createGenerateTool(cwd, sandbox, vault),
-    image_analyze: () => createAnalyzeTool(cwd, sandbox, vault),
-    video_generate: () => createVideoGenerateTool(cwd, sandbox, vault),
+    image_generate: () => createGenerateTool(cwd, sandbox, _fs, vault),
+    image_analyze: () => createAnalyzeTool(cwd, sandbox, _fs, vault),
+    video_generate: () => createVideoGenerateTool(cwd, sandbox, _fs, vault),
   };
 
   const names = allowedTools

--- a/packages/tools/src/outcome-tools.ts
+++ b/packages/tools/src/outcome-tools.ts
@@ -11,11 +11,12 @@
  * registering them.
  */
 
-import { existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 
 // ─── Tool: register_outcome ───
 
@@ -61,7 +62,7 @@ function guessMime(filePath: string): string | undefined {
   return EXT_MIME[filePath.slice(dot).toLowerCase()];
 }
 
-function createRegisterOutcomeTool(cwd: string, sandbox: string[], outputDir?: string): AgentTool<typeof RegisterOutcomeSchema> {
+function createRegisterOutcomeTool(cwd: string, sandbox: string[], fs: FileSystem, outputDir?: string): AgentTool<typeof RegisterOutcomeSchema> {
   // Use outputDir in examples when available so the agent naturally writes there
   const exampleDir = outputDir ? outputDir.replace(/\/$/, "") : "output";
   return {
@@ -117,7 +118,7 @@ function createRegisterOutcomeTool(cwd: string, sandbox: string[], outputDir?: s
         filePath = resolve(cwd, params.path);
         assertPathAllowed(filePath, sandbox, "register_outcome");
 
-        if (!existsSync(filePath)) {
+        if (!(await fs.exists(filePath))) {
           return {
             content: [{ type: "text", text: `Error: file not found: ${filePath}` }],
             details: { error: "file_not_found", path: filePath },
@@ -125,7 +126,7 @@ function createRegisterOutcomeTool(cwd: string, sandbox: string[], outputDir?: s
         }
 
         try {
-          const stats = statSync(filePath);
+          const stats = await fs.stat(filePath);
           fileSize = stats.size;
         } catch {
           // stat failed — file may have been deleted between exists check and stat
@@ -186,12 +187,14 @@ export const ALL_OUTCOME_TOOL_NAMES: OutcomeToolName[] = ["register_outcome"];
  * @param allowedPaths - Sandbox paths
  * @param allowedTools - Optional filter
  * @param outputDir - Per-task output directory for deliverables
+ * @param fs - FileSystem implementation (default: NodeFileSystem)
  */
-export function createOutcomeTools(cwd: string, allowedPaths?: string[], allowedTools?: string[], outputDir?: string): AgentTool<any>[] {
+export function createOutcomeTools(cwd: string, allowedPaths?: string[], allowedTools?: string[], outputDir?: string, fs?: FileSystem): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<OutcomeToolName, () => AgentTool<any>> = {
-    register_outcome: () => createRegisterOutcomeTool(cwd, sandbox, outputDir),
+    register_outcome: () => createRegisterOutcomeTool(cwd, sandbox, _fs, outputDir),
   };
 
   const names = allowedTools

--- a/packages/tools/src/pdf-tools.ts
+++ b/packages/tools/src/pdf-tools.ts
@@ -12,10 +12,11 @@
  * All file operations enforce path sandboxing.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 
 const MAX_TEXT_OUTPUT = 50_000;
@@ -28,7 +29,7 @@ const PdfReadSchema = Type.Object({
   max_chars: Type.Optional(Type.Number({ description: "Max characters to return (default: 50000)" })),
 });
 
-function createPdfReadTool(cwd: string, sandbox: string[]): AgentTool<typeof PdfReadSchema> {
+function createPdfReadTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof PdfReadSchema> {
   return {
     name: "pdf_read",
     label: "Read PDF",
@@ -39,19 +40,23 @@ function createPdfReadTool(cwd: string, sandbox: string[]): AgentTool<typeof Pdf
       assertPathAllowed(filePath, sandbox, "pdf_read");
 
       try {
+        if (!fs.readFileBuffer) {
+          return {
+            content: [{ type: "text", text: "PDF read error: Binary read not supported by injected FileSystem" }],
+            details: { error: "binary_read_unsupported" },
+          };
+        }
         const { PDFDocument } = await import("pdf-lib");
-        const bytes = readFileSync(filePath);
+        const bytes = await fs.readFileBuffer(filePath);
         const pdfDoc = await PDFDocument.load(bytes);
         const pageCount = pdfDoc.getPageCount();
         const title = pdfDoc.getTitle() ?? "";
         const author = pdfDoc.getAuthor() ?? "";
 
-        // pdf-lib doesn't extract text - we use a basic approach via page content streams
-        // For production, agents should use the bash tool with a CLI like pdftotext
-        // Here we provide metadata and suggest using bash for full text extraction
+        // Full text extraction is best-effort via pdf-lib; for production text extraction
+        // use a dedicated PDF parsing service.
         const maxChars = params.max_chars ?? MAX_TEXT_OUTPUT;
 
-        // Try to extract text using pdf-lib's low-level API
         const selectedPages = params.pages ?? Array.from({ length: pageCount }, (_, i) => i + 1);
         const textParts: string[] = [];
 
@@ -60,27 +65,10 @@ function createPdfReadTool(cwd: string, sandbox: string[]): AgentTool<typeof Pdf
           const page = pdfDoc.getPage(pageNum - 1);
           const { width, height } = page.getSize();
           textParts.push(`--- Page ${pageNum} (${Math.round(width)}x${Math.round(height)}) ---`);
-          // Note: pdf-lib doesn't support text extraction natively.
-          // We extract what we can from content streams
-          textParts.push(`[Page ${pageNum} content - use 'bash' tool with 'pdftotext' for full text extraction]`);
+          textParts.push(`[Page ${pageNum} content - pdf-lib does not support native text extraction; use a dedicated PDF parsing service for full text]`);
         }
 
-        // If pdftotext is available, try to use it
-        let extractedText = "";
-        try {
-          const { execSync } = await import("node:child_process");
-          const pagesArg = params.pages
-            ? `-f ${Math.min(...params.pages)} -l ${Math.max(...params.pages)}`
-            : "";
-          extractedText = execSync(
-            `pdftotext ${pagesArg} -layout ${JSON.stringify(filePath)} -`,
-            { encoding: "utf-8", timeout: 15_000 },
-          ).trim();
-        } catch {
-          // pdftotext not available - that's fine
-        }
-
-        const text = extractedText || textParts.join("\n");
+        const text = textParts.join("\n");
         const truncated = text.length > maxChars
           ? text.slice(0, maxChars) + `\n[truncated — ${text.length} total chars]`
           : text;
@@ -132,7 +120,7 @@ const PdfCreateSchema = Type.Object({
   wait_for_network: Type.Optional(Type.Boolean({ description: "Wait for network idle before rendering (default: true). Disable for offline HTML with no external resources." })),
 });
 
-function createPdfCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof PdfCreateSchema> {
+function createPdfCreateTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof PdfCreateSchema> {
   return {
     name: "pdf_create",
     label: "Create PDF",
@@ -165,7 +153,7 @@ function createPdfCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof P
 
       const filePath = resolve(cwd, params.path);
       assertPathAllowed(filePath, sandbox, "pdf_create");
-      mkdirSync(dirname(filePath), { recursive: true });
+      await fs.mkdir(dirname(filePath));
 
       // Resolve HTML content
       let htmlContent: string;
@@ -173,7 +161,7 @@ function createPdfCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof P
         const htmlFilePath = resolve(cwd, params.html_path);
         assertPathAllowed(htmlFilePath, sandbox, "pdf_create");
         try {
-          htmlContent = readFileSync(htmlFilePath, "utf-8");
+          htmlContent = await fs.readFile(htmlFilePath);
         } catch (err: any) {
           return {
             content: [{ type: "text", text: `Error reading HTML file: ${err.message}` }],
@@ -207,9 +195,14 @@ function createPdfCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof P
         // Determine if custom header/footer templates are provided
         const hasHeaderFooter = !!(params.header_template || params.footer_template);
 
-        // Generate PDF
+        // Generate PDF (capture buffer instead of writing to path so we can route through fs)
+        if (!fs.writeFileBuffer) {
+          return {
+            content: [{ type: "text", text: "PDF create error: Binary write not supported by injected FileSystem" }],
+            details: { error: "binary_write_unsupported" },
+          };
+        }
         const pdfBuffer = await page.pdf({
-          path: filePath,
           format: params.format ?? "A4",
           landscape: params.landscape ?? false,
           printBackground: params.print_background ?? true,
@@ -222,13 +215,14 @@ function createPdfCreateTool(cwd: string, sandbox: string[]): AgentTool<typeof P
           } : {}),
         });
 
+        await fs.writeFileBuffer(filePath, new Uint8Array(pdfBuffer));
         const bytes = pdfBuffer.byteLength;
 
         // Count pages in the generated PDF for reporting
         let pageCount = 0;
         try {
           const { PDFDocument } = await import("pdf-lib");
-          const doc = await PDFDocument.load(readFileSync(filePath));
+          const doc = await PDFDocument.load(new Uint8Array(pdfBuffer));
           pageCount = doc.getPageCount();
         } catch {
           // Best effort — pdf-lib may fail on some PDFs
@@ -268,7 +262,7 @@ const PdfMergeSchema = Type.Object({
   output: Type.String({ description: "Output merged PDF path" }),
 });
 
-function createPdfMergeTool(cwd: string, sandbox: string[]): AgentTool<typeof PdfMergeSchema> {
+function createPdfMergeTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof PdfMergeSchema> {
   return {
     name: "pdf_merge",
     label: "Merge PDFs",
@@ -277,9 +271,15 @@ function createPdfMergeTool(cwd: string, sandbox: string[]): AgentTool<typeof Pd
     async execute(_id, params) {
       const outputPath = resolve(cwd, params.output);
       assertPathAllowed(outputPath, sandbox, "pdf_merge");
-      mkdirSync(dirname(outputPath), { recursive: true });
+      await fs.mkdir(dirname(outputPath));
 
       try {
+        if (!fs.readFileBuffer || !fs.writeFileBuffer) {
+          return {
+            content: [{ type: "text", text: "PDF merge error: Binary I/O not supported by injected FileSystem" }],
+            details: { error: "binary_io_unsupported" },
+          };
+        }
         const { PDFDocument } = await import("pdf-lib");
         const merged = await PDFDocument.create();
         let totalPages = 0;
@@ -287,7 +287,7 @@ function createPdfMergeTool(cwd: string, sandbox: string[]): AgentTool<typeof Pd
         for (const inputPath of params.inputs) {
           const fullPath = resolve(cwd, inputPath);
           assertPathAllowed(fullPath, sandbox, "pdf_merge");
-          const bytes = readFileSync(fullPath);
+          const bytes = await fs.readFileBuffer(fullPath);
           const src = await PDFDocument.load(bytes);
           const indices = Array.from({ length: src.getPageCount() }, (_, i) => i);
           const copiedPages = await merged.copyPages(src, indices);
@@ -296,7 +296,7 @@ function createPdfMergeTool(cwd: string, sandbox: string[]): AgentTool<typeof Pd
         }
 
         const mergedBytes = await merged.save();
-        writeFileSync(outputPath, mergedBytes);
+        await fs.writeFileBuffer(outputPath, mergedBytes);
 
         return {
           content: [{ type: "text", text: `Merged ${params.inputs.length} PDFs -> ${outputPath} (${totalPages} pages, ${mergedBytes.byteLength} bytes)` }],
@@ -318,7 +318,7 @@ const PdfInfoSchema = Type.Object({
   path: Type.String({ description: "Path to PDF file" }),
 });
 
-function createPdfInfoTool(cwd: string, sandbox: string[]): AgentTool<typeof PdfInfoSchema> {
+function createPdfInfoTool(cwd: string, sandbox: string[], fs: FileSystem): AgentTool<typeof PdfInfoSchema> {
   return {
     name: "pdf_info",
     label: "PDF Info",
@@ -329,8 +329,14 @@ function createPdfInfoTool(cwd: string, sandbox: string[]): AgentTool<typeof Pdf
       assertPathAllowed(filePath, sandbox, "pdf_info");
 
       try {
+        if (!fs.readFileBuffer) {
+          return {
+            content: [{ type: "text", text: "PDF info error: Binary read not supported by injected FileSystem" }],
+            details: { error: "binary_read_unsupported" },
+          };
+        }
         const { PDFDocument } = await import("pdf-lib");
-        const bytes = readFileSync(filePath);
+        const bytes = await fs.readFileBuffer(filePath);
         const pdfDoc = await PDFDocument.load(bytes);
 
         const pages = pdfDoc.getPageCount();
@@ -390,14 +396,15 @@ export const ALL_PDF_TOOL_NAMES: PdfToolName[] = ["pdf_read", "pdf_create", "pdf
  * @param allowedPaths - Sandbox paths
  * @param allowedTools - Optional filter
  */
-export function createPdfTools(cwd: string, allowedPaths?: string[], allowedTools?: string[]): AgentTool<any>[] {
+export function createPdfTools(cwd: string, allowedPaths?: string[], allowedTools?: string[], fs?: FileSystem): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
+  const _fs = fs ?? new NodeFileSystem();
 
   const factories: Record<PdfToolName, () => AgentTool<any>> = {
-    pdf_read: () => createPdfReadTool(cwd, sandbox),
-    pdf_create: () => createPdfCreateTool(cwd, sandbox),
-    pdf_merge: () => createPdfMergeTool(cwd, sandbox),
-    pdf_info: () => createPdfInfoTool(cwd, sandbox),
+    pdf_read: () => createPdfReadTool(cwd, sandbox, _fs),
+    pdf_create: () => createPdfCreateTool(cwd, sandbox, _fs),
+    pdf_merge: () => createPdfMergeTool(cwd, sandbox, _fs),
+    pdf_info: () => createPdfInfoTool(cwd, sandbox, _fs),
   };
 
   const names = allowedTools

--- a/packages/tools/src/system-tools.ts
+++ b/packages/tools/src/system-tools.ts
@@ -494,32 +494,32 @@ export async function createAllTools(options: CreateAllToolsOptions): Promise<Ag
 
   // Email tools — activated when any email_* tool is in allowedTools
   if (categoryRequested(ALL_EMAIL_TOOL_NAMES)) {
-    tools.push(...createEmailTools(cwd, allowedPaths, allowedTools, options.vault, options.emailAllowedDomains, options.outputDir));
+    tools.push(...createEmailTools(cwd, allowedPaths, allowedTools, options.vault, options.emailAllowedDomains, options.outputDir, options.fs));
   }
 
   // Image & video tools — activated when any image_* or video_* tool is in allowedTools
   if (categoryRequested(ALL_IMAGE_TOOL_NAMES)) {
-    tools.push(...createImageTools(cwd, allowedPaths, allowedTools, options.vault));
+    tools.push(...createImageTools(cwd, allowedPaths, allowedTools, options.vault, options.fs));
   }
 
   // Audio tools — activated when any audio_* tool is in allowedTools
   if (categoryRequested(ALL_AUDIO_TOOL_NAMES)) {
-    tools.push(...createAudioTools(cwd, allowedPaths, allowedTools, options.vault));
+    tools.push(...createAudioTools(cwd, allowedPaths, allowedTools, options.vault, options.fs));
   }
 
   // Excel tools — activated when any excel_* tool is in allowedTools
   if (categoryRequested(ALL_EXCEL_TOOL_NAMES)) {
-    tools.push(...createExcelTools(cwd, allowedPaths, allowedTools));
+    tools.push(...createExcelTools(cwd, allowedPaths, allowedTools, options.fs));
   }
 
   // PDF tools — activated when any pdf_* tool is in allowedTools
   if (categoryRequested(ALL_PDF_TOOL_NAMES)) {
-    tools.push(...createPdfTools(cwd, allowedPaths, allowedTools));
+    tools.push(...createPdfTools(cwd, allowedPaths, allowedTools, options.fs));
   }
 
   // Docx tools — activated when any docx_* tool is in allowedTools
   if (categoryRequested(ALL_DOCX_TOOL_NAMES)) {
-    tools.push(...createDocxTools(cwd, allowedPaths, allowedTools));
+    tools.push(...createDocxTools(cwd, allowedPaths, allowedTools, options.fs));
   }
 
   // Search tools (Exa) — activated when any search_* tool is in allowedTools


### PR DESCRIPTION
## Summary

Email, Excel, PDF, DOCX, image, audio, http, and outcome tools were
calling `node:fs` directly, which breaks them in any non-Node runtime —
notably the cloud chat-completion path where `SandboxProxyFS` is the
only filesystem the agent can see. ~35 of the 62 extended tools were
silently failing in that path.

Every read/write now goes through the `FileSystem` port, and
`options.fs` is threaded through `createAllTools` so the caller's
implementation actually reaches every tool factory.

## Changes per file

- **email-tools / image-tools / audio-tools**: attachments and outputs
  via `readFileBuffer` / `writeFileBuffer`
- **excel-tools**: `xlsx.load(buffer)` / `xlsx.writeBuffer()` instead of
  passing file paths to `xlsx.readFile` / `workbook.xlsx.writeFile`
- **pdf-tools**: pdf-lib already accepts `Uint8Array`; drop the
  `pdftotext` `execSync` fallback and have Playwright `page.pdf()`
  return a buffer
- **docx-tools**: mammoth `{ buffer }`, `Packer.toBuffer()` then
  `fs.writeFileBuffer`
- **http-tools**: `await fs.mkdir` + `await fs.writeFileBuffer` for
  downloads
- **outcome-tools**: `existsSync` / `statSync` →
  `await fs.exists` / `await fs.stat`
- **system-tools**: forward `options.fs` to every child factory in
  `createAllTools` (the previous wiring only passed it to
  `createSystemTools`)

## Test plan

- [x] `pnpm --filter @polpo-ai/tools build` clean
- [x] Full monorepo build clean (core, drizzle, llm, tools, server,
      sdk, react-sdk, cli)
- [ ] Smoke-test the cloud chat-completion path on `polpo-runner-v6`
      after the 0.6.28 bump (covered by the cloud rollout, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)