### PR TITLE
feat: canonical runner Dockerfile + Layer-2 smoke + GHCR publish

### DIFF
--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -51,19 +51,25 @@ jobs:
       # Buildx is needed for cache-from/cache-to type=gha.
       - uses: docker/setup-buildx-action@v3
 
-      # Pick a POLPO_VERSION:
-      # - tag push v0.7.0 → 0.7.0
-      # - main push       → "main"
-      # - PR              → the PR's head ref (just for the build label)
-      - name: Compute version
+      # `polpo_version` is the npm package version the Dockerfile
+      # installs INSIDE the image — must always be a published, real
+      # version. We read it from packages/core/package.json so it
+      # tracks main automatically.
+      #
+      # `image_tag` is the Docker tag we attach to the built image
+      # (separate concern from the npm version).
+      - name: Compute build inputs
         id: ver
         run: |
+          POLPO_VERSION=$(node -p "require('./packages/core/package.json').version")
+          echo "polpo_version=$POLPO_VERSION" >> "$GITHUB_OUTPUT"
+
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == refs/heads/main ]]; then
-            echo "version=main" >> "$GITHUB_OUTPUT"
+            echo "image_tag=main" >> "$GITHUB_OUTPUT"
           else
-            echo "version=pr-${{ github.event.pull_request.number || 'manual' }}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=pr-${{ github.event.pull_request.number || 'manual' }}" >> "$GITHUB_OUTPUT"
           fi
 
       # Build the image but DON'T push yet — we want smoke to pass first.
@@ -76,9 +82,9 @@ jobs:
           context: docker/runner
           file: docker/runner/Dockerfile
           load: true
-          tags: ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.image_tag }}
           build-args: |
-            POLPO_VERSION=${{ steps.ver.outputs.version == 'main' && '0.7.0' || steps.ver.outputs.version }}
+            POLPO_VERSION=${{ steps.ver.outputs.polpo_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -87,7 +93,7 @@ jobs:
           docker run --rm \
             -v "$PWD/docker/runner/tests:/tests:ro" \
             -w /home/daytona \
-            ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }} \
+            ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.image_tag }} \
             node /tests/runtime-smoke.mjs
 
       # Push only happens after smoke is green AND we're on main/tag.
@@ -107,10 +113,10 @@ jobs:
           file: docker/runner/Dockerfile
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}
+            ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.image_tag }}
             ${{ env.IMAGE_NAME }}:latest
           build-args: |
-            POLPO_VERSION=${{ steps.ver.outputs.version == 'main' && '0.7.0' || steps.ver.outputs.version }}
+            POLPO_VERSION=${{ steps.ver.outputs.polpo_version }}
           cache-from: type=gha
 
   # ─── Nightly: pull whatever is published on :latest and re-run

--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -1,0 +1,149 @@
+name: Runtime Smoke
+
+# Layer-2 tests for @polpo-ai/tools — they need the real runtime
+# binaries (Chromium, Playwright, edge-tts, mountpoint-s3, polpo-ai
+# npm) which Layer-1 vitest tests mock. We run them inside the
+# canonical runner image so this same workflow doubles as the
+# publish pipeline for ghcr.io/lumea-labs/polpo-runner.
+#
+# Per-PR        → build + smoke (no push)
+# Push to main  → build + smoke + push :main, :latest
+# Tag v*        → build + smoke + push :<version>, :latest
+# Manual run    → build + smoke (workflow_dispatch for debug)
+# Nightly       → smoke against the published :latest image (catches
+#                 transitive-dep / npm-published regressions even if
+#                 nobody opened a PR that day)
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - "docker/runner/**"
+      - ".github/workflows/runtime-smoke.yml"
+      - "packages/tools/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *" # 02:00 UTC daily
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/lumea-labs/polpo-runner
+
+jobs:
+  # ─── Build + smoke against the current branch's Dockerfile ───
+  # Skipped for the nightly schedule trigger — that path runs the
+  # published image instead, see `nightly-published` below.
+  build-and-smoke:
+    name: Build runner image + Layer-2 smoke
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      # Buildx is needed for cache-from/cache-to type=gha.
+      - uses: docker/setup-buildx-action@v3
+
+      # Pick a POLPO_VERSION:
+      # - tag push v0.7.0 → 0.7.0
+      # - main push       → "main"
+      # - PR              → the PR's head ref (just for the build label)
+      - name: Compute version
+        id: ver
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" == refs/heads/main ]]; then
+            echo "version=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=pr-${{ github.event.pull_request.number || 'manual' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Build the image but DON'T push yet — we want smoke to pass first.
+      # `load: true` puts the image into the local Docker daemon so we
+      # can `docker run` it in the next step.
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/runner
+          file: docker/runner/Dockerfile
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}
+          build-args: |
+            POLPO_VERSION=${{ steps.ver.outputs.version == 'main' && '0.7.0' || steps.ver.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Layer-2 smoke tests
+        run: |
+          docker run --rm \
+            -v "$PWD/docker/runner/tests:/tests:ro" \
+            -w /home/daytona \
+            ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }} \
+            node /tests/runtime-smoke.mjs
+
+      # Push only happens after smoke is green AND we're on main/tag.
+      - name: Login to GHCR
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to GHCR (main / tag only)
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/runner
+          file: docker/runner/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            POLPO_VERSION=${{ steps.ver.outputs.version == 'main' && '0.7.0' || steps.ver.outputs.version }}
+          cache-from: type=gha
+
+  # ─── Nightly: pull whatever is published on :latest and re-run
+  # the smoke tests against it. This catches regressions that come
+  # from outside the repo — e.g. a transitive dep upgrade in
+  # @polpo-ai/tools' optionalDependencies pulled in at build time —
+  # without us having to push anything new.
+  nightly-published:
+    name: Nightly smoke against published :latest
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: docker/runner/tests
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull published image
+        run: docker pull ${{ env.IMAGE_NAME }}:latest
+
+      - name: Run Layer-2 smoke tests
+        run: |
+          docker run --rm \
+            -v "$PWD/docker/runner/tests:/tests:ro" \
+            -w /home/daytona \
+            ${{ env.IMAGE_NAME }}:latest \
+            node /tests/runtime-smoke.mjs

