### PR TITLE
fix(cli): kill deploy crashes + flickering spinner + always-differs prompts (0.7.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/src/commands/cloud/deploy.ts
+++ b/packages/cli/src/commands/cloud/deploy.ts
@@ -86,6 +86,19 @@ function listJsonFiles(dir: string): string[] {
   return fs.readdirSync(dir).filter(f => f.endsWith(".json")).map(f => path.join(dir, f));
 }
 
+/**
+ * Extract the most useful error string from an API response body, regardless
+ * of whether the server returned `{ error: "string" }`, `{ error: { ... } }`,
+ * `{ error: [issue, …] }`, or nothing. Falls back to "HTTP <status>" so
+ * downstream consumers (friendlyError) always get a non-empty input.
+ */
+function readErrorBody(body: unknown, status: number): unknown {
+  const err = (body as { error?: unknown } | null)?.error;
+  if (typeof err === "string" && err.length > 0) return err;
+  if (err && typeof err === "object") return err;
+  return `HTTP ${status}`;
+}
+
 // ── Core deployers ──────────────────────────────────────
 
 async function deployTeams(client: ApiClient, polpoDir: string, opts: ConflictOptions): Promise<DeployResult> {
@@ -127,7 +140,7 @@ async function deployTeams(client: ApiClient, polpoDir: string, opts: ConflictOp
       const res = await client.patch(`/v1/agents/team`, { name: team.name, description: team.description });
       if (res.status >= 200 && res.status < 300) { result.updated++; }
       else {
-        const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+        const msg = readErrorBody(res.data, res.status);
         result.errors.push(`team "${team.name}": ${friendlyError(msg)}`);
         result.failed++;
       }
@@ -135,7 +148,7 @@ async function deployTeams(client: ApiClient, polpoDir: string, opts: ConflictOp
       const res = await client.post("/v1/agents/teams", local);
       if (res.status >= 200 && res.status < 300) { result.created++; }
       else {
-        const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+        const msg = readErrorBody(res.data, res.status);
         result.errors.push(`team "${team.name}": ${friendlyError(msg)}`);
         result.failed++;
       }
@@ -193,7 +206,7 @@ async function deployAgents(client: ApiClient, polpoDir: string, opts: ConflictO
       const res = await client.patch(`/v1/agents/${encodeURIComponent(agent.name)}`, { ...agent, team: teamName });
       if (res.status >= 200 && res.status < 300) { result.updated++; }
       else {
-        const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+        const msg = readErrorBody(res.data, res.status);
         result.errors.push(`agent "${agent.name}": update failed — ${friendlyError(msg)}`);
         result.failed++;
       }
@@ -201,7 +214,7 @@ async function deployAgents(client: ApiClient, polpoDir: string, opts: ConflictO
       const res = await client.post("/v1/agents", { ...agent, team: teamName });
       if (res.status >= 200 && res.status < 300) { result.created++; }
       else {
-        const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+        const msg = readErrorBody(res.data, res.status);
         result.errors.push(`agent "${agent.name}": create failed — ${friendlyError(msg)}`);
         result.failed++;
       }
@@ -218,14 +231,15 @@ async function deployMemory(client: ApiClient, polpoDir: string, opts: ConflictO
     let remoteShared: string | null = null;
     try {
       const r = await client.get<any>("/v1/memory");
-      if (r.status === 200) remoteShared = r.data?.content ?? null;
+      // Server returns { ok, data: { exists, content } } — unwrap both layers.
+      if (r.status === 200) remoteShared = r.data?.data?.content ?? r.data?.content ?? null;
     } catch {}
 
     const action = await resolveDeployConflict(shared, remoteShared, "shared memory", opts);
     if (action === "write") {
       const res = await client.put("/v1/memory", { content: shared });
       if (res.status >= 200 && res.status < 300) { result.updated++; }
-      else { result.errors.push(`memory: ${friendlyError((res.data as any)?.error ?? `HTTP ${res.status}`)}`); result.failed++; }
+      else { result.errors.push(`memory: ${friendlyError(readErrorBody(res.data, res.status))}`); result.failed++; }
     } else {
       result.skipped++;
     }
@@ -240,14 +254,14 @@ async function deployMemory(client: ApiClient, polpoDir: string, opts: ConflictO
         let remoteAgent: string | null = null;
         try {
           const r = await client.get<any>(`/v1/memory/agent/${agentName}`);
-          if (r.status === 200) remoteAgent = r.data?.content ?? null;
+          if (r.status === 200) remoteAgent = r.data?.data?.content ?? r.data?.content ?? null;
         } catch {}
 
         const action = await resolveDeployConflict(content, remoteAgent, `memory "${agentName}"`, opts);
         if (action === "write") {
           const res = await client.put(`/v1/memory/agent/${agentName}`, { content });
           if (res.status >= 200 && res.status < 300) { result.updated++; }
-          else { result.errors.push(`memory "${agentName}": ${friendlyError((res.data as any)?.error ?? `HTTP ${res.status}`)}`); result.failed++; }
+          else { result.errors.push(`memory "${agentName}": ${friendlyError(readErrorBody(res.data, res.status))}`); result.failed++; }
         } else {
           result.skipped++;
         }
@@ -274,7 +288,7 @@ async function deployMissions(client: ApiClient, polpoDir: string): Promise<Depl
     });
     if (res.status >= 200 && res.status < 300) { result.created++; }
     else {
-      const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+      const msg = readErrorBody(res.data, res.status);
       result.errors.push(`mission "${mission.name ?? path.basename(file)}": ${friendlyError(msg)}`);
       result.failed++;
     }
@@ -299,7 +313,7 @@ async function deployPlaybooks(client: ApiClient, polpoDir: string): Promise<Dep
     });
     if (res.status >= 200 && res.status < 300) { result.created++; }
     else {
-      const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+      const msg = readErrorBody(res.data, res.status);
       result.errors.push(`playbook "${entry.name}": ${friendlyError(msg)}`);
       result.failed++;
     }
@@ -363,15 +377,27 @@ async function deploySkills(client: ApiClient, polpoDir: string, opts: ConflictO
       continue;
     }
 
+    // The server doesn't expose `PUT /v1/skills/{name}` for in-place updates —
+    // only POST /v1/skills/create + DELETE /v1/skills/{name} exist. So
+    // "update existing skill" is implemented as delete-then-recreate. The
+    // DELETE failure is logged but we still try the create: if it succeeds
+    // the user ends up with a fresh copy, which is the intent.
     if (remote) {
-      const updateRes = await client.put(`/v1/skills/${encodeURIComponent(name)}`, {
-        description, content,
+      const delRes = await client.delete(`/v1/skills/${encodeURIComponent(name)}`);
+      if (delRes.status >= 400 && delRes.status !== 404) {
+        const msg = readErrorBody(delRes.data, delRes.status);
+        result.errors.push(`skill "${name}": delete-before-update failed — ${friendlyError(msg)}`);
+        result.failed++;
+        continue;
+      }
+      const res = await client.post("/v1/skills/create", {
+        name, description, content,
         ...(allowedTools?.length ? { allowedTools } : {}),
       });
-      if (updateRes.status >= 200 && updateRes.status < 300) { result.updated++; }
+      if (res.status >= 200 && res.status < 300) { result.updated++; }
       else {
-        const msg = (updateRes.data as any)?.error ?? `HTTP ${updateRes.status}`;
-        result.errors.push(`skill "${name}": ${friendlyError(msg)}`);
+        const msg = readErrorBody(res.data, res.status);
+        result.errors.push(`skill "${name}": recreate failed — ${friendlyError(msg)}`);
         result.failed++;
       }
     } else {
@@ -381,7 +407,7 @@ async function deploySkills(client: ApiClient, polpoDir: string, opts: ConflictO
       });
       if (res.status >= 200 && res.status < 300) { result.created++; }
       else {
-        const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+        const msg = readErrorBody(res.data, res.status);
         result.errors.push(`skill "${name}": ${friendlyError(msg)}`);
         result.failed++;
       }
@@ -423,7 +449,7 @@ async function deployVault(client: ApiClient, polpoDir: string): Promise<DeployR
       });
       if (res.status >= 200 && res.status < 300) { result.created++; }
       else {
-        const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+        const msg = readErrorBody(res.data, res.status);
         result.errors.push(`vault "${agent}/${service}": ${friendlyError(msg)}`);
         result.failed++;
       }
@@ -481,7 +507,7 @@ async function deploySchedules(client: ApiClient, polpoDir: string): Promise<Dep
     const res = await client.post("/v1/schedules", schedule);
     if (res.status >= 200 && res.status < 300) { result.created++; }
     else {
-      const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+      const msg = readErrorBody(res.data, res.status);
       result.errors.push(`schedule "${schedule.name ?? path.basename(file)}": ${friendlyError(msg)}`);
       result.failed++;
     }
@@ -506,7 +532,7 @@ async function deployTasks(client: ApiClient, polpoDir: string): Promise<DeployR
     });
     if (res.status >= 200 && res.status < 300) { result.created++; }
     else {
-      const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+      const msg = readErrorBody(res.data, res.status);
       result.errors.push(`task "${task.title ?? path.basename(file)}": ${friendlyError(msg)}`);
       result.failed++;
     }
@@ -544,7 +570,7 @@ async function deploySessions(client: ApiClient, polpoDir: string): Promise<Depl
     const res = await client.post("/v1/chat/sessions/import", { title, agent, messages });
     if (res.status >= 200 && res.status < 300) { result.created++; }
     else {
-      const msg = (res.data as any)?.error ?? `HTTP ${res.status}`;
+      const msg = readErrorBody(res.data, res.status);
       result.errors.push(`session "${title ?? file}": ${friendlyError(msg)}`);
       result.failed++;
     }
@@ -778,27 +804,47 @@ export async function runDeploy(opts: DeployOptions): Promise<DeployReport> {
 
       // ── Step 4: Deploy each resource ────────────────────
       const total = emptyResult();
-      const conflictOpts: ConflictOptions = { force, interactive };
+
+      // Track the current spinner label so the conflict-resolver can pause
+      // the spinner before a `clack.confirm` (otherwise the spinner keeps
+      // animating on top of the prompt → flicker + invisible question)
+      // and resume it after the user answers.
+      let activeSpinnerLabel: string | null = null;
+      const conflictOpts: ConflictOptions = {
+        force,
+        interactive,
+        beforePrompt: () => { if (activeSpinnerLabel) s.stop(""); },
+        afterPrompt:  () => { if (activeSpinnerLabel) s.start(activeSpinnerLabel); },
+      };
+
+      const startSpinner = (label: string) => {
+        activeSpinnerLabel = label;
+        s.start(label);
+      };
+      const stopSpinner = (final: string) => {
+        activeSpinnerLabel = null;
+        s.stop(final);
+      };
 
       if (hasTeams) {
-        s.start("Deploying teams...");
+        startSpinner("Deploying teams...");
         const r = await deployTeams(client, polpoDir, conflictOpts);
         mergeResult(total, r);
-        s.stop(`Teams: ${r.created} created, ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
+        stopSpinner(`Teams: ${r.created} created, ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
       }
 
       if (hasAgents) {
-        s.start("Deploying agents...");
+        startSpinner("Deploying agents...");
         const r = await deployAgents(client, polpoDir, conflictOpts);
         mergeResult(total, r);
-        s.stop(`Agents: ${r.created} created, ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
+        stopSpinner(`Agents: ${r.created} created, ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
       }
 
       if (hasMemory) {
-        s.start("Deploying memory...");
+        startSpinner("Deploying memory...");
         const r = await deployMemory(client, polpoDir, conflictOpts);
         mergeResult(total, r);
-        s.stop(`Memory: ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
+        stopSpinner(`Memory: ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
       }
 
       if (hasMissions) {
@@ -816,10 +862,10 @@ export async function runDeploy(opts: DeployOptions): Promise<DeployReport> {
       }
 
       if (hasSkills) {
-        s.start("Deploying skills...");
+        startSpinner("Deploying skills...");
         const r = await deploySkills(client, polpoDir, conflictOpts);
         mergeResult(total, r);
-        s.stop(`Skills: ${r.created} created, ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
+        stopSpinner(`Skills: ${r.created} created, ${r.updated} updated${r.skipped ? `, ${r.skipped} skipped` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
       }
 
       if (hasSchedules) {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -66,7 +66,7 @@ export function registerCreateCommand(program: Command): void {
     .option("--api-url <url>", "Override the API base URL (self-hosted, custom domain, dev)")
     .option(
       "--scenario <id>",
-      `Seed demo data: none | ${SCENARIOS.map((s) => s.id).join(" | ")}`,
+      `Seed example data: none | ${SCENARIOS.map((s) => s.id).join(" | ")}`,
       "",
     )
     .option("--skills <scope>", "Coding-agent skills install: global | project | skip", "")
@@ -141,7 +141,7 @@ export function registerCreateCommand(program: Command): void {
       }
 
       // Step 4b: Scenario (blank template only — remote templates ship their
-      // own .polpo/ scaffold). User can opt into seeded demo data: agent +
+      // own .polpo/ scaffold). User can opt into seeded example data: agent +
       // project/agent memory + a single draft task + a multi-step draft mission.
       // Default: none (single empty agent, legacy behavior).
       let scenario: Scenario | undefined;
@@ -160,7 +160,7 @@ export function registerCreateCommand(program: Command): void {
           }
         } else if (!opts.yes) {
           const choice = await clack.select<string>({
-            message: "Seed demo data? (project memory + draft task + multi-step draft mission)",
+            message: "Seed example data? (project memory + draft task + multi-step draft mission)",
             options: [
               { value: "none", label: "No — single empty agent", hint: "current default" },
               ...SCENARIOS.map((s) => ({ value: s.id, label: `Yes — ${s.label}`, hint: s.hint })),
@@ -512,7 +512,8 @@ export function registerCreateCommand(program: Command): void {
         lines.push(`    ${pc.bold(`curl $POLPO_URL/v1/chat/completions \\`)}`);
         lines.push(`      ${pc.bold(`-H "Authorization: Bearer $POLPO_API_KEY" \\`)}`);
         lines.push(`      ${pc.bold(`-H "Content-Type: application/json" \\`)}`);
-        lines.push(`      ${pc.bold(`-d '{"agent":"agent-1","stream":true,"messages":[{"role":"user","content":"Hello"}]}'`)}`);
+        const exampleAgent = scenario?.agent.name ?? "agent-1";
+        lines.push(`      ${pc.bold(`-d '{"agent":"${exampleAgent}","stream":true,"messages":[{"role":"user","content":"Hello"}]}'`)}`);
         lines.push("");
       }
 

--- a/packages/cli/src/util/conflicts.ts
+++ b/packages/cli/src/util/conflicts.ts
@@ -14,10 +14,19 @@ import * as fs from "node:fs";
 import * as clack from "@clack/prompts";
 
 export interface ConflictOptions {
-  /** --force / --yes: always override without asking. */
+  /** --force: always override without asking. */
   force: boolean;
   /** TTY present: can prompt the user. */
   interactive: boolean;
+  /**
+   * Called just before a user prompt fires. Lets the caller stop any active
+   * spinner so the prompt isn't drawn on top of "Deploying X…" (clack draws
+   * both on the same row otherwise → flicker, prompt invisible).
+   * Called only when the conflict actually triggers a prompt.
+   */
+  beforePrompt?: () => void;
+  /** Called after the user has answered, so the caller can restart its spinner. */
+  afterPrompt?: () => void;
 }
 
 export type ConflictAction = "write" | "skip";
@@ -79,18 +88,27 @@ export async function resolveJsonConflict(
  * - Remote is null/undefined → "write" (doesn't exist yet, create)
  * - Data identical → "skip" (no change needed)
  * - Data differs → same force/interactive/skip logic
+ *
+ * The optional `compareKeys` argument lets the caller specify exactly which
+ * fields to diff. Without it, a denylist of server-managed fields (id,
+ * timestamps, etc.) is stripped from both sides so a remote that carries
+ * extra metadata doesn't trigger false-positive "differs" prompts. Without
+ * this guard every existing resource looks "different" and the user gets
+ * spammed with prompts (or, worse, in non-TTY non-force mode every existing
+ * resource is silently skipped).
  */
 export async function resolveDeployConflict(
   localData: unknown,
   remoteData: unknown | null | undefined,
   label: string,
   opts: ConflictOptions,
+  compareKeys?: string[],
 ): Promise<ConflictAction> {
   if (remoteData == null) return "write";
 
-  if (JSON.stringify(normalize(localData)) === JSON.stringify(normalize(remoteData))) {
-    return "skip";
-  }
+  const a = compareKeys ? project(localData, compareKeys) : strip(normalize(localData));
+  const b = compareKeys ? project(remoteData, compareKeys) : strip(normalize(remoteData));
+  if (stableStringify(a) === stableStringify(b)) return "skip";
 
   return resolveConflictPrompt(`${label} differs from cloud version. Push local?`, opts);
 }
@@ -104,21 +122,89 @@ async function resolveConflictPrompt(
   if (opts.force) return "write";
 
   if (opts.interactive) {
-    const answer = await clack.confirm({
-      message,
-      initialValue: true,
-    });
-    if (clack.isCancel(answer) || !answer) return "skip";
-    return "write";
+    opts.beforePrompt?.();
+    try {
+      const answer = await clack.confirm({
+        message,
+        initialValue: true,
+      });
+      if (clack.isCancel(answer) || !answer) return "skip";
+      return "write";
+    } finally {
+      opts.afterPrompt?.();
+    }
   }
 
-  return "skip";
+  // Non-interactive, non-force: default to WRITE so CI/scripted deploys
+  // don't silently no-op on every existing resource. Old behavior was
+  // "skip" — looked safer but in practice meant "deploy did nothing"
+  // with no log line for the user to notice.
+  return "write";
 }
 
 /**
- * Normalize an object for comparison — strip undefined values and
- * sort keys so field ordering doesn't cause false conflicts.
+ * Server-managed fields that local JSON never contains. Stripped before
+ * the local-vs-remote diff so a remote response carrying these doesn't
+ * make every existing resource look "different".
  */
+const SERVER_ONLY_FIELDS = new Set([
+  "id",
+  "createdAt",
+  "updatedAt",
+  "created_at",
+  "updated_at",
+  "projectId",
+  "orgId",
+  "owner",
+  "team",        // attached server-side when an agent is returned
+  "agents",      // teams come back with their member list
+  "lastUsedAt",
+  "keyPrefix",
+]);
+
 function normalize(data: unknown): unknown {
-  return JSON.parse(JSON.stringify(data));
+  return data == null ? data : JSON.parse(JSON.stringify(data));
+}
+
+function strip(data: unknown): unknown {
+  if (Array.isArray(data)) return data.map(strip);
+  if (data && typeof data === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (SERVER_ONLY_FIELDS.has(k)) continue;
+      if (v === undefined) continue;
+      out[k] = strip(v);
+    }
+    return out;
+  }
+  return data;
+}
+
+function project(data: unknown, keys: string[]): unknown {
+  if (data == null || typeof data !== "object") return data;
+  const src = data as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of keys) {
+    if (k in src && src[k] !== undefined) out[k] = src[k];
+  }
+  return out;
+}
+
+/**
+ * JSON.stringify with deterministic key ordering, so two objects whose keys
+ * arrived in different orders still produce identical strings. Plain
+ * JSON.stringify is order-preserving but that order depends on the insertion
+ * order at each layer — which can drift between client + server.
+ */
+function stableStringify(value: unknown): string {
+  if (value == null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(stableStringify).join(",") + "]";
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return (
+    "{" +
+    keys
+      .map((k) => JSON.stringify(k) + ":" + stableStringify((value as Record<string, unknown>)[k]))
+      .join(",") +
+    "}"
+  );
 }

--- a/packages/cli/src/util/errors.ts
+++ b/packages/cli/src/util/errors.ts
@@ -3,8 +3,14 @@
  *
  * Order matters: more specific patterns first. Falls through to the original
  * message when nothing matches, so we never lose information.
+ *
+ * Accepts `unknown` because callers pull `error` straight off API response
+ * bodies and that field can be a string, a Zod issue array, an object, or
+ * undefined. We normalize defensively here so a malformed 4xx body can't
+ * crash the deploy with `msg.includes is not a function`.
  */
-export function friendlyError(msg: string): string {
+export function friendlyError(input: unknown): string {
+  const msg = normalizeToString(input);
   if (msg.includes("Multiple projects found")) return "Multiple projects found. Run: polpo projects set";
   if (/HTTP 401|Unauthorized/i.test(msg)) return "Session expired or invalid. Run: polpo login";
   if (/HTTP 403|Forbidden/i.test(msg)) return "Access denied. Check your credentials or project permissions.";
@@ -20,6 +26,22 @@ export function friendlyError(msg: string): string {
     return "Could not reach the Polpo API. Check your network or run: polpo whoami";
   }
   return msg;
+}
+
+/**
+ * Coerce any value to a short, human-readable string suitable for an error
+ * message. Strings pass through. Objects/arrays JSON.stringify, with a safe
+ * fallback when stringify throws (e.g. circular refs).
+ */
+function normalizeToString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (value instanceof Error) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 /**

--- a/packages/cli/src/util/scenarios.ts
+++ b/packages/cli/src/util/scenarios.ts
@@ -1,5 +1,5 @@
 /**
- * Demo scenarios for `polpo create` — optional seeded data so a fresh
+ * Example scenarios for `polpo create` — optional seeded data so a fresh
  * project lands in the dashboard with a working agent, project + agent
  * memory, a single draft task, and a multi-step draft mission ready to
  * run. Picking "none" keeps the legacy behavior (single blank agent).
@@ -9,7 +9,7 @@
  *     (see writeBlankScaffold) so we don't duplicate the list here.
  *   - projectMemory / agentMemory: free-form markdown.
  *   - task: a single, standalone task in draft status (no llm_review —
- *     verification is a file_exists check so the demo is deterministic).
+ *     verification is a file_exists check so the run is deterministic).
  *   - mission: a 4-step graph — brief → research → (spreadsheet || pdf)
  *     where the last two run in parallel because they share dependsOn.
  *

--- a/packages/cli/tests/conflicts.test.ts
+++ b/packages/cli/tests/conflicts.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Behavioral tests for resolveDeployConflict.
+ *
+ * The two regressions we lock in here:
+ *   1) Server-managed fields (id, createdAt, …) used to make every existing
+ *      resource look "different" → either spammed conflict prompts in TTY
+ *      mode or silently skipped every existing resource in CI. strip()
+ *      now filters those before diffing.
+ *   2) Non-interactive non-force used to default to "skip" → CI deploys
+ *      silently no-op'd. Now defaults to "write" so scripted deploys
+ *      actually push.
+ *
+ * Interactive prompt branches are exercised by stubbing @clack/prompts
+ * confirm + isCancel via vi.mock so the test runs in headless CI.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const confirmMock = vi.fn();
+vi.mock("@clack/prompts", () => ({
+  confirm: (args: unknown) => confirmMock(args),
+  isCancel: (v: unknown) => v === Symbol.for("clack.cancel"),
+}));
+
+// Import AFTER vi.mock so the module picks up the stub.
+const { resolveDeployConflict } = await import("../src/util/conflicts.js");
+
+beforeEach(() => confirmMock.mockReset());
+
+describe("resolveDeployConflict — null/undefined remote", () => {
+  it("returns 'write' when remote is null (resource doesn't exist yet)", async () => {
+    const action = await resolveDeployConflict({ name: "a" }, null, "agent a", {
+      force: false, interactive: false,
+    });
+    expect(action).toBe("write");
+  });
+
+  it("returns 'write' when remote is undefined", async () => {
+    const action = await resolveDeployConflict({ name: "a" }, undefined, "agent a", {
+      force: false, interactive: false,
+    });
+    expect(action).toBe("write");
+  });
+});
+
+describe("resolveDeployConflict — diff via strip()", () => {
+  it("returns 'skip' when local and remote are identical (no prompt)", async () => {
+    const local = { name: "agt", role: "r", model: "m" };
+    const remote = { name: "agt", role: "r", model: "m" };
+    const action = await resolveDeployConflict(local, remote, "agent agt", {
+      force: false, interactive: true,
+    });
+    expect(action).toBe("skip");
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("strips server-managed fields before comparing — same fields ≠ differ", async () => {
+    const local = { name: "agt", role: "r", model: "m" };
+    const remote = {
+      id: "agt_xyz",
+      name: "agt",
+      role: "r",
+      model: "m",
+      team: "default",
+      createdAt: "2026-05-01T00:00:00Z",
+      updatedAt: "2026-05-17T00:00:00Z",
+      projectId: "prj_abc",
+    };
+    const action = await resolveDeployConflict(local, remote, "agent agt", {
+      force: false, interactive: true,
+    });
+    expect(action).toBe("skip");
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 'write' when force=true even without prompt", async () => {
+    const local = { name: "agt", role: "r2" };
+    const remote = { name: "agt", role: "r1" };
+    const action = await resolveDeployConflict(local, remote, "agent agt", {
+      force: true, interactive: false,
+    });
+    expect(action).toBe("write");
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("defaults to 'write' when non-interactive AND non-force (CI safety)", async () => {
+    const local = { name: "agt", role: "r2" };
+    const remote = { name: "agt", role: "r1" };
+    const action = await resolveDeployConflict(local, remote, "agent agt", {
+      force: false, interactive: false,
+    });
+    expect(action).toBe("write");
+  });
+
+  it("opens a prompt when interactive AND non-force AND fields actually differ", async () => {
+    confirmMock.mockResolvedValueOnce(true);
+    const local = { name: "agt", role: "new" };
+    const remote = { id: "x", name: "agt", role: "old", createdAt: "x" };
+    const action = await resolveDeployConflict(local, remote, "agent agt", {
+      force: false, interactive: true,
+    });
+    expect(action).toBe("write");
+    expect(confirmMock).toHaveBeenCalledOnce();
+    const args = confirmMock.mock.calls[0][0] as { message: string };
+    expect(args.message).toContain("agent agt");
+  });
+
+  it("returns 'skip' when interactive prompt is answered no", async () => {
+    confirmMock.mockResolvedValueOnce(false);
+    const local = { name: "agt", role: "new" };
+    const remote = { name: "agt", role: "old" };
+    const action = await resolveDeployConflict(local, remote, "agent agt", {
+      force: false, interactive: true,
+    });
+    expect(action).toBe("skip");
+  });
+
+  it("returns 'skip' when interactive prompt is cancelled", async () => {
+    confirmMock.mockResolvedValueOnce(Symbol.for("clack.cancel"));
+    const local = { role: "new" };
+    const remote = { role: "old" };
+    const action = await resolveDeployConflict(local, remote, "agent agt", {
+      force: false, interactive: true,
+    });
+    expect(action).toBe("skip");
+  });
+});
+
+describe("resolveDeployConflict — beforePrompt / afterPrompt hooks", () => {
+  it("fires beforePrompt then afterPrompt around the prompt (spinner handoff)", async () => {
+    confirmMock.mockResolvedValueOnce(true);
+    const events: string[] = [];
+    const local = { role: "new" };
+    const remote = { role: "old" };
+
+    await resolveDeployConflict(local, remote, "agent agt", {
+      force: false,
+      interactive: true,
+      beforePrompt: () => events.push("before"),
+      afterPrompt: () => events.push("after"),
+    });
+
+    expect(events).toEqual(["before", "after"]);
+  });
+
+  it("still calls afterPrompt when the prompt is cancelled (so spinner restarts)", async () => {
+    confirmMock.mockResolvedValueOnce(Symbol.for("clack.cancel"));
+    const events: string[] = [];
+
+    await resolveDeployConflict({ a: 1 }, { a: 2 }, "x", {
+      force: false,
+      interactive: true,
+      beforePrompt: () => events.push("before"),
+      afterPrompt: () => events.push("after"),
+    });
+
+    expect(events).toEqual(["before", "after"]);
+  });
+
+  it("does NOT fire the hooks when no prompt is needed (identical, force, or non-interactive)", async () => {
+    const events: string[] = [];
+
+    await resolveDeployConflict({ a: 1 }, { a: 1 }, "x", {
+      force: false, interactive: true,
+      beforePrompt: () => events.push("before"),
+      afterPrompt: () => events.push("after"),
+    });
+    expect(events).toEqual([]);
+
+    await resolveDeployConflict({ a: 1 }, { a: 2 }, "x", {
+      force: true, interactive: false,
+      beforePrompt: () => events.push("before"),
+      afterPrompt: () => events.push("after"),
+    });
+    expect(events).toEqual([]);
+  });
+});
+
+describe("resolveDeployConflict — explicit compareKeys", () => {
+  it("only diffs the listed fields, ignoring everything else", async () => {
+    const local = { name: "a", description: "same", extra: "local-only" };
+    const remote = { name: "a", description: "same", extra: "remote-only", id: "x" };
+    const action = await resolveDeployConflict(local, remote, "team a", {
+      force: false, interactive: true,
+    }, ["name", "description"]);
+    expect(action).toBe("skip");
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("detects a diff on a listed field", async () => {
+    confirmMock.mockResolvedValueOnce(false);
+    const local = { name: "a", description: "new" };
+    const remote = { name: "a", description: "old" };
+    const action = await resolveDeployConflict(local, remote, "team a", {
+      force: false, interactive: true,
+    }, ["description"]);
+    expect(action).toBe("skip"); // user answered no
+    expect(confirmMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe("resolveDeployConflict — key-order independence", () => {
+  it("matches identical objects whose JSON keys are in different insertion order", async () => {
+    const local = { b: 2, a: 1, c: { y: 2, x: 1 } };
+    const remote = { c: { x: 1, y: 2 }, a: 1, b: 2 };
+    const action = await resolveDeployConflict(local, remote, "x", {
+      force: false, interactive: true,
+    });
+    expect(action).toBe("skip");
+  });
+});

--- a/packages/cli/tests/errors.test.ts
+++ b/packages/cli/tests/errors.test.ts
@@ -110,4 +110,51 @@ describe("friendlyError", () => {
       );
     });
   });
+
+  // ── Defensive normalization ─────────────────────────────────────
+  //
+  // Regression: deploy.ts feeds res.data.error straight into friendlyError,
+  // and that field can be an object (Zod issue list), an array, undefined,
+  // or null when the server returns a 4xx body that doesn't match the
+  // happy-path { error: "…" } shape. Calling `.includes` on a non-string
+  // crashed the entire deploy with `TypeError: msg.includes is not a function`.
+
+  describe("accepts non-string inputs without crashing", () => {
+    it("undefined → empty string passes through", () => {
+      expect(friendlyError(undefined)).toBe("");
+    });
+
+    it("null → empty string passes through", () => {
+      expect(friendlyError(null)).toBe("");
+    });
+
+    it("a Zod-style error object gets JSON-stringified", () => {
+      const out = friendlyError({ code: "ValidationError", issues: [{ path: "name", message: "required" }] });
+      expect(out).toContain("ValidationError");
+      expect(out).toContain("required");
+    });
+
+    it("an array of error strings gets JSON-stringified", () => {
+      const out = friendlyError(["bad name", "bad model"]);
+      expect(out).toContain("bad name");
+      expect(out).toContain("bad model");
+    });
+
+    it("an Error instance uses its .message", () => {
+      const out = friendlyError(new Error("boom"));
+      expect(out).toBe("boom");
+    });
+
+    it("a number gets coerced safely", () => {
+      const out = friendlyError(42);
+      expect(out).toBe("42");
+    });
+
+    it("an object whose string form matches a pattern still maps to its hint", () => {
+      // JSON.stringify of { http: 401 } produces '{"http":401}' — doesn't trigger 401 rule on its own.
+      // But if the stringified body contains 'Unauthorized' we should still recognize it.
+      const out = friendlyError({ message: "Unauthorized: stale token" });
+      expect(out).toBe("Session expired or invalid. Run: polpo login");
+    });
+  });
 });

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Closes six bugs that broke the \`polpo create\` → \`polpo deploy\` happy path.

### What was breaking

| # | Bug | Symptom |
|---|-----|---------|
| 1 | \`friendlyError(msg)\` typed \`string\` but fed \`res.data.error\` (can be object/array) | \`TypeError: msg.includes is not a function\` killed the deploy |
| 2 | \`clack.spinner\` stayed active while \`clack.confirm\` opened a prompt | "Deploying teams…" flickered, "cloud" peeked underneath, prompt invisible |
| 3 | \`normalize()\` didn't strip server-only fields (\`id\`, \`createdAt\`, \`team\`, …) | Every existing resource looked "different" → spam-prompt or silent skip |
| 4 | Non-interactive non-force defaulted to \`"skip"\` | CI deploys silently no-op'd every existing resource |
| 5 | CLI used \`PUT /v1/skills/{name}\` — route doesn't exist on server | Every skill update returned 404 silently |
| 6 | Memory read \`r.data?.content\` but server returns \`{ ok, data: { exists, content } }\` | \`remoteShared\` always null → memory overwritten without prompt every time |

### Plus two UX tweaks from review
- Outro curl example now uses the seeded scenario's agent name (\`analyst\` / \`researcher\` / \`pm\`) instead of hard-coded \`agent-1\`.
- Wording: \`Seed demo data\` → \`Seed example data\` everywhere. This CLI ships to real users, not just founder demos.

### Key implementation details

- **friendlyError**: now \`(input: unknown) => string\` with defensive normalization (Error → .message, object/array → JSON.stringify, null → ""). New helper \`readErrorBody(body, status)\` consolidates the 14 inline call sites.
- **Spinner pause**: \`ConflictOptions\` exposes \`beforePrompt\` / \`afterPrompt\` hooks; \`deploy.ts\` pauses the active spinner around any prompt and resumes with the same label.
- **Strip server fields**: denylist (\`id, createdAt, updatedAt, projectId, orgId, team, agents, …\`) filtered from both sides before diff. Plus deterministic \`stableStringify\` so key insertion order doesn't matter.
- **\`compareKeys\` opt-in**: callers can pass an explicit field list when the denylist isn't enough.
- **Skills update**: \`DELETE /v1/skills/{name}\` → \`POST /v1/skills/create\`. Fails fast on the DELETE leg (not a 404).
- **Memory unwrap**: \`r.data?.data?.content ?? r.data?.content ?? null\` — back-compat with both wrapped and unwrapped responses.

### Tests
- \`packages/cli/tests/errors.test.ts\` — 26 tests, 6 new for non-string inputs (undefined, null, object, array, Error, number).
- \`packages/cli/tests/conflicts.test.ts\` — 15 new tests covering null-remote → write, server-field stripping, prompt branches, hook hand-off, \`compareKeys\` projection, key-order independence.
- Full suite: **1772 passed**, 0 regressions.

Version bumped to 0.7.8 across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)