### PR TITLE
feat(server): extraAiTools for provider-executed tools (0.7.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -513,11 +513,19 @@ export interface CompletionRouteDeps {
   buildAgentPrompt: (agentConfig: any) => string | Promise<string>;
   /** Create tools + executor for the agent. Return empty arrays for chat-only.
    *  Optional `cleanup` is invoked once the response finishes — used to close
-   *  long-lived resources like MCP transports. */
+   *  long-lived resources like MCP transports.
+   *
+   *  `extraAiTools` is an escape hatch for tools already in AI SDK shape that
+   *  should be merged into the LLM's tool palette as-is (no Polpo conversion,
+   *  no manual execution). Used by cloud to inject Vercel Gateway provider
+   *  tools (e.g. `gateway.tools.perplexitySearch`) which are server-executed
+   *  by the gateway during `generateText` — Polpo never sees the tool-call.
+   *  The keys here MUST NOT collide with names in `tools`. */
   resolveAgentTools: (agentConfig: any) => Promise<{
     tools: any[];
     executor: (name: string, args: Record<string, unknown>) => Promise<string>;
     cleanup?: () => Promise<void>;
+    extraAiTools?: Record<string, any>;
   }>;
   /** Called after each completion finishes (streaming or non-streaming). Receives usage, model info, and provider metadata. Fire-and-forget — errors are silently ignored. */
   onCompletionFinished?: (info: {
@@ -566,6 +574,13 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
     let providerOpts: Record<string, any> | undefined;
     let effectiveTools: any[];
     let effectiveToolExecutor: (name: string, args: Record<string, unknown>) => Promise<string>;
+    /**
+     * Provider-executed tools the host wants merged into the AI SDK tool
+     * palette as-is. Polpo never invokes these — they're handled inside
+     * `generateText` by the SDK / model provider (Vercel Gateway today).
+     * Keys here MUST be skipped by the manual tool-call dispatcher.
+     */
+    let extraAiTools: Record<string, any> | undefined;
     let isInteractiveFn: ((name: string) => boolean) | undefined;
     /**
      * Resource cleanup hook — set when an agent's tool resolver opens
@@ -620,10 +635,11 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
       providerOpts = resolved.providerOptions;
 
       // Resolve tools via dep
-      const { tools, executor, cleanup } = await deps.resolveAgentTools(agentConfig);
-      effectiveTools = tools;
-      effectiveToolExecutor = executor;
-      onResponseFinished = cleanup;
+      const resolvedTools = await deps.resolveAgentTools(agentConfig);
+      effectiveTools = resolvedTools.tools;
+      effectiveToolExecutor = resolvedTools.executor;
+      onResponseFinished = resolvedTools.cleanup;
+      extraAiTools = resolvedTools.extraAiTools;
     } else {
       // ── Orchestrator mode (default) ──
       if (!deps.resolveOrchestratorContext) {
@@ -677,10 +693,16 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
       c.header("x-session-id", sessionId);
     }
 
-    // Convert Polpo tools to AI SDK format (no execute — manual execution)
-    // Client-side tools (ask_user_question, etc.) are added on top — they stop
-    // the server loop and return to the client as standard tool_calls.
-    const aiTools = { ...toAITools(effectiveTools), ...CLIENT_SIDE_TOOLS };
+    // Convert Polpo tools to AI SDK format (no execute — manual execution).
+    // Client-side tools (ask_user_question, etc.) stop the server loop and
+    // return to the client as standard tool_calls.
+    // `extraAiTools` are provider-executed (e.g. Vercel Gateway native
+    // tools) — already in AI SDK shape, must NOT be Polpo-converted.
+    const aiTools = {
+      ...toAITools(effectiveTools),
+      ...(extraAiTools ?? {}),
+      ...CLIENT_SIDE_TOOLS,
+    };
 
     if (body.stream) {
       // ── Streaming mode ──
@@ -940,11 +962,37 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
               return; // finally block will persist whatever finalText we have
             }
 
+            // Provider tools (extraAiTools) are executed by the SDK / gateway
+            // inside generateText itself — their results are already on
+            // `result.toolResults`. Skip them in our manual dispatcher; just
+            // forward the result message into history for the next turn.
+            const providerToolNames = new Set(Object.keys(extraAiTools ?? {}));
+            const providerToolResults = new Map<string, any>();
+            try {
+              const settled = (await (result as any).toolResults) as any[] | undefined;
+              for (const tr of settled ?? []) providerToolResults.set(tr.toolCallId, tr);
+            } catch { /* best effort */ }
+
             for (const call of toolCalls) {
               // Stop executing tools if client disconnected
               if (abortController.signal.aborted) break;
 
               const callArgs = call.input as Record<string, unknown>;
+
+              if (providerToolNames.has(call.toolName)) {
+                const tr = providerToolResults.get(call.toolCallId);
+                const value = tr?.output ?? tr?.result ?? null;
+                messages.push({
+                  role: "tool",
+                  content: [{
+                    type: "tool-result",
+                    toolCallId: call.toolCallId,
+                    toolName: call.toolName,
+                    output: { type: "json" as const, value },
+                  }],
+                });
+                continue;
+              }
 
               // Notify client that a tool is being called
               await stream.writeSSE({
@@ -1279,8 +1327,33 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
             // Note: finally block persists finalText + toolCallsAccum
           }
 
+          // Provider tools (extraAiTools) are executed by the SDK / gateway
+          // inside generateText itself — their results are already on
+          // `genResult.toolResults`. Skip them in the manual dispatcher.
+          const providerToolNames = new Set(Object.keys(extraAiTools ?? {}));
+          const providerToolResults = new Map<string, any>();
+          for (const tr of (genResult.toolResults as any[] | undefined) ?? []) {
+            providerToolResults.set(tr.toolCallId, tr);
+          }
+
           for (const call of toolCalls) {
             const callArgs = call.input as Record<string, unknown>;
+
+            if (providerToolNames.has(call.toolName)) {
+              const tr = providerToolResults.get(call.toolCallId);
+              const value = tr?.output ?? tr?.result ?? null;
+              messages.push({
+                role: "tool",
+                content: [{
+                  type: "tool-result",
+                  toolCallId: call.toolCallId,
+                  toolName: call.toolName,
+                  output: { type: "json" as const, value },
+                }],
+              });
+              continue;
+            }
+
             const result = await effectiveToolExecutor(call.toolName, callArgs);
             const isError = result.startsWith("Error:");
             emitFileChanged(call.toolName, callArgs, result, deps.emit);

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Add an optional \`extraAiTools\` field to \`CompletionRouteDeps.resolveAgentTools\` for tools that are already in AI SDK shape and get executed by the model provider, not by Polpo.

The motivating use case is **Vercel AI Gateway native tools** (\`gateway.tools.perplexitySearch\`, etc.). These are *provider tools* — declarative descriptors whose execution happens server-side at the gateway when an LLM calls them during \`generateText\`. They have no client-side \`execute()\` function (it's undefined by design). The cloud previously tried to wrap them in Polpo's \`SearchProvider\` port, which assumes a callable HTTP client; that crashed in production with \`tool.execute is not a function\`.

This PR adds the right plumbing in OSS server. Cloud will follow with a one-liner change to inject the gateway tool when an agent has \`web_search\` enabled, deleting the broken \`GatewayPerplexitySearchProvider\` entirely.

## Surface area

- New optional field on \`CompletionRouteDeps.resolveAgentTools\` return type:
  \`\`\`ts
  extraAiTools?: Record<string, any>
  \`\`\`
- Merged into the AI SDK tool palette right after Polpo-converted tools, before client-side tools.
- Manual tool-call dispatcher (both streaming and non-streaming) skips names present in \`extraAiTools\` and reads the result from \`genResult.toolResults\` to push the tool-result message into conversation history.

## Backward compatibility

Hosts that don't set the field see no change — \`extraAiTools ?? {}\` collapses to a no-op spread.

## Test plan

- [x] \`pnpm --filter @polpo-ai/server build\` clean
- [x] All vault tests still pass (\`vitest -t \"Vault API\"\`)
- [ ] CI green
- [ ] After merge: cloud PR uses this field, web_search via gateway works end-to-end

## What this is NOT

- Not a runtime check on \"am I in cloud\". The cloud handler decides whether to populate \`extraAiTools\` (it imports \`@ai-sdk/gateway\`); OSS standalone leaves it \`undefined\`. The dual implementation already exists on \`resolveAgentTools\` itself.
- Not a SearchProvider replacement. OSS \`SearchProvider\` (Exa, Tavily future) keeps working unchanged for callable HTTP-backed search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)