### PR TITLE
fix: default model bump to grok-4.1-fast-non-reasoning + friendly 404 on model_not_found (0.7.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/src/util/template.ts
+++ b/packages/cli/src/util/template.ts
@@ -108,7 +108,7 @@ export function writeBlankScaffold(targetDir: string, projectName: string): void
           agent: {
             name: "agent-1",
             role: "helpful assistant",
-            model: "xai/grok-4-fast",
+            model: "xai/grok-4.1-fast-non-reasoning",
             // Mirror the cloud onboarding default — the bare set of tools that
             // covers "I want to do useful stuff" without overwhelming a brand-new
             // agent. Users can add browser_*, email_*, doc_*, etc. as needed.

--- a/packages/cli/tests/template.test.ts
+++ b/packages/cli/tests/template.test.ts
@@ -122,7 +122,7 @@ describe("writeBlankScaffold", () => {
     expect(agents[0].teamName).toBe("default");
     expect(agents[0].agent.name).toBe("agent-1");
     expect(agents[0].agent.role).toBe("helpful assistant");
-    expect(agents[0].agent.model).toBe("xai/grok-4-fast");
+    expect(agents[0].agent.model).toBe("xai/grok-4.1-fast-non-reasoning");
   });
 
   it("writes .env.local.example with POLPO_API_KEY placeholder", () => {

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -381,6 +381,43 @@ function buildSummarizeFn(
   };
 }
 
+/**
+ * Detect Vercel AI Gateway "model not found" errors so callers see a
+ * clean 400 (with the offending model id + agent name) instead of a
+ * generic 500 surfaced by Hono's default error handler.
+ *
+ * Triggers on:
+ *   - `GatewayModelNotFoundError` constructor name from `@ai-sdk/gateway`
+ *   - any 404 response whose body mentions `model_not_found` (covers
+ *     custom gateways that don't ship the typed error class)
+ *
+ * Returns the error envelope to send back, or null if the error isn't a
+ * model-not-found and should propagate untouched.
+ */
+function modelNotFoundEnvelope(
+  err: unknown,
+  fallbackModelId: string | undefined,
+  agent: string | undefined,
+): { message: string; type: "model_not_found"; param: { modelId: string; agent?: string } } | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as any;
+  const isGatewayNotFound =
+    e.name === "GatewayModelNotFoundError" ||
+    e.constructor?.name === "GatewayModelNotFoundError" ||
+    (e.statusCode === 404 &&
+      typeof e.responseBody === "string" &&
+      e.responseBody.includes("model_not_found"));
+  if (!isGatewayNotFound) return null;
+  const modelId: string = e.modelId ?? fallbackModelId ?? "unknown";
+  return {
+    message:
+      `Model "${modelId}" is not available on the gateway. ` +
+      `It may have been renamed or deprecated — update the agent config (or the orchestrator default).`,
+    type: "model_not_found",
+    param: { modelId, ...(agent ? { agent } : {}) },
+  };
+}
+
 function completionResponse(id: string, content: string, usage: LanguageModelUsage) {
   return {
     id,
@@ -1059,8 +1096,21 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
           }
         } catch (err) {
           // Suppress AbortError — expected when client disconnects
-          if (!(err instanceof DOMException && err.name === "AbortError") && !abortController.signal.aborted) {
-            throw err;
+          if ((err instanceof DOMException && err.name === "AbortError") || abortController.signal.aborted) {
+            // fall through to finally — no SSE error event needed
+          } else {
+            // Friendly model_not_found surface — gateway returns 404 for
+            // renamed/deprecated SKUs (e.g. xai/grok-4-fast after the 4.1
+            // rename). Without this catch the error propagates as a 500.
+            const notFound = modelNotFoundEnvelope(err, m?.id, body.agent);
+            if (notFound) {
+              await stream.writeSSE({
+                data: sseChunk(completionId, {}, "stop", { error: notFound }),
+              });
+              await stream.writeSSE({ data: "[DONE]" });
+            } else {
+              throw err;
+            }
           }
         } finally {
           clearInterval(heartbeatInterval);
@@ -1399,6 +1449,15 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
         }
 
         return c.json(completionResponse(completionId, finalText, totalUsage));
+      } catch (err) {
+        // Friendly model_not_found surface — gateway returns 404 for
+        // renamed/deprecated SKUs (e.g. xai/grok-4-fast after the 4.1
+        // rename). Without this catch the error propagates as a 500.
+        const notFound = modelNotFoundEnvelope(err, m?.id, body.agent);
+        if (notFound) {
+          return c.json({ error: notFound }, 400 as any);
+        }
+        throw err;
       } finally {
         // Always persist the final text + tool calls — even on early return (ask_user) or error
         // SECURITY: Redact vault credentials before persisting to SQLite

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

\`xai/grok-4-fast\` returns 404 \`model_not_found\` from Vercel AI Gateway after the xAI 4.1 rename. Two changes:

1. **Bump the hard-coded default** in \`polpo create\`'s scaffold + its test → \`xai/grok-4.1-fast-non-reasoning\` (drop-in successor, verified live against \`https://ai-gateway.vercel.sh/v1/models\`).

2. **Friendly error on gateway model_not_found** — Layer 1 of the model-deprecation roadmap. Detects the typed \`GatewayModelNotFoundError\` (or any 404 with \`model_not_found\` in the body) and returns a clean envelope:

   \`\`\`json
   { \"error\": { \"type\": \"model_not_found\", \"message\": \"Model X is not available...\", \"param\": { \"modelId\", \"agent\" } } }
   \`\`\`

   Wired into both streaming (final SSE chunk + \`[DONE]\`) and non-streaming (400 JSON) completion paths. The dashboard can now render \"Update agent config\" instead of bare \"Internal server error\".

Layers 2 (validate model at agent-create time) and 3 (alias map for legacy slugs) are NTH — added separately when needed.

## Test plan

- [x] \`pnpm --filter @polpo-ai/cli build\` clean
- [x] \`pnpm --filter @polpo-ai/server build\` clean
- [ ] CI: \`vitest\` template + completions tests
- [ ] After merge → tag v0.7.5 → npm publish → cloud lockfile bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)