--- a/docker/runner/.dockerignore
+++ b/docker/runner/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -1,0 +1,110 @@
+# Polpo Runner image — canonical source of truth.
+#
+# Translates the declarative `create-snapshot-v6.ts` (Daytona Image
+# SDK) into a real Dockerfile so we have a single artifact we can:
+#   - build & push to GHCR per release
+#   - use as base for the Daytona snapshot (Image.fromImage)
+#   - pull locally for the layer-2 test rig
+#   - hand to a future provider (Vercel Sandbox / Modal / Fly Machines)
+#
+# This image is the *runtime* sandbox where agent tools execute. It
+# is NOT the Polpo HTTP server — that one stays as the Koyeb deploy
+# (Node, no Docker needed there). Daytona pulls this image to spin
+# sandboxes; tools run via `docker exec` against an idle container,
+# so there's no ENTRYPOINT / CMD that auto-starts anything.
+
+FROM node:22-slim
+
+ARG POLPO_VERSION=0.7.0
+LABEL org.opencontainers.image.source="https://github.com/Lumea-Technologies/polpo-cloud" \
+      org.opencontainers.image.title="polpo-runner" \
+      org.opencontainers.image.description="Polpo agent sandbox runtime — Chromium, agent-browser, edge-tts, polpo-ai" \
+      org.opencontainers.image.version="${POLPO_VERSION}"
+
+# ─────────────────────────────────────────────────────────────
+# 1. System deps
+# ─────────────────────────────────────────────────────────────
+# Baseline tools + every shared library agent-browser's bundled
+# Chrome links against + poppler for pdf_read full-text extraction
+# + python for edge-tts + a few font packages so PDF/browser
+# rendering doesn't fall back to "Tofu" boxes for non-ASCII.
+#
+# The Chromium list MUST be exhaustive: `agent-browser install
+# --with-deps` shells to `sudo apt-get`, which doesn't exist in
+# node:22-slim, so the wrapped Playwright installer silently
+# no-ops. If a lib is missing here, Chrome dies at navigate-time
+# with `error while loading shared libraries: libXfoo.so.N` and
+# the sandbox is broken. Verified empirically inside a live v6
+# sandbox; this exact list is what made navigate + screenshot
+# work end-to-end.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        # Baseline
+        git curl ca-certificates fuse libfuse2 \
+        # PDF text extraction
+        poppler-utils \
+        # edge-tts runtime
+        python3 python3-pip \
+        # Chromium runtime libs (exhaustive — see comment above)
+        libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+        libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 \
+        libxss1 libasound2 libpangocairo-1.0-0 libpango-1.0-0 \
+        libcairo2 libwayland-client0 libxshmfence1 \
+        libxfixes3 libxext6 libxcursor1 libxi6 libxtst6 \
+        libxrender1 libxinerama1 libdbus-1-3 libatspi2.0-0 \
+        # Fonts so Chromium renders non-ASCII / emoji properly
+        fonts-liberation fonts-dejavu-core fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/*
+
+# ─────────────────────────────────────────────────────────────
+# 2. mountpoint-s3 (R2 / S3 FUSE mount)
+# ─────────────────────────────────────────────────────────────
+# The cloud sandbox pool mounts each project's R2 bucket at
+# /home/daytona/project via mountpoint-s3 at sandbox-acquire time.
+# The binary is harmless in a non-cloud context (self-hosters or
+# local test rigs simply don't invoke it) but cheap to keep here
+# for parity with the production image.
+RUN curl -sSL https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb \
+        -o /tmp/mount-s3.deb \
+    && dpkg -i /tmp/mount-s3.deb \
+    && rm /tmp/mount-s3.deb
+
+# ─────────────────────────────────────────────────────────────
+# 3. Edge TTS (free voice fallback for audio_speak)
+# ─────────────────────────────────────────────────────────────
+# --break-system-packages because slim is PEP-668-locked. We are
+# intentionally installing a single CLI tool globally.
+RUN pip install --break-system-packages edge-tts
+
+# ─────────────────────────────────────────────────────────────
+# 4. Polpo runtime (npm packages)
+# ─────────────────────────────────────────────────────────────
+# /home/daytona/project is the future mountpoint-s3 attach point,
+# so it must stay empty in the image. node_modules live one level
+# up at /home/daytona/node_modules. `--include=optional` makes
+# @polpo-ai/tools peer deps explicit (pdf-lib, exceljs, docx,
+# mammoth, nodemailer, imapflow, playwright-core, execa) regardless
+# of the consumer's npm config.
+WORKDIR /home/daytona
+RUN npm init -y \
+    && npm install --include=optional \
+        polpo-ai@${POLPO_VERSION} \
+        @polpo-ai/core@${POLPO_VERSION} \
+        @polpo-ai/drizzle@${POLPO_VERSION} \
+        @polpo-ai/tools@${POLPO_VERSION} \
+        postgres drizzle-orm
+
+# ─────────────────────────────────────────────────────────────
+# 5. Browser stack (agent-browser CLI + Chromium binary)
+# ─────────────────────────────────────────────────────────────
+# `install` (without --with-deps) just downloads the bundled
+# Chromium binary into ~/.agent-browser/browsers. We deliberately
+# do NOT use --with-deps: it shells to `sudo apt-get`, sudo isn't
+# available in node:22-slim, so it would silently do nothing
+# while making the build look successful. All the shared libs
+# Chrome needs are installed in step 1.
+RUN npm install -g agent-browser && agent-browser install
+
+# No ENTRYPOINT / CMD on purpose. Daytona keeps the container alive
+# externally and runs every tool call via `docker exec`. The local
+# test rig invokes specific commands explicitly (`docker run …
+# node /tests/runtime-smoke.mjs`).

--- a/docker/runner/README.md
+++ b/docker/runner/README.md
@@ -1,0 +1,80 @@
+# Polpo Runner Image
+
+Canonical source of truth for the Polpo agent **sandbox runtime**.
+This is the filesystem every Daytona sandbox boots into; it is also
+what the local layer-2 test rig pulls.
+
+It is **not** the Polpo HTTP server (that one is the Koyeb deploy,
+no Docker needed there).
+
+## What's inside
+
+| Layer | Purpose |
+|---|---|
+| `node:22-slim` | Base |
+| apt baseline | git/curl/ca-certs/fuse |
+| apt Chromium libs | exhaustive list — every `.so` agent-browser's bundled Chrome links against |
+| apt extras | poppler (pdf_read full text), python3 (edge-tts), fonts |
+| `mountpoint-s3` | R2 FUSE mount (used by cloud sandbox pool) |
+| `edge-tts` (pip) | free TTS fallback for `audio_speak` |
+| `polpo-ai@VERSION` (npm) | the runtime + tool packages |
+| `agent-browser` (npm global) + Chromium | browser_* tools + pdf_create driver |
+
+No `ENTRYPOINT` / `CMD`. Daytona keeps the container alive externally
+and runs every tool call via `docker exec`. The local test rig invokes
+specific commands explicitly.
+
+## Build
+
+```bash
+# From the cloud repo root:
+docker build \
+  --build-arg POLPO_VERSION=0.7.0 \
+  -t ghcr.io/lumea-labs/polpo-runner:0.7.0 \
+  -t ghcr.io/lumea-labs/polpo-runner:latest \
+  docker/runner
+```
+
+`POLPO_VERSION` defaults to the value baked into the Dockerfile but
+should be overridden at build time so each release of `polpo-ai` on
+npm gets a matching image tag.
+
+## Push (manual, until CI is wired)
+
+```bash
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <username> --password-stdin
+docker push ghcr.io/lumea-labs/polpo-runner:0.7.0
+docker push ghcr.io/lumea-labs/polpo-runner:latest
+```
+
+## Use as Daytona snapshot base
+
+Replace the imperative `Image.base("node:22-slim").runCommands(...)`
+in `packages/server/scripts/create-snapshot-v6.ts` with:
+
+```ts
+const image = Image.fromImage(`ghcr.io/lumea-labs/polpo-runner:${POLPO_VERSION}`);
+```
+
+Snapshot creation collapses from ~5 min of apt+npm+download to ~30 s
+of registry pull.
+
+## Use locally for layer-2 tests
+
+```bash
+docker pull ghcr.io/lumea-labs/polpo-runner:0.7.0
+docker run --rm \
+  -v "$(pwd)/tests:/tests:ro" \
+  ghcr.io/lumea-labs/polpo-runner:0.7.0 \
+  node /tests/runtime-smoke.mjs
+```
+
+## Versioning
+
+Tag matches the `polpo-ai` npm release. When OSS publishes a new
+`v0.6.X`, this image is rebuilt with `--build-arg POLPO_VERSION=0.6.X`
+and pushed as `:0.6.X` + `:latest`.
+
+The `:latest` tag tracks the most recent build but should not be
+used in production sandbox config — pin a specific version on
+Daytona's `DAYTONA_SNAPSHOT_IMAGE` env var.

--- a/docker/runner/tests/runtime-smoke.mjs
+++ b/docker/runner/tests/runtime-smoke.mjs
@@ -1,0 +1,573 @@
+#!/usr/bin/env node
+/**
+ * Layer-2 smoke for the Polpo runner image — paranoid edition.
+ *
+ * Covers every tool that needs a real binary:
+ *   - pdf_create               → Chromium via the @polpo-ai/tools driver
+ *   - all 18 browser_* tools   → agent-browser CLI + Chromium
+ *   - audio_speak (edge)       → edge-tts CLI
+ *
+ * Run inside the runner image:
+ *   docker run --rm \
+ *     -v $PWD/docker/runner/tests:/tests:ro \
+ *     -w /home/daytona \
+ *     polpo-runner:0.6.32 \
+ *     node /tests/runtime-smoke.mjs
+ *
+ * The framework on purpose stays minimal — the image doesn't ship
+ * vitest. Each case is an async function with explicit assertions;
+ * failures collect and don't short-circuit the rest of the run.
+ *
+ * Exit 0 if everything passes, 1 otherwise. CI can rely on this.
+ */
+import { mkdtempSync, mkdirSync, rmSync, existsSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Run inside /home/daytona so the staged pdf-render driver script can
+// `import("playwright-core")` — Node walks up looking for node_modules,
+// and playwright-core lives at /home/daytona/node_modules. /tmp would
+// break that resolution.
+const SMOKE_ROOT = "/home/daytona/.smoke";
+mkdirSync(SMOKE_ROOT, { recursive: true });
+const CWD = mkdtempSync(join(SMOKE_ROOT, "run-"));
+process.chdir(CWD);
+
+let mod;
+try {
+  mod = await import("@polpo-ai/tools");
+} catch {
+  mod = await import("/home/daytona/node_modules/@polpo-ai/tools/dist/index.js");
+}
+const { createAllTools, NodeFileSystem, NodeShell } = mod;
+
+const vault = {
+  get: () => undefined, getSmtp: () => undefined, getImap: () => undefined,
+  getKey: () => undefined, has: () => false, list: () => [],
+};
+
+const tools = await createAllTools({
+  cwd: CWD,
+  allowedPaths: [CWD],
+  allowedTools: ["*"],
+  vault,
+  fs: new NodeFileSystem(),
+  shell: new NodeShell(),
+  outputDir: CWD,
+});
+
+function pick(name) {
+  const t = tools.find((x) => x.name === name);
+  if (!t) throw new Error(`Tool '${name}' not registered`);
+  return t;
+}
+function textOf(result) {
+  const block = result?.content?.[0];
+  return block?.type === "text" ? (block.text ?? "") : "";
+}
+function detailsOf(result) {
+  return result?.details ?? {};
+}
+function assertOk(result, label) {
+  if (!result) throw new Error(`${label}: no result`);
+  const errKey = result.details?.error;
+  if (errKey) throw new Error(`${label}: ${JSON.stringify(result.details).slice(0, 300)}`);
+}
+function assertFail(result, label) {
+  // Either a structured error in details OR text indicating failure.
+  const blob = (textOf(result) + JSON.stringify(detailsOf(result))).toLowerCase();
+  if (!result.details?.error && !/error|fail|not found|invalid|denied|timeout/.test(blob)) {
+    throw new Error(`${label}: expected failure but got ${blob.slice(0, 200)}`);
+  }
+}
+function approx(actual, expected, tol = 2) {
+  return Math.abs(actual - expected) <= tol;
+}
+
+// ─── HTML fixture for browser interactions ─────────────────
+// Self-contained page with every element type the browser tools need
+// to exercise: form, button, links, select, textarea, scrollable
+// region, anchor for back/forward.
+const FIXTURE_HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Polpo Smoke Fixture</title>
+<style>
+  body { font-family: sans-serif; padding: 1em; }
+  #spacer { height: 2000px; background: linear-gradient(#fff, #ccc); }
+  #target { padding: 1em; background: #ffd; }
+</style></head>
+<body>
+  <h1 id="title">Polpo Smoke Fixture</h1>
+  <p id="intro">Intro text for browser_get.</p>
+
+  <form id="form">
+    <label>Name <input id="name" type="text" placeholder="your name"></label>
+    <label>Bio  <textarea id="bio" rows="3"></textarea></label>
+    <label>Plan <select id="plan">
+      <option value="free">Free</option>
+      <option value="pro">Pro</option>
+      <option value="enterprise">Enterprise</option>
+    </select></label>
+    <button id="submit" type="button" onclick="document.getElementById('result').textContent='submitted'">Submit</button>
+  </form>
+  <div id="result"></div>
+
+  <a id="link-page2" href="page2.html">Go to page 2</a>
+  <div id="hover-target" onmouseover="this.dataset.hovered='yes'">Hover me</div>
+
+  <div id="spacer"></div>
+  <div id="target">Bottom target</div>
+</body></html>`;
+
+const FIXTURE_PAGE2 = `<!doctype html>
+<html><head><title>Page 2</title></head>
+<body><h1 id="title">Page Two</h1></body></html>`;
+
+writeFileSync(join(CWD, "fixture.html"), FIXTURE_HTML);
+writeFileSync(join(CWD, "page2.html"), FIXTURE_PAGE2);
+const FIXTURE_URL = `file://${join(CWD, "fixture.html")}`;
+const PAGE2_URL = `file://${join(CWD, "page2.html")}`;
+
+// ─── case registry ─────────────────────────────────────────
+const cases = [];
+function suite(name, fn) { cases.push({ name, fn }); }
+
+// ════════════════════════════════════════════════════════════
+// PDF_CREATE — happy + paranoid
+// ════════════════════════════════════════════════════════════
+suite("pdf_create — default A4 portrait", async () => {
+  const t = pick("pdf_create");
+  const r = await t.execute("c", { html: "<h1>hi</h1>", path: "p1.pdf" });
+  assertOk(r, "pdf_create");
+  if (statSync(join(CWD, "p1.pdf")).size < 500) throw new Error("pdf too small");
+});
+
+suite("pdf_create — Letter landscape", async () => {
+  const t = pick("pdf_create");
+  const r = await t.execute("c", { html: "<h1>hi</h1>", path: "p2.pdf", format: "Letter", landscape: true });
+  assertOk(r, "pdf_create");
+  // Verify dimensions via pdf-lib (in /home/daytona/node_modules,
+  // not in this script's sibling tree, so we import by absolute path).
+  const { PDFDocument } = await import("/home/daytona/node_modules/pdf-lib/cjs/index.js");
+  const doc = await PDFDocument.load(readFileSync(join(CWD, "p2.pdf")));
+  const { width, height } = doc.getPage(0).getSize();
+  // Letter portrait = 612×792, landscape rotates → 792×612.
+  if (!approx(width, 792) || !approx(height, 612)) {
+    throw new Error(`Letter landscape wrong dims: ${width}×${height}`);
+  }
+});
+
+suite("pdf_create — header + footer template", async () => {
+  const t = pick("pdf_create");
+  const r = await t.execute("c", {
+    html: "<h1>Body</h1>",
+    path: "p3.pdf",
+    header_template: '<div style="font-size:8px">HEADER</div>',
+    footer_template: '<div style="font-size:8px">PG <span class="pageNumber"></span></div>',
+  });
+  assertOk(r, "pdf_create");
+});
+
+suite("pdf_create — custom margins (0mm)", async () => {
+  const t = pick("pdf_create");
+  const r = await t.execute("c", {
+    html: "<h1>Edge to edge</h1>",
+    path: "p4.pdf",
+    margin: { top: "0mm", right: "0mm", bottom: "0mm", left: "0mm" },
+  });
+  assertOk(r, "pdf_create");
+});
+
+suite("pdf_create — scale extremes (0.5 and 2.0)", async () => {
+  const t = pick("pdf_create");
+  const a = await t.execute("c", { html: "<h1>tiny</h1>", path: "p5a.pdf", scale: 0.5 });
+  const b = await t.execute("c", { html: "<h1>HUGE</h1>", path: "p5b.pdf", scale: 2.0 });
+  assertOk(a, "pdf_create scale 0.5");
+  assertOk(b, "pdf_create scale 2.0");
+});
+
+suite("pdf_create — non-ASCII content (CJK + RTL + emoji)", async () => {
+  const t = pick("pdf_create");
+  const r = await t.execute("c", {
+    html: `<!doctype html><html><body>
+      <p>Latin café</p><p>CJK 你好世界</p>
+      <p>RTL שלום עולם</p><p>Emoji 🐙🚀</p>
+    </body></html>`,
+    path: "p6.pdf",
+  });
+  assertOk(r, "pdf_create");
+});
+
+suite("pdf_create — html_path (read from file)", async () => {
+  writeFileSync(join(CWD, "src.html"), "<h1>From file</h1>");
+  const t = pick("pdf_create");
+  const r = await t.execute("c", { html_path: "src.html", path: "p7.pdf" });
+  assertOk(r, "pdf_create");
+});
+
+suite("pdf_create — wait_for_network=false (no external fetch)", async () => {
+  const t = pick("pdf_create");
+  const r = await t.execute("c", {
+    html: "<h1>offline</h1>",
+    path: "p8.pdf",
+    wait_for_network: false,
+  });
+  assertOk(r, "pdf_create");
+});
+
+suite("pdf_create — 200KB inline HTML doesn't crash the renderer", async () => {
+  const filler = "<p>" + "x ".repeat(40_000) + "</p>";
+  const t = pick("pdf_create");
+  const r = await t.execute("c", { html: `<html><body>${filler}</body></html>`, path: "p9.pdf" });
+  assertOk(r, "pdf_create big html");
+  if (statSync(join(CWD, "p9.pdf")).size < 1000) throw new Error("pdf too small");
+});
+
+suite("pdf_create — refuses output outside the sandbox", async () => {
+  const t = pick("pdf_create");
+  let threw = false;
+  try { await t.execute("c", { html: "<h1>x</h1>", path: "/etc/escape.pdf" }); }
+  catch { threw = true; }
+  if (!threw) throw new Error("expected sandbox rejection");
+});
+
+suite("pdf_create — refuses missing both html and html_path", async () => {
+  const t = pick("pdf_create");
+  const r = await t.execute("c", { path: "p11.pdf" });
+  assertFail(r, "pdf_create no source");
+});
+
+// ════════════════════════════════════════════════════════════
+// BROWSER_* — all 18 tools, happy path + paranoid
+// Browser tools share a single agent-browser session, so order
+// matters: navigate first, mutate, snapshot, query, then close.
+// ════════════════════════════════════════════════════════════
+suite("browser_navigate — local fixture", async () => {
+  const r = await pick("browser_navigate").execute("c", { url: FIXTURE_URL });
+  assertOk(r, "browser_navigate");
+});
+
+suite("browser_get — title", async () => {
+  const r = await pick("browser_get").execute("c", { what: "title" });
+  assertOk(r, "browser_get title");
+  if (!textOf(r).includes("Polpo Smoke Fixture")) throw new Error("title not found");
+});
+
+suite("browser_get — html of a specific element", async () => {
+  const r = await pick("browser_get").execute("c", { what: "html", selector: "#title" });
+  assertOk(r, "browser_get html");
+  if (!textOf(r).includes("Polpo Smoke Fixture")) throw new Error("html missing title");
+});
+
+suite("browser_get — text of a missing selector reports error cleanly", async () => {
+  const r = await pick("browser_get").execute("c", { what: "text", selector: "#nope-does-not-exist" });
+  assertFail(r, "browser_get missing");
+});
+
+suite("browser_snapshot — accessibility tree includes form fields", async () => {
+  const r = await pick("browser_snapshot").execute("c", {});
+  assertOk(r, "browser_snapshot");
+  const out = textOf(r).toLowerCase();
+  // Snapshot should reference at least the form / inputs we placed.
+  if (!/input|button|select|textarea|name|plan|submit/.test(out)) {
+    throw new Error("snapshot missing form elements");
+  }
+});
+
+suite("browser_snapshot — interactive_only filter", async () => {
+  const r = await pick("browser_snapshot").execute("c", { interactive_only: true });
+  assertOk(r, "browser_snapshot interactive");
+});
+
+suite("browser_fill — sets a text input value", async () => {
+  const r = await pick("browser_fill").execute("c", { selector: "#name", text: "Alice" });
+  assertOk(r, "browser_fill");
+  // Verify via a subsequent get.
+  const v = await pick("browser_get").execute("c", { what: "value", selector: "#name" });
+  if (!textOf(v).includes("Alice")) throw new Error("fill didn't persist");
+});
+
+suite("browser_fill — overwrites previous value (no append)", async () => {
+  await pick("browser_fill").execute("c", { selector: "#name", text: "Bob" });
+  const v = await pick("browser_get").execute("c", { what: "value", selector: "#name" });
+  const out = textOf(v);
+  if (out.includes("Alice") || !out.includes("Bob")) {
+    throw new Error("fill should clear before setting; got: " + out.slice(0, 120));
+  }
+});
+
+suite("browser_fill — handles unicode (RTL + CJK)", async () => {
+  await pick("browser_fill").execute("c", { selector: "#name", text: "你好 שלום 🚀" });
+  const v = await pick("browser_get").execute("c", { what: "value", selector: "#name" });
+  if (!textOf(v).includes("你好")) throw new Error("unicode dropped");
+});
+
+suite("browser_fill — non-existent selector reports error", async () => {
+  const r = await pick("browser_fill").execute("c", { selector: "#nope", text: "x" });
+  assertFail(r, "browser_fill missing");
+});
+
+suite("browser_type — appends to existing value", async () => {
+  // type() does keystroke-style input; reset first via fill.
+  await pick("browser_fill").execute("c", { selector: "#bio", text: "hello " });
+  const r = await pick("browser_type").execute("c", { selector: "#bio", text: "world" });
+  assertOk(r, "browser_type");
+  const v = await pick("browser_get").execute("c", { what: "value", selector: "#bio" });
+  const out = textOf(v);
+  if (!out.includes("hello") || !out.includes("world")) {
+    throw new Error("type result missing expected content: " + out.slice(0, 120));
+  }
+});
+
+suite("browser_press — Tab key shifts focus", async () => {
+  await pick("browser_navigate").execute("c", { url: FIXTURE_URL });
+  await pick("browser_fill").execute("c", { selector: "#name", text: "x" });
+  const r = await pick("browser_press").execute("c", { key: "Tab" });
+  assertOk(r, "browser_press");
+});
+
+suite("browser_select — picks an option by value", async () => {
+  const r = await pick("browser_select").execute("c", { selector: "#plan", value: "pro" });
+  assertOk(r, "browser_select");
+  const v = await pick("browser_get").execute("c", { what: "value", selector: "#plan" });
+  if (!textOf(v).includes("pro")) throw new Error("select didn't apply");
+});
+
+suite("browser_hover — fires onmouseover handler", async () => {
+  const r = await pick("browser_hover").execute("c", { selector: "#hover-target" });
+  assertOk(r, "browser_hover");
+  // Verify via the side-effect attribute the page sets onmouseover.
+  const ev = await pick("browser_eval").execute("c", {
+    javascript: `document.getElementById('hover-target').dataset.hovered ?? ''`,
+  });
+  if (!textOf(ev).toLowerCase().includes("yes")) {
+    throw new Error("hover handler didn't fire; eval returned: " + textOf(ev).slice(0, 120));
+  }
+});
+
+suite("browser_click — triggers handler that updates the DOM", async () => {
+  const r = await pick("browser_click").execute("c", { selector: "#submit" });
+  assertOk(r, "browser_click");
+  const out = await pick("browser_get").execute("c", { what: "text", selector: "#result" });
+  if (!textOf(out).includes("submitted")) {
+    throw new Error("click didn't fire handler; #result text: " + textOf(out).slice(0, 120));
+  }
+});
+
+suite("browser_click — non-existent selector reports error", async () => {
+  const r = await pick("browser_click").execute("c", { selector: "#nope-button" });
+  assertFail(r, "browser_click missing");
+});
+
+suite("browser_scroll — scrolls down by 800px", async () => {
+  const r = await pick("browser_scroll").execute("c", { direction: "down", pixels: 800 });
+  assertOk(r, "browser_scroll");
+});
+
+suite("browser_wait — waits for a selector that exists", async () => {
+  const r = await pick("browser_wait").execute("c", { selector: "#title", timeout: 5000 });
+  assertOk(r, "browser_wait");
+});
+
+suite("browser_wait — selector that never appears times out cleanly", async () => {
+  const r = await pick("browser_wait").execute("c", { selector: "#never-shown", timeout: 1500 });
+  // Either a structured error or a clean timeout message.
+  assertFail(r, "browser_wait timeout");
+});
+
+suite("browser_eval — returns serialized result", async () => {
+  const r = await pick("browser_eval").execute("c", { javascript: `1 + 2 + 3` });
+  assertOk(r, "browser_eval");
+  if (!textOf(r).includes("6")) throw new Error("eval result missing 6");
+});
+
+suite("browser_eval — DOM query via evaluate", async () => {
+  const r = await pick("browser_eval").execute("c", { javascript: `document.querySelectorAll('label').length` });
+  assertOk(r, "browser_eval dom");
+  if (!/[1-9]/.test(textOf(r))) throw new Error("expected positive label count");
+});
+
+suite("browser_screenshot — non-empty PNG with magic bytes", async () => {
+  const r = await pick("browser_screenshot").execute("c", { path: "shot.png" });
+  assertOk(r, "browser_screenshot");
+  const head = readFileSync(join(CWD, "shot.png")).subarray(0, 8);
+  if (head[0] !== 0x89 || head[1] !== 0x50 || head[2] !== 0x4e || head[3] !== 0x47) {
+    throw new Error(`not a PNG: ${head.toString("hex")}`);
+  }
+  if (statSync(join(CWD, "shot.png")).size < 1000) throw new Error("png too small");
+});
+
+suite("browser_screenshot — full_page captures more bytes than viewport", async () => {
+  const partial = await pick("browser_screenshot").execute("c", { path: "shot-partial.png" });
+  assertOk(partial, "browser_screenshot partial");
+  const full = await pick("browser_screenshot").execute("c", { path: "shot-full.png", full_page: true });
+  assertOk(full, "browser_screenshot full");
+  // The fixture has a 2000px tall #spacer, so full_page must be
+  // strictly bigger than the viewport screenshot.
+  const partialBytes = statSync(join(CWD, "shot-partial.png")).size;
+  const fullBytes = statSync(join(CWD, "shot-full.png")).size;
+  if (fullBytes <= partialBytes) {
+    throw new Error(`full_page should be larger; partial=${partialBytes} full=${fullBytes}`);
+  }
+});
+
+suite("browser_back / forward — preserves navigation history", async () => {
+  // Build a clean two-page history inside this test, independent of
+  // whatever happened earlier in the run. Use URL (not title) as the
+  // truth signal: it's the deterministic outcome of navigate, no race
+  // with page-load-completion timing.
+  await pick("browser_navigate").execute("c", { url: FIXTURE_URL });
+  await pick("browser_navigate").execute("c", { url: PAGE2_URL });
+
+  let url = textOf(await pick("browser_get").execute("c", { what: "url" }));
+  if (!url.includes("page2")) throw new Error(`expected page2 URL, got: ${url.slice(0, 200)}`);
+
+  assertOk(await pick("browser_back").execute("c", {}), "browser_back");
+  url = textOf(await pick("browser_get").execute("c", { what: "url" }));
+  if (!url.includes("fixture")) throw new Error(`back didn't return to fixture; URL: ${url.slice(0, 200)}`);
+
+  assertOk(await pick("browser_forward").execute("c", {}), "browser_forward");
+  url = textOf(await pick("browser_get").execute("c", { what: "url" }));
+  if (!url.includes("page2")) throw new Error(`forward didn't reach page2; URL: ${url.slice(0, 200)}`);
+});
+
+suite("browser_reload — same URL, fresh DOM state", async () => {
+  await pick("browser_navigate").execute("c", { url: FIXTURE_URL });
+  // Mutate the DOM.
+  await pick("browser_eval").execute("c", { javascript: `document.title = 'Mutated';` });
+  let title = await pick("browser_get").execute("c", { what: "title" });
+  if (!textOf(title).includes("Mutated")) throw new Error("eval mutation failed");
+  // Reload; mutation should be gone.
+  const rl = await pick("browser_reload").execute("c", {});
+  assertOk(rl, "browser_reload");
+  title = await pick("browser_get").execute("c", { what: "title" });
+  if (!textOf(title).includes("Polpo Smoke Fixture")) {
+    throw new Error("reload didn't restore original title; got: " + textOf(title).slice(0, 120));
+  }
+});
+
+suite("browser_tabs — lists currently open tabs", async () => {
+  const r = await pick("browser_tabs").execute("c", {});
+  assertOk(r, "browser_tabs");
+  // Output should mention either the title or URL of the open page.
+  const out = textOf(r).toLowerCase();
+  if (!out.includes("polpo") && !out.includes("fixture") && !out.includes("file://")) {
+    throw new Error("tabs missing current page reference: " + out.slice(0, 200));
+  }
+});
+
+suite("browser_navigate — invalid scheme reports error", async () => {
+  // file:/// is fine, but a clearly broken URL should fail cleanly.
+  const r = await pick("browser_navigate").execute("c", { url: "not-a-url://garbage" });
+  assertFail(r, "browser_navigate bad scheme");
+});
+
+suite("browser_close — releases the session cleanly", async () => {
+  const r = await pick("browser_close").execute("c", {});
+  assertOk(r, "browser_close");
+});
+
+// ════════════════════════════════════════════════════════════
+// AUDIO_SPEAK (edge-tts) — happy + paranoid
+// ════════════════════════════════════════════════════════════
+function isAudioFile(buf) {
+  // ID3 tag OR MPEG sync bytes.
+  return (buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33)
+      || (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0);
+}
+
+suite("audio_speak — edge with default voice", async () => {
+  const r = await pick("audio_speak").execute("c", {
+    text: "Default voice smoke test.",
+    path: "audio-default.mp3",
+    model: "edge/edge-tts",
+  });
+  assertOk(r, "audio_speak default");
+  const head = readFileSync(join(CWD, "audio-default.mp3")).subarray(0, 3);
+  if (!isAudioFile(head)) throw new Error(`not an audio file: ${head.toString("hex")}`);
+});
+
+suite("audio_speak — explicit voice (en-US-AriaNeural)", async () => {
+  const r = await pick("audio_speak").execute("c", {
+    text: "Explicit voice smoke.",
+    path: "audio-aria.mp3",
+    model: "edge/edge-tts",
+    voice: "en-US-AriaNeural",
+  });
+  assertOk(r, "audio_speak aria");
+  if (statSync(join(CWD, "audio-aria.mp3")).size < 1000) throw new Error("audio too small");
+});
+
+suite("audio_speak — non-ASCII text (Italian + emoji)", async () => {
+  const r = await pick("audio_speak").execute("c", {
+    text: "Buongiorno mondo, è bello qui ☀️",
+    path: "audio-it.mp3",
+    model: "edge/edge-tts",
+    language: "it",
+  });
+  assertOk(r, "audio_speak italian");
+});
+
+suite("audio_speak — long text (~500 chars) doesn't truncate the file", async () => {
+  const long = "A medium length sentence for the smoke test. ".repeat(12);
+  const r = await pick("audio_speak").execute("c", {
+    text: long,
+    path: "audio-long.mp3",
+    model: "edge/edge-tts",
+  });
+  assertOk(r, "audio_speak long");
+  // Long text → at least 5KB of audio.
+  if (statSync(join(CWD, "audio-long.mp3")).size < 5000) {
+    throw new Error("long audio truncated");
+  }
+});
+
+suite("audio_speak — invalid voice name reports error", async () => {
+  const r = await pick("audio_speak").execute("c", {
+    text: "won't speak",
+    path: "audio-bad-voice.mp3",
+    model: "edge/edge-tts",
+    voice: "xx-XX-NonExistentNeural",
+  });
+  // Either rejects or returns a structured error. Pin "no crash, no
+  // valid mp3 produced".
+  if (existsSync(join(CWD, "audio-bad-voice.mp3"))) {
+    const head = readFileSync(join(CWD, "audio-bad-voice.mp3")).subarray(0, 3);
+    if (isAudioFile(head)) throw new Error("non-existent voice unexpectedly produced audio");
+  }
+});
+
+suite("audio_speak — refuses output outside the sandbox", async () => {
+  let threw = false;
+  try {
+    await pick("audio_speak").execute("c", {
+      text: "x", path: "/etc/escape.mp3", model: "edge/edge-tts",
+    });
+  } catch { threw = true; }
+  if (!threw) throw new Error("expected sandbox rejection");
+});
+
+// ════════════════════════════════════════════════════════════
+// runner
+// ════════════════════════════════════════════════════════════
+let pass = 0, fail = 0;
+const failed = [];
+for (const c of cases) {
+  const t0 = Date.now();
+  try {
+    await c.fn();
+    const ms = Date.now() - t0;
+    pass++;
+    console.log(`OK   ${c.name.padEnd(60)} ${ms.toString().padStart(5)}ms`);
+  } catch (err) {
+    const ms = Date.now() - t0;
+    fail++;
+    failed.push({ name: c.name, err: err.message ?? String(err) });
+    console.log(`FAIL ${c.name.padEnd(60)} ${ms.toString().padStart(5)}ms`);
+    console.log(`     ${err.message ?? err}`);
+  }
+}
+
+console.log();
+console.log(`=== ${pass} OK, ${fail} FAIL ===`);
+
+try { rmSync(CWD, { recursive: true, force: true }); } catch {}
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary

Brings the polpo-runner image source-of-truth into OSS. Until now the Dockerfile and 45 Layer-2 smoke tests lived in the cloud repo, which meant:
- OSS contributors couldn't run the runtime tests
- OSS CI couldn't validate the runtime against the published npm packages
- Cloud CI was rebuilding the image even though all the code being tested is OSS

## What's in this PR

**`docker/runner/`** (moved verbatim from cloud working tree, bumped to 0.7.0, GHCR namespace fixed to \`lumea-labs\`):
- \`Dockerfile\` — \`node:22-slim\` base + apt baseline (Chromium libs, poppler, python3, fonts) + mountpoint-s3 + edge-tts + polpo-ai npm + agent-browser. ~1.58 GB built.
- \`tests/runtime-smoke.mjs\` — **45 paranoid Layer-2 tests**: pdf_create × 11, browser_* × 28, audio_speak (edge) × 6. Smoke tests updated to the post-#54 agent-config API (\`model: "edge/edge-tts"\` instead of the removed \`provider: "edge"\`).
- \`README.md\` + \`.dockerignore\`

**`.github/workflows/runtime-smoke.yml`** — new workflow that doubles as test runner + publish pipeline:
| Trigger | What it does |
|---|---|
| Per-PR (paths: \`docker/runner/**\` or \`packages/tools/**\`) | build + smoke (no push) |
| Push to \`main\` | build + smoke + push \`:main\` + \`:latest\` |
| Tag \`v*\` | build + smoke + push \`:<version>\` + \`:latest\` |
| \`workflow_dispatch\` | manual run for debug |
| Nightly cron 02:00 UTC | pull published \`:latest\` + run smoke (catches transitive-dep regressions when nobody opened a PR) |

Caching via \`cache-from/cache-to: type=gha\` so warm CI runs land in 2-4 min.

## Validated locally

- \`docker build -t polpo-runner:0.7.0-local --build-arg POLPO_VERSION=0.7.0 docker/runner/\` → clean
- \`docker run --rm -v "\$PWD/docker/runner/tests:/tests:ro" -w /home/daytona polpo-runner:0.7.0-local node /tests/runtime-smoke.mjs\` → **45/45 OK**
- Image consumes \`@polpo-ai/tools@0.7.0\` from the just-published v0.7.0 release

## Test plan

- [x] Local build + smoke green
- [ ] CI \`runtime-smoke\` job green on this PR (build + smoke, no push)
- [ ] After merge: \`runtime-smoke\` on main publishes \`ghcr.io/lumea-labs/polpo-runner:main\` + \`:latest\`
- [ ] Verify \`ghcr.io/lumea-labs/polpo-runner\` packages page shows the published tags
- [ ] Cloud follow-up PR: remove its local \`docker/runner/\` working tree, point sandbox at \`ghcr.io/lumea-labs/polpo-runner:0.7.0\`

## Why this matters

- Layer-2 in OSS CI = regressions in browser/pdf/audio tools caught at PR time, not weeks later when cloud rebuilds
- Single runtime image artifact for OSS users who want to self-host with the same environment as Polpo Cloud
- Cloud becomes a thin consumer (pulls a published image) instead of a duplicated build pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)