### PR TITLE
fix(cli): deploy PATCH + default agent allowedTools

### DIFF
--- a/packages/cli/src/commands/cloud/api.ts
+++ b/packages/cli/src/commands/cloud/api.ts
@@ -17,6 +17,7 @@ export interface ApiClient {
   get<T = unknown>(path: string): Promise<ApiResponse<T>>;
   post<T = unknown>(path: string, body?: unknown): Promise<ApiResponse<T>>;
   put<T = unknown>(path: string, body?: unknown): Promise<ApiResponse<T>>;
+  patch<T = unknown>(path: string, body?: unknown): Promise<ApiResponse<T>>;
   delete<T = unknown>(path: string): Promise<ApiResponse<T>>;
 }
 
@@ -66,6 +67,8 @@ export function createApiClient(credentials: Credentials, projectId?: string): A
       request<T>("POST", path, body),
     put: <T = unknown>(path: string, body?: unknown) =>
       request<T>("PUT", path, body),
+    patch: <T = unknown>(path: string, body?: unknown) =>
+      request<T>("PATCH", path, body),
     delete: <T = unknown>(path: string) => request<T>("DELETE", path),
   };
 }

--- a/packages/cli/src/commands/cloud/deploy.ts
+++ b/packages/cli/src/commands/cloud/deploy.ts
@@ -122,8 +122,9 @@ async function deployTeams(client: ApiClient, polpoDir: string, opts: ConflictOp
     }
 
     if (remote) {
-      // Update existing
-      const res = await client.put(`/v1/agents/team`, { name: team.name, description: team.description });
+      // Update existing — server exposes PATCH /v1/agents/team (rename + describe),
+      // not PUT. Using PUT here would 404 ("Resource not found") on the server side.
+      const res = await client.patch(`/v1/agents/team`, { name: team.name, description: team.description });
       if (res.status >= 200 && res.status < 300) { result.updated++; }
       else {
         const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
@@ -187,7 +188,9 @@ async function deployAgents(client: ApiClient, polpoDir: string, opts: ConflictO
     }
 
     if (remote) {
-      const res = await client.put(`/v1/agents/${encodeURIComponent(agent.name)}`, { ...agent, team: teamName });
+      // Update existing — server exposes PATCH /v1/agents/{name}, not PUT.
+      // Using PUT here would 404 ("Resource not found") on the server side.
+      const res = await client.patch(`/v1/agents/${encodeURIComponent(agent.name)}`, { ...agent, team: teamName });
       if (res.status >= 200 && res.status < 300) { result.updated++; }
       else {
         const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;

--- a/packages/cli/src/util/template.ts
+++ b/packages/cli/src/util/template.ts
@@ -109,6 +109,18 @@ export function writeBlankScaffold(targetDir: string, projectName: string): void
             name: "agent-1",
             role: "helpful assistant",
             model: "xai/grok-4-fast",
+            // Mirror the cloud onboarding default — the bare set of tools that
+            // covers "I want to do useful stuff" without overwhelming a brand-new
+            // agent. Users can add browser_*, email_*, doc_*, etc. as needed.
+            allowedTools: [
+              "bash",
+              "read",
+              "write",
+              "edit",
+              "glob",
+              "grep",
+              "http_fetch",
+            ],
           },
           teamName: "default",
         },


### PR DESCRIPTION
## Bugs fixed

### 1. \`polpo deploy\` 404s on every update path

\`\`\`
▲  Errors:
│    × team \"default\": Resource not found.
│    × agent \"agent-1\": update failed — Resource not found.
└  Deployed with errors: 2 failed
\`\`\`

Root cause: the CLI called \`PUT /v1/agents/{name}\` and \`PUT /v1/agents/team\` for updates, but the server only exposes \`PATCH\` on those routes (\`agents.ts:434\` and \`agents.ts:330\` — no PUT handler). Hono routes match on \`method:path\`, so the PUT requests dropped to the default 404, which the CLI's \`friendlyError\` translates to \"Resource not found.\"

**Fix**: added \`patch()\` to \`ApiClient\` (interface + implementation), switched both deploy update call sites from PUT to PATCH.

### 2. Default agent has no \`allowedTools\`

\`polpo create\` scaffolded \`agents.json\` with no \`allowedTools\` field, leaving the seeded \`agent-1\` stuck on the core palette (no \`http_fetch\`, no extended categories). The cloud onboarding wizard already preselects a sensible base (\`bash\`, \`read\`, \`write\`, \`edit\`, \`glob\`, \`grep\`, \`http_fetch\`) — the CLI now mirrors that so first-deploy UX is consistent across both surfaces.

## Out of scope

Memory tools (\`memory_get\`, \`memory_save\`, \`memory_append\`, \`memory_update\`) are missing from \`TOOL_CATALOG\` and not wired into \`createAllTools\` — validation rejects them in \`allowedTools\` even though the implementation exists. Handled in a separate PR because it requires extending \`createAllTools({...})\` to accept \`memoryStore\` + \`agentName\` and threading them through the cloud data-plane handler.

## Test plan

- [x] \`pnpm --filter @polpo-ai/cli build\` clean
- [ ] \`polpo create foo && cd foo && polpo deploy\` — first deploy succeeds (creates team + agent)
- [ ] Edit \`.polpo/agents.json\` (change role) → \`polpo deploy\` again — update succeeds (no 404)
- [ ] First deploy ships agent with \`allowedTools: [bash, read, write, edit, glob, grep, http_fetch]\` visible in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)