### PR TITLE
fix(tools): route browser & audio CLI calls through Shell abstraction

### DIFF
--- a/packages/tools/src/audio-tools.ts
+++ b/packages/tools/src/audio-tools.ts
@@ -28,11 +28,12 @@
  */
 
 import { resolve, dirname, extname } from "node:path";
-import { execFile } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
+import type { Shell } from "@polpo-ai/core";
 import { NodeFileSystem } from "./adapters/node-filesystem.js";
+import { NodeShell } from "./adapters/node-shell.js";
 
 // Re-export with concrete generic to avoid "requires 1 type argument" errors
 type ToolResult = AgentToolResult<any>;
@@ -305,7 +306,7 @@ const AudioSpeakSchema = Type.Object({
   instructions: Type.Optional(Type.String({ description: "Voice style instructions (OpenAI gpt-4o-mini-tts only, e.g. 'Speak in a cheerful tone')" })),
 });
 
-function createSpeakTool(cwd: string, sandbox: string[], fs: FileSystem, vault?: ResolvedVault): AgentTool<typeof AudioSpeakSchema> {
+function createSpeakTool(cwd: string, sandbox: string[], fs: FileSystem, shell: Shell, vault?: ResolvedVault): AgentTool<typeof AudioSpeakSchema> {
   return {
     name: "audio_speak",
     label: "Text to Speech",
@@ -324,14 +325,14 @@ function createSpeakTool(cwd: string, sandbox: string[], fs: FileSystem, vault?:
 
       // Direct edge-tts request — no fallback needed
       if (provider === "edge") {
-        if (!edgeTtsAvailable()) {
+        if (!(await edgeTtsAvailable(shell))) {
           return {
             content: [{ type: "text", text: "Edge TTS not available in this environment. Use openai/deepgram/elevenlabs instead." }],
             details: { provider: "edge", error: "edge_tts_unavailable" },
           };
         }
         try {
-          return await speakEdgeTts(filePath, params, signal);
+          return await speakEdgeTts(filePath, params, fs, shell);
         } catch (err: any) {
           return {
             content: [{ type: "text", text: `TTS error (edge): ${err.message}` }],
@@ -351,9 +352,9 @@ function createSpeakTool(cwd: string, sandbox: string[], fs: FileSystem, vault?:
         }
       } catch (err: any) {
         // Automatic fallback to edge-tts if available
-        if (edgeTtsAvailable()) {
+        if (await edgeTtsAvailable(shell)) {
           try {
-            const result = await speakEdgeTts(filePath, params, signal);
+            const result = await speakEdgeTts(filePath, params, fs, shell);
             // Prepend fallback notice
             const notice = `[Fallback] ${provider} failed (${err.message}), used edge-tts instead.\n`;
             return {
@@ -604,76 +605,69 @@ function resolveEdgeVoice(voice?: string, language?: string, gender?: "male" | "
   return gender === "male" ? pair[1] : pair[0]; // default female if no gender hint
 }
 
-/** Check if edge-tts CLI is available on the system. */
-function isEdgeTtsAvailable(): boolean {
-  // Allow operators (e.g. cloud chat-completion path) to opt out explicitly.
-  if (process.env.POLPO_DISABLE_EDGE_TTS === "1") return false;
-  try {
-    const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
-    execFileSync("edge-tts", ["--version"], { stdio: "pipe", timeout: 5000 });
-    return true;
-  } catch {
-    return false;
-  }
+/** Per-Shell cache of "is edge-tts on PATH" — checked once per shell. */
+const _edgeTtsAvailable = new WeakMap<Shell, Promise<boolean>>();
+
+/** Check if edge-tts CLI is available, routed through the Shell so the
+ *  check runs in the same environment as the actual TTS call (sandbox
+ *  in cloud, local Node in OSS). */
+function edgeTtsAvailable(shell: Shell): Promise<boolean> {
+  const existing = _edgeTtsAvailable.get(shell);
+  if (existing) return existing;
+  const fresh: Promise<boolean> = shell
+    .execute("edge-tts --version", { timeout: 5000 })
+    .then((r: { exitCode: number }) => r.exitCode === 0)
+    .catch(() => false);
+  _edgeTtsAvailable.set(shell, fresh);
+  return fresh;
 }
 
-// Cache the availability check
-let _edgeTtsAvailable: boolean | undefined;
-function edgeTtsAvailable(): boolean {
-  if (_edgeTtsAvailable === undefined) _edgeTtsAvailable = isEdgeTtsAvailable();
-  return _edgeTtsAvailable;
+/** Quote a CLI argument for inclusion in a `shell.execute` command line. */
+function quoteArg(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
 async function speakEdgeTts(
   filePath: string,
   params: { text: string; voice?: string; language?: string; gender?: "male" | "female" },
-  signal?: AbortSignal,
+  fs: FileSystem,
+  shell: Shell,
 ): Promise<ToolResult> {
-  if (!edgeTtsAvailable()) {
+  if (!(await edgeTtsAvailable(shell))) {
     throw new Error("edge-tts CLI is not installed. Install it with: pip install edge-tts");
   }
 
   const voice = resolveEdgeVoice(params.voice, params.language, params.gender);
-  // edge-tts is a local Node-only path — direct node:fs is acceptable here
-  // since the provider is gated by isEdgeTtsAvailable() which already requires Node.
-  const nodeFs = require("node:fs") as typeof import("node:fs");
-  nodeFs.mkdirSync(dirname(filePath), { recursive: true });
+  await fs.mkdir(dirname(filePath));
 
-  // Determine rate from speed if present
-  const args = [
-    "--text", params.text,
-    "--voice", voice,
-    "--write-media", filePath,
-  ];
+  const cmd = [
+    "edge-tts",
+    "--text", quoteArg(params.text),
+    "--voice", quoteArg(voice),
+    "--write-media", quoteArg(filePath),
+  ].join(" ");
 
-  return new Promise<ToolResult>((resolvePromise, reject) => {
-    const child = execFile("edge-tts", args, { timeout: DEFAULT_TIMEOUT }, (err, _stdout, stderr) => {
-      if (err) {
-        reject(new Error(`edge-tts failed: ${err.message}${stderr ? ` — ${stderr}` : ""}`));
-        return;
-      }
+  const result = await shell.execute(cmd, { timeout: DEFAULT_TIMEOUT });
+  if (result.exitCode !== 0) {
+    throw new Error(`edge-tts failed: ${(result.stderr || result.stdout || "").trim() || `exit ${result.exitCode}`}`);
+  }
 
-      let bytes = 0;
-      try {
-        bytes = nodeFs.statSync(filePath).size;
-      } catch { /* ignore */ }
+  let bytes = 0;
+  try {
+    const stat = await fs.stat(filePath);
+    bytes = stat?.size ?? 0;
+  } catch { /* ignore */ }
 
-      resolvePromise({
-        content: [{ type: "text", text: `Speech audio saved: ${filePath} (${(bytes / 1024).toFixed(1)} KB, voice: ${voice}, provider: edge-tts)` }],
-        details: {
-          provider: "edge",
-          voice,
-          path: filePath,
-          bytes,
-          textLength: params.text.length,
-        },
-      });
-    });
-
-    if (signal) {
-      signal.addEventListener("abort", () => child.kill(), { once: true });
-    }
-  });
+  return {
+    content: [{ type: "text", text: `Speech audio saved: ${filePath} (${(bytes / 1024).toFixed(1)} KB, voice: ${voice}, provider: edge-tts)` }],
+    details: {
+      provider: "edge",
+      voice,
+      path: filePath,
+      bytes,
+      textLength: params.text.length,
+    },
+  };
 }
 
 // ─── Factory ───
@@ -696,13 +690,15 @@ export function createAudioTools(
   allowedTools?: string[],
   vault?: ResolvedVault,
   fs?: FileSystem,
+  shell?: Shell,
 ): AgentTool<any>[] {
   const sandbox = resolveAllowedPaths(cwd, allowedPaths);
   const _fs = fs ?? new NodeFileSystem();
+  const _shell = shell ?? new NodeShell();
 
   const factories: Record<AudioToolName, () => AgentTool<any>> = {
     audio_transcribe: () => createTranscribeTool(cwd, sandbox, _fs, vault),
-    audio_speak: () => createSpeakTool(cwd, sandbox, _fs, vault),
+    audio_speak: () => createSpeakTool(cwd, sandbox, _fs, _shell, vault),
   };
 
   const names = allowedTools

--- a/packages/tools/src/browser-tools.ts
+++ b/packages/tools/src/browser-tools.ts
@@ -2,38 +2,47 @@
  * Browser automation tools powered by agent-browser.
  *
  * Uses the agent-browser CLI (https://github.com/vercel-labs/agent-browser)
- * via child_process with --json output for structured results.
+ * with --json output for structured results, routed through the
+ * Shell abstraction so it works the same in three environments:
+ *   - OSS standalone (NodeShell): agent-browser must be on PATH
+ *     locally (`npm install -g agent-browser && agent-browser install`).
+ *   - Polpo task runner: NodeShell inside the sandbox; agent-browser
+ *     is baked into the snapshot.
+ *   - Cloud chat-completion (SandboxProxyShell): the worker proxies
+ *     every command into the project's sandbox, where agent-browser
+ *     lives. Without this routing the worker would `spawn` locally
+ *     and fail with `ENOENT`, since the worker container has no
+ *     Chromium and no agent-browser binary.
  *
- * The agent-browser CLI manages a daemon process that keeps the browser alive
- * between commands, making sequential tool calls fast (no cold-start per command).
- *
- * Requires `agent-browser` to be installed globally or in PATH.
- * Install: `npm install -g agent-browser && agent-browser install`
- *
- * Session isolation: Each agent gets its own browser session via --session flag,
- * preventing cross-agent interference when multiple agents use browser tools.
+ * Session isolation: each agent gets its own browser session via
+ * --session, preventing cross-agent interference.
  */
 
-import { execSync, spawn as spawnChild } from "node:child_process";
 import { resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { PolpoTool as AgentTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { Shell } from "@polpo-ai/core";
+import { NodeShell } from "./adapters/node-shell.js";
 
 const MAX_OUTPUT_BYTES = 50_000;
 const DEFAULT_TIMEOUT = 30_000;
+
+/** Quote a CLI argument so it survives `shell.execute` (which takes a
+ *  full command line, not an argv). Conservative: single-quote and
+ *  escape any embedded single quotes. */
+function quote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
 
 /**
  * Cleanup an agent-browser session: close the session.
  * Profile data is automatically persisted by agent-browser when --profile is used.
  * Called by the engine on agent exit.
  */
-export async function cleanupAgentBrowserSession(session: string): Promise<void> {
+export async function cleanupAgentBrowserSession(session: string, shell?: Shell): Promise<void> {
+  const _shell = shell ?? new NodeShell();
   try {
-    execSync(`agent-browser --session ${session} close`, {
-      encoding: "utf-8",
-      timeout: 10_000,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    await _shell.execute(`agent-browser --session ${quote(session)} close`, { timeout: 10_000 });
   } catch {
     // Already closed
   }
@@ -41,84 +50,49 @@ export async function cleanupAgentBrowserSession(session: string): Promise<void>
 
 // ─── Helpers ───
 
-/** Execute agent-browser CLI command and return parsed result */
-function execBrowser(
+/** Execute an agent-browser CLI command via the Shell abstraction
+ *  and parse the --json response. */
+async function execBrowserAsync(
+  shell: Shell,
   args: string[],
   options: { session?: string; profileDir?: string; timeout?: number; cwd?: string } = {},
-): { success: boolean; data?: any; error?: string; raw: string } {
-  const sessionArgs = options.session ? ["--session", options.session] : [];
-  const profileArgs = options.profileDir ? ["--profile", options.profileDir] : [];
-  const cmd = ["agent-browser", ...sessionArgs, ...profileArgs, ...args, "--json"].join(" ");
+): Promise<{ success: boolean; data?: any; error?: string; raw: string }> {
+  const parts = ["agent-browser"];
+  if (options.session) parts.push("--session", quote(options.session));
+  if (options.profileDir) parts.push("--profile", quote(options.profileDir));
+  for (const a of args) parts.push(quote(a));
+  parts.push("--json");
+  const cmd = parts.join(" ");
+
+  let result;
   try {
-    const raw = execSync(cmd, {
-      encoding: "utf-8",
-      timeout: options.timeout ?? DEFAULT_TIMEOUT,
-      cwd: options.cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-    }).trim();
+    result = await shell.execute(cmd, { cwd: options.cwd, timeout: options.timeout ?? DEFAULT_TIMEOUT });
+  } catch (err: any) {
+    return { success: false, error: err?.message ?? String(err), raw: err?.message ?? String(err) };
+  }
+
+  let raw = (result.stdout || result.stderr || "").trim();
+  if (raw.length > MAX_OUTPUT_BYTES) {
+    raw = raw.slice(-MAX_OUTPUT_BYTES) + "\n[truncated]";
+  }
+
+  if (result.exitCode !== 0) {
+    // agent-browser still emits structured JSON on failure when --json
+    // is set; try to parse it before falling back to raw stderr.
     try {
       const parsed = JSON.parse(raw);
-      return { success: parsed.success ?? true, data: parsed.data ?? parsed, raw };
+      return { success: false, error: parsed.error ?? raw, data: parsed.data, raw };
     } catch {
-      return { success: true, data: raw, raw };
+      return { success: false, error: raw || `exit ${result.exitCode}`, raw };
     }
-  } catch (err: any) {
-    const stderr = err.stderr?.toString() ?? "";
-    const stdout = err.stdout?.toString() ?? "";
-    return { success: false, error: stderr || stdout || err.message, raw: stderr || stdout };
   }
-}
 
-/** Execute agent-browser command async with signal support */
-function execBrowserAsync(
-  args: string[],
-  options: { session?: string; profileDir?: string; timeout?: number; cwd?: string; signal?: AbortSignal } = {},
-): Promise<{ success: boolean; data?: any; error?: string; raw: string }> {
-  return new Promise((resolve) => {
-    const sessionArgs = options.session ? ["--session", options.session] : [];
-    const profileArgs = options.profileDir ? ["--profile", options.profileDir] : [];
-    const fullArgs = [...sessionArgs, ...profileArgs, ...args, "--json"];
-
-    const child = spawnChild("agent-browser", fullArgs, {
-      cwd: options.cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    const chunks: Buffer[] = [];
-    let killed = false;
-
-    const timer = setTimeout(() => {
-      killed = true;
-      child.kill("SIGTERM");
-    }, options.timeout ?? DEFAULT_TIMEOUT);
-
-    const onAbort = () => { killed = true; child.kill("SIGTERM"); };
-    options.signal?.addEventListener("abort", onAbort, { once: true });
-
-    child.stdout.on("data", (d: Buffer) => chunks.push(d));
-    child.stderr.on("data", (d: Buffer) => chunks.push(d));
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      options.signal?.removeEventListener("abort", onAbort);
-      let raw = Buffer.concat(chunks).toString("utf-8").trim();
-      if (raw.length > MAX_OUTPUT_BYTES) {
-        raw = raw.slice(-MAX_OUTPUT_BYTES) + "\n[truncated]";
-      }
-      try {
-        const parsed = JSON.parse(raw);
-        resolve({ success: parsed.success ?? (code === 0), data: parsed.data ?? parsed, raw });
-      } catch {
-        resolve({ success: code === 0, data: raw, raw });
-      }
-    });
-
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      options.signal?.removeEventListener("abort", onAbort);
-      resolve({ success: false, error: err.message, raw: err.message });
-    });
-  });
+  try {
+    const parsed = JSON.parse(raw);
+    return { success: parsed.success ?? true, data: parsed.data ?? parsed, raw };
+  } catch {
+    return { success: true, data: raw, raw };
+  }
 }
 
 function browserResult(result: { success: boolean; data?: any; error?: string; raw: string }): AgentToolResult<any> {
@@ -141,14 +115,14 @@ const BrowserNavigateSchema = Type.Object({
   url: Type.String({ description: "URL to navigate to (e.g. 'https://example.com')" }),
 });
 
-function createBrowserNavigateTool(session: string, profileDir?: string): AgentTool<typeof BrowserNavigateSchema> {
+function createBrowserNavigateTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserNavigateSchema> {
   return {
     name: "browser_navigate",
     label: "Browser Navigate",
     description: "Open a URL in the browser. Launches the browser if not already running.",
     parameters: BrowserNavigateSchema,
     async execute(_id, params, signal) {
-      const result = await execBrowserAsync(["open", params.url], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["open", params.url], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -163,7 +137,7 @@ const BrowserSnapshotSchema = Type.Object({
   selector: Type.Optional(Type.String({ description: "Scope snapshot to a CSS selector" })),
 });
 
-function createBrowserSnapshotTool(session: string, profileDir?: string): AgentTool<typeof BrowserSnapshotSchema> {
+function createBrowserSnapshotTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserSnapshotSchema> {
   return {
     name: "browser_snapshot",
     label: "Browser Snapshot",
@@ -176,7 +150,7 @@ function createBrowserSnapshotTool(session: string, profileDir?: string): AgentT
       if (params.compact) args.push("-c");
       if (params.max_depth) args.push("-d", String(params.max_depth));
       if (params.selector) args.push("-s", params.selector);
-      const result = await execBrowserAsync(args, { session, profileDir, signal, timeout: 15_000 });
+      const result = await execBrowserAsync(shell, args, { session, profileDir, timeout: 15_000 });
       return browserResult(result);
     },
   };
@@ -188,14 +162,14 @@ const BrowserClickSchema = Type.Object({
   selector: Type.String({ description: "Element ref from snapshot (e.g. '@e2') or CSS selector" }),
 });
 
-function createBrowserClickTool(session: string, profileDir?: string): AgentTool<typeof BrowserClickSchema> {
+function createBrowserClickTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserClickSchema> {
   return {
     name: "browser_click",
     label: "Browser Click",
     description: "Click an element. Use refs from snapshot (e.g. @e2) for reliable targeting.",
     parameters: BrowserClickSchema,
     async execute(_id, params, signal) {
-      const result = await execBrowserAsync(["click", params.selector], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["click", params.selector], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -208,14 +182,14 @@ const BrowserFillSchema = Type.Object({
   text: Type.String({ description: "Text to fill into the input" }),
 });
 
-function createBrowserFillTool(session: string, profileDir?: string): AgentTool<typeof BrowserFillSchema> {
+function createBrowserFillTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserFillSchema> {
   return {
     name: "browser_fill",
     label: "Browser Fill",
     description: "Clear an input field and type new text. Use refs from snapshot for targeting.",
     parameters: BrowserFillSchema,
     async execute(_id, params, signal) {
-      const result = await execBrowserAsync(["fill", params.selector, params.text], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["fill", params.selector, params.text], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -228,14 +202,14 @@ const BrowserTypeSchema = Type.Object({
   text: Type.String({ description: "Text to type (appends to existing content)" }),
 });
 
-function createBrowserTypeTool(session: string, profileDir?: string): AgentTool<typeof BrowserTypeSchema> {
+function createBrowserTypeTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserTypeSchema> {
   return {
     name: "browser_type",
     label: "Browser Type",
     description: "Type text into an element without clearing it first. Use for appending text.",
     parameters: BrowserTypeSchema,
     async execute(_id, params, signal) {
-      const result = await execBrowserAsync(["type", params.selector, params.text], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["type", params.selector, params.text], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -247,14 +221,14 @@ const BrowserPressSchema = Type.Object({
   key: Type.String({ description: "Key to press (e.g. 'Enter', 'Tab', 'Control+a', 'Escape')" }),
 });
 
-function createBrowserPressTool(session: string, profileDir?: string): AgentTool<typeof BrowserPressSchema> {
+function createBrowserPressTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserPressSchema> {
   return {
     name: "browser_press",
     label: "Browser Press Key",
     description: "Press a keyboard key. Supports modifiers like 'Control+a', 'Shift+Enter'.",
     parameters: BrowserPressSchema,
     async execute(_id, params, signal) {
-      const result = await execBrowserAsync(["press", params.key], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["press", params.key], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -267,7 +241,7 @@ const BrowserScreenshotSchema = Type.Object({
   full_page: Type.Optional(Type.Boolean({ description: "Capture full page, not just viewport" })),
 });
 
-function createBrowserScreenshotTool(session: string, cwd: string, profileDir?: string): AgentTool<typeof BrowserScreenshotSchema> {
+function createBrowserScreenshotTool(shell: Shell, session: string, cwd: string, profileDir?: string): AgentTool<typeof BrowserScreenshotSchema> {
   return {
     name: "browser_screenshot",
     label: "Browser Screenshot",
@@ -277,7 +251,7 @@ function createBrowserScreenshotTool(session: string, cwd: string, profileDir?: 
       const args = ["screenshot"];
       if (params.path) args.push(resolve(cwd, params.path));
       if (params.full_page) args.push("--full");
-      const result = await execBrowserAsync(args, { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, args, { session, profileDir });
       return browserResult(result);
     },
   };
@@ -296,7 +270,7 @@ const BrowserGetSchema = Type.Object({
   selector: Type.Optional(Type.String({ description: "Element ref or CSS selector (required for text/html/value)" })),
 });
 
-function createBrowserGetTool(session: string, profileDir?: string): AgentTool<typeof BrowserGetSchema> {
+function createBrowserGetTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserGetSchema> {
   return {
     name: "browser_get",
     label: "Browser Get Info",
@@ -305,7 +279,7 @@ function createBrowserGetTool(session: string, profileDir?: string): AgentTool<t
     async execute(_id, params, signal) {
       const args = ["get", params.what];
       if (params.selector) args.push(params.selector);
-      const result = await execBrowserAsync(args, { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, args, { session, profileDir });
       return browserResult(result);
     },
   };
@@ -318,14 +292,14 @@ const BrowserSelectSchema = Type.Object({
   value: Type.String({ description: "Option value to select" }),
 });
 
-function createBrowserSelectTool(session: string, profileDir?: string): AgentTool<typeof BrowserSelectSchema> {
+function createBrowserSelectTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserSelectSchema> {
   return {
     name: "browser_select",
     label: "Browser Select",
     description: "Select an option from a dropdown <select> element.",
     parameters: BrowserSelectSchema,
     async execute(_id, params, signal) {
-      const result = await execBrowserAsync(["select", params.selector, params.value], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["select", params.selector, params.value], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -337,14 +311,14 @@ const BrowserHoverSchema = Type.Object({
   selector: Type.String({ description: "Element ref or CSS selector to hover" }),
 });
 
-function createBrowserHoverTool(session: string, profileDir?: string): AgentTool<typeof BrowserHoverSchema> {
+function createBrowserHoverTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserHoverSchema> {
   return {
     name: "browser_hover",
     label: "Browser Hover",
     description: "Hover over an element to trigger hover states, tooltips, or dropdown menus.",
     parameters: BrowserHoverSchema,
     async execute(_id, params, signal) {
-      const result = await execBrowserAsync(["hover", params.selector], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["hover", params.selector], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -362,7 +336,7 @@ const BrowserScrollSchema = Type.Object({
   pixels: Type.Optional(Type.Number({ description: "Number of pixels to scroll (default: varies)" })),
 });
 
-function createBrowserScrollTool(session: string, profileDir?: string): AgentTool<typeof BrowserScrollSchema> {
+function createBrowserScrollTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserScrollSchema> {
   return {
     name: "browser_scroll",
     label: "Browser Scroll",
@@ -371,7 +345,7 @@ function createBrowserScrollTool(session: string, profileDir?: string): AgentToo
     async execute(_id, params, signal) {
       const args = ["scroll", params.direction];
       if (params.pixels) args.push(String(params.pixels));
-      const result = await execBrowserAsync(args, { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, args, { session, profileDir });
       return browserResult(result);
     },
   };
@@ -391,7 +365,7 @@ const BrowserWaitSchema = Type.Object({
   ], { description: "Wait for load state" })),
 });
 
-function createBrowserWaitTool(session: string, profileDir?: string): AgentTool<typeof BrowserWaitSchema> {
+function createBrowserWaitTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserWaitSchema> {
   return {
     name: "browser_wait",
     label: "Browser Wait",
@@ -404,7 +378,7 @@ function createBrowserWaitTool(session: string, profileDir?: string): AgentTool<
       if (params.url) args.push("--url", params.url);
       if (params.timeout_ms) args.push(String(params.timeout_ms));
       if (params.load_state) args.push("--load", params.load_state);
-      const result = await execBrowserAsync(args, { session, profileDir, signal, timeout: 60_000 });
+      const result = await execBrowserAsync(shell, args, { session, profileDir, timeout: 60_000 });
       return browserResult(result);
     },
   };
@@ -416,7 +390,7 @@ const BrowserEvalSchema = Type.Object({
   javascript: Type.String({ description: "JavaScript code to execute in the browser page context" }),
 });
 
-function createBrowserEvalTool(session: string, profileDir?: string): AgentTool<typeof BrowserEvalSchema> {
+function createBrowserEvalTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserEvalSchema> {
   return {
     name: "browser_eval",
     label: "Browser Evaluate JS",
@@ -426,7 +400,7 @@ function createBrowserEvalTool(session: string, profileDir?: string): AgentTool<
     async execute(_id, params, signal) {
       // Use base64 encoding for safe transport of complex JS
       const b64 = Buffer.from(params.javascript).toString("base64");
-      const result = await execBrowserAsync(["eval", b64, "-b"], { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, ["eval", b64, "-b"], { session, profileDir });
       return browserResult(result);
     },
   };
@@ -436,14 +410,14 @@ function createBrowserEvalTool(session: string, profileDir?: string): AgentTool<
 
 const BrowserCloseSchema = Type.Object({});
 
-function createBrowserCloseTool(session: string): AgentTool<typeof BrowserCloseSchema> {
+function createBrowserCloseTool(shell: Shell, session: string): AgentTool<typeof BrowserCloseSchema> {
   return {
     name: "browser_close",
     label: "Browser Close",
     description: "Close the browser session. Profile data (cookies, login) is saved automatically.",
     parameters: BrowserCloseSchema,
     async execute(_id, _params, signal) {
-      const result = await execBrowserAsync(["close"], { session, signal });
+      const result = await execBrowserAsync(shell, ["close"], { session });
       return browserResult(result);
     },
   };
@@ -453,38 +427,38 @@ function createBrowserCloseTool(session: string): AgentTool<typeof BrowserCloseS
 
 const BrowserNavActionSchema = Type.Object({});
 
-function createBrowserBackTool(session: string, profileDir?: string): AgentTool<typeof BrowserNavActionSchema> {
+function createBrowserBackTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserNavActionSchema> {
   return {
     name: "browser_back",
     label: "Browser Back",
     description: "Navigate back in browser history.",
     parameters: BrowserNavActionSchema,
     async execute(_id, _params, signal) {
-      return browserResult(await execBrowserAsync(["back"], { session, profileDir, signal }));
+      return browserResult(await execBrowserAsync(shell, ["back"], { session, profileDir }));
     },
   };
 }
 
-function createBrowserForwardTool(session: string, profileDir?: string): AgentTool<typeof BrowserNavActionSchema> {
+function createBrowserForwardTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserNavActionSchema> {
   return {
     name: "browser_forward",
     label: "Browser Forward",
     description: "Navigate forward in browser history.",
     parameters: BrowserNavActionSchema,
     async execute(_id, _params, signal) {
-      return browserResult(await execBrowserAsync(["forward"], { session, profileDir, signal }));
+      return browserResult(await execBrowserAsync(shell, ["forward"], { session, profileDir }));
     },
   };
 }
 
-function createBrowserReloadTool(session: string, profileDir?: string): AgentTool<typeof BrowserNavActionSchema> {
+function createBrowserReloadTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserNavActionSchema> {
   return {
     name: "browser_reload",
     label: "Browser Reload",
     description: "Reload the current page.",
     parameters: BrowserNavActionSchema,
     async execute(_id, _params, signal) {
-      return browserResult(await execBrowserAsync(["reload"], { session, profileDir, signal }));
+      return browserResult(await execBrowserAsync(shell, ["reload"], { session, profileDir }));
     },
   };
 }
@@ -502,7 +476,7 @@ const BrowserTabsSchema = Type.Object({
   url: Type.Optional(Type.String({ description: "URL to open in new tab" })),
 });
 
-function createBrowserTabsTool(session: string, profileDir?: string): AgentTool<typeof BrowserTabsSchema> {
+function createBrowserTabsTool(shell: Shell, session: string, profileDir?: string): AgentTool<typeof BrowserTabsSchema> {
   return {
     name: "browser_tabs",
     label: "Browser Tabs",
@@ -525,7 +499,7 @@ function createBrowserTabsTool(session: string, profileDir?: string): AgentTool<
           if (params.index !== undefined) args.push(String(params.index));
           break;
       }
-      const result = await execBrowserAsync(args, { session, profileDir, signal });
+      const result = await execBrowserAsync(shell, args, { session, profileDir });
       return browserResult(result);
     },
   };
@@ -563,26 +537,28 @@ export function createBrowserTools(
   session: string = "default",
   allowedTools?: string[],
   profileDir?: string,
+  shell?: Shell,
 ): AgentTool<any>[] {
+  const _shell = shell ?? new NodeShell();
   const factories: Record<BrowserToolName, () => AgentTool<any>> = {
-    browser_navigate: () => createBrowserNavigateTool(session, profileDir),
-    browser_snapshot: () => createBrowserSnapshotTool(session, profileDir),
-    browser_click: () => createBrowserClickTool(session, profileDir),
-    browser_fill: () => createBrowserFillTool(session, profileDir),
-    browser_type: () => createBrowserTypeTool(session, profileDir),
-    browser_press: () => createBrowserPressTool(session, profileDir),
-    browser_screenshot: () => createBrowserScreenshotTool(session, cwd, profileDir),
-    browser_get: () => createBrowserGetTool(session, profileDir),
-    browser_select: () => createBrowserSelectTool(session, profileDir),
-    browser_hover: () => createBrowserHoverTool(session, profileDir),
-    browser_scroll: () => createBrowserScrollTool(session, profileDir),
-    browser_wait: () => createBrowserWaitTool(session, profileDir),
-    browser_eval: () => createBrowserEvalTool(session, profileDir),
-    browser_close: () => createBrowserCloseTool(session),
-    browser_back: () => createBrowserBackTool(session, profileDir),
-    browser_forward: () => createBrowserForwardTool(session, profileDir),
-    browser_reload: () => createBrowserReloadTool(session, profileDir),
-    browser_tabs: () => createBrowserTabsTool(session, profileDir),
+    browser_navigate: () => createBrowserNavigateTool(_shell, session, profileDir),
+    browser_snapshot: () => createBrowserSnapshotTool(_shell, session, profileDir),
+    browser_click: () => createBrowserClickTool(_shell, session, profileDir),
+    browser_fill: () => createBrowserFillTool(_shell, session, profileDir),
+    browser_type: () => createBrowserTypeTool(_shell, session, profileDir),
+    browser_press: () => createBrowserPressTool(_shell, session, profileDir),
+    browser_screenshot: () => createBrowserScreenshotTool(_shell, session, cwd, profileDir),
+    browser_get: () => createBrowserGetTool(_shell, session, profileDir),
+    browser_select: () => createBrowserSelectTool(_shell, session, profileDir),
+    browser_hover: () => createBrowserHoverTool(_shell, session, profileDir),
+    browser_scroll: () => createBrowserScrollTool(_shell, session, profileDir),
+    browser_wait: () => createBrowserWaitTool(_shell, session, profileDir),
+    browser_eval: () => createBrowserEvalTool(_shell, session, profileDir),
+    browser_close: () => createBrowserCloseTool(_shell, session),
+    browser_back: () => createBrowserBackTool(_shell, session, profileDir),
+    browser_forward: () => createBrowserForwardTool(_shell, session, profileDir),
+    browser_reload: () => createBrowserReloadTool(_shell, session, profileDir),
+    browser_tabs: () => createBrowserTabsTool(_shell, session, profileDir),
   };
 
   const names = allowedTools

--- a/packages/tools/src/system-tools.ts
+++ b/packages/tools/src/system-tools.ts
@@ -504,7 +504,7 @@ export async function createAllTools(options: CreateAllToolsOptions): Promise<Ag
 
   // Browser tools — activated when any browser_* tool is in allowedTools
   if (categoryRequested(ALL_BROWSER_TOOL_NAMES)) {
-    tools.push(...createBrowserTools(cwd, browserSession, allowedTools, options.browserProfileDir));
+    tools.push(...createBrowserTools(cwd, browserSession, allowedTools, options.browserProfileDir, options.shell));
   }
 
   // Email tools — activated when any email_* tool is in allowedTools
@@ -519,7 +519,7 @@ export async function createAllTools(options: CreateAllToolsOptions): Promise<Ag
 
   // Audio tools — activated when any audio_* tool is in allowedTools
   if (categoryRequested(ALL_AUDIO_TOOL_NAMES)) {
-    tools.push(...createAudioTools(cwd, allowedPaths, allowedTools, options.vault, options.fs));
+    tools.push(...createAudioTools(cwd, allowedPaths, allowedTools, options.vault, options.fs, options.shell));
   }
 
   // Excel tools — activated when any excel_* tool is in allowedTools


### PR DESCRIPTION
## Summary

`browser-tools` and `audio-tools`' edge-tts fallback shelled out to
`node:child_process` directly. That works in OSS standalone (CLIs on
the local PATH) and in the runner-in-sandbox path (CLIs baked into
the snapshot), but **breaks in cloud chat-completion**: the LLM loop
runs in the Koyeb worker, which has neither `agent-browser` nor
`edge-tts` installed. First `browser_navigate` call fails with:

```
Browser error: spawn agent-browser ENOENT
```

Audio fallback fails the same way.

Same pattern as the FS-abstraction refactor in #45 — route every CLI
call through the `Shell` port. `SandboxProxyShell` is already wired
in the cloud handler, so the spawn happens inside the project's
sandbox where the binaries actually live.

## Changes

- **browser-tools.ts**: dropped `child_process.spawn` / `execSync`.
  Single `execBrowserAsync(shell, args, opts)` helper that calls
  `shell.execute()`. All 18 tool factories now take `shell: Shell`
  as their first argument.
  AbortSignal propagation removed (the `Shell` port has no cancel
  primitive). Minor regression — can be added later when `Shell`
  grows a cancel API.
- **audio-tools.ts**: edge-tts CLI presence check and TTS writes go
  through `Shell`. `isEdgeTtsAvailable` is async with per-Shell
  caching via `WeakMap`. `speakEdgeTts` writes via the `FileSystem`
  port instead of `nodeFs.mkdirSync` / `statSync`. The
  `POLPO_DISABLE_EDGE_TTS` env opt-out is removed — it was only
  there to mask the worker-side check; no longer needed once the
  check runs in the right environment.
- **system-tools.ts**: thread `options.shell` to `createBrowserTools`
  and `createAudioTools` from `createAllTools`.

## Verification

Manual smoke test inside a fresh `polpo-runner-v6` sandbox via
`SandboxProxyShell`:

```
agent-browser navigate https://example.com  → success
agent-browser screenshot /tmp/smoke.png      → 16KB file written
agent-browser close                          → success
```

## Out of scope

`packages/tools/src/path-sandbox.ts` calls `realpathSync` directly,
which makes the anti-symlink check a no-op in the cloud worker
(silent fallback to logical-only). Tracked in memory, deferred —
Daytona's kernel sandbox covers the practical risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)