### PR TITLE
fix(cli): kill nested-spinner flicker on polpo create (0.7.9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/src/commands/cloud/deploy.ts
+++ b/packages/cli/src/commands/cloud/deploy.ts
@@ -87,6 +87,20 @@ function listJsonFiles(dir: string): string[] {
 }
 
 /**
+ * Returns a spinner-shaped object whose start/stop/message are no-ops.
+ * Used when `runDeploy` is invoked under a caller that already drives a
+ * spinner (e.g. `polpo create`'s "Deploying agents to cloud...") so we
+ * don't get two animations fighting for the same TTY row.
+ */
+function createNullSpinner() {
+  return {
+    start: (_msg?: string) => undefined,
+    stop:  (_msg?: string) => undefined,
+    message: (_msg?: string) => undefined,
+  } as ReturnType<typeof clack.spinner>;
+}
+
+/**
  * Extract the most useful error string from an API response body, regardless
  * of whether the server returned `{ error: "string" }`, `{ error: { ... } }`,
  * `{ error: [issue, …] }`, or nothing. Falls back to "HTTP <status>" so
@@ -615,7 +629,12 @@ export async function runDeploy(opts: DeployOptions): Promise<DeployReport> {
   const interactive = !opts.silent && !force && isTTY();
 
   const cpClient = createApiClient(creds);
-  const s = clack.spinner();
+  // When called by an outer flow (e.g. `polpo create`) with `silent: true`,
+  // that flow already owns a spinner — opening another here causes terminal
+  // flicker (two spinners writing to the same row at the same time). The
+  // null-spinner is a tiny shim that no-ops start/stop so all the existing
+  // `s.start(...)` / `s.stop(...)` call sites keep working unchanged.
+  const s = opts.silent ? createNullSpinner() : clack.spinner();
 
   // ── Step 1: Resolve project ────────────────────────
   let projectId: string | undefined = polpoConfig?.projectId;

--- a/packages/cli/src/util/scenarios.ts
+++ b/packages/cli/src/util/scenarios.ts
@@ -1,20 +1,35 @@
 /**
  * Example scenarios for `polpo create` — optional seeded data so a fresh
  * project lands in the dashboard with a working agent, project + agent
- * memory, a single draft task, and a multi-step draft mission ready to
- * run. Picking "none" keeps the legacy behavior (single blank agent).
+ * memory, a single draft task, a multi-step draft mission, and one
+ * custom skill ready to use. Picking "none" keeps the legacy behavior
+ * (single blank agent).
  *
  * Every scenario keeps the same shape so callers can iterate the seed:
- *   - agent: name + role; tool palette is the default full palette
- *     (see writeBlankScaffold) so we don't duplicate the list here.
+ *   - agent: name + role + systemPrompt; tool palette is the default
+ *     full palette (see writeBlankScaffold) so we don't duplicate it
+ *     here.
  *   - projectMemory / agentMemory: free-form markdown.
- *   - task: a single, standalone task in draft status (no llm_review —
- *     verification is a file_exists check so the run is deterministic).
+ *   - task: a single, standalone task in draft status with a
+ *     file_exists expectation. Verification is deterministic — no
+ *     llm_review.
  *   - mission: a 4-step graph — brief → research → (spreadsheet || pdf)
  *     where the last two run in parallel because they share dependsOn.
+ *   - skill: one SKILL.md scaffold per scenario, scoped to the tools
+ *     the mission actually uses.
  *
  * Output paths are all under `.polpo/output/<…>` so the agent's
  * sandboxed write tool can hit them without extra config.
+ *
+ * Schema alignment (verified against core + server):
+ *   - file_exists expectations use `paths: string[]` per
+ *     `core/src/schemas.ts:21-24` (NOT `path: string` — that gets
+ *     silently dropped by `sanitizeExpectations`).
+ *   - agent.systemPrompt is an optional field on `AddAgentSchema`
+ *     (`server/src/schemas.ts:320`).
+ *   - mission.data is a structured object here; `deploy.ts:295`
+ *     stringifies it before POST so both shapes are accepted at
+ *     write time.
  */
 
 export interface ScenarioTask {
@@ -27,21 +42,40 @@ export interface ScenarioMission {
   payload: Record<string, unknown>;
 }
 
+export interface ScenarioSkill {
+  /** Directory + frontmatter `name` — kebab-case slug. */
+  name: string;
+  /** Short summary, used as SKILL.md frontmatter `description`. */
+  description: string;
+  /** Tool patterns scoped to this skill (frontmatter `allowed-tools`). */
+  allowedTools: string[];
+  /** Markdown body of SKILL.md (after the frontmatter block). */
+  content: string;
+}
+
 export interface Scenario {
   id: "data-analyst" | "marketing-researcher" | "product-manager";
   label: string;
   hint: string;
-  agent: { name: string; role: string };
+  agent: { name: string; role: string; systemPrompt: string };
   projectMemory: string;
   agentMemory: string;
   task: ScenarioTask;
   mission: ScenarioMission;
+  skill: ScenarioSkill;
 }
 
 // ─── Shared helpers ────────────────────────────────────────────────
 
+/**
+ * file_exists expectations are validated by `parseExpectation` in
+ * @polpo-ai/core; the schema requires `paths` (plural array), not
+ * `path` (singular). Building the wrong shape causes the runtime
+ * sanitizer to silently drop the expectation, so the task appears
+ * unverified.
+ */
 function fileExists(path: string) {
-  return { type: "file_exists", path };
+  return { type: "file_exists" as const, paths: [path] };
 }
 
 // ─── Scenario A: Data Analyst ──────────────────────────────────────
@@ -53,6 +87,16 @@ const dataAnalyst: Scenario = {
   agent: {
     name: "analyst",
     role: "Senior data analyst — turns raw datasets into clear, actionable reports for leadership.",
+    systemPrompt:
+      "You are a Senior Data Analyst preparing recurring quarterly KPI reviews for leadership.\n\n" +
+      "Style: numbers first, narrative second. Every section ends with a one-line takeaway.\n" +
+      "Always include a 'what changed since last quarter' note. Default visuals: bar for absolute " +
+      "values, line for trends, table for raw data.\n\n" +
+      "Confirm whether ARR or MRR is the headline metric before drafting any section. Validate the " +
+      "CAC payback assumption (currently 14 months) against the latest data before quoting it. " +
+      "When you cite an industry benchmark, include the source URL and the date you accessed it.\n\n" +
+      "Output formats by task: brief.md (markdown), kpis.xlsx (spreadsheet), Q1-executive-summary.pdf " +
+      "(one-page PDF, monochrome, header + body sections).",
   },
   projectMemory: `# Project — Quarterly KPI Review
 
@@ -69,7 +113,7 @@ Recurring quarterly KPI review for the leadership team.
 Style:
 - Numbers first, narrative second.
 - Always include a "what changed since last quarter" section.
-- Default visuals: bar for absolute values, line for trends, table for raw.
+- Default visuals: bar for absolute values, line for trends, table for raw data.
 
 Open questions:
 - Confirm whether ARR or MRR is the headline metric.
@@ -136,6 +180,41 @@ Open questions:
       },
     },
   },
+  skill: {
+    name: "kpi-review-framework",
+    description: "Structured workflow for quarterly KPI reviews — scope → benchmarks → spreadsheet → executive summary.",
+    allowedTools: ["search_*", "excel_*", "pdf_*", "read", "write"],
+    content:
+`# KPI Review Framework
+
+Use this skill when preparing a quarterly review for leadership.
+
+## Step 1 — Scope the questions
+Before pulling any number, list the 3-5 questions leadership will actually ask:
+- Revenue movement: YoY/QoQ growth, ARR/MRR breakdown
+- Churn: logo churn vs dollar churn, by cohort
+- Biggest win / biggest risk this quarter
+- One recommended action with a clear owner
+
+## Step 2 — Gather benchmarks
+Use \`search_web\` to find 5-7 SaaS industry benchmarks (median churn, CAC payback, LTV/CAC).
+For each benchmark capture: value, source URL, date accessed, sample size if reported.
+
+## Step 3 — Build the spreadsheet
+Two sheets in \`.polpo/output/kpis.xlsx\`:
+1. **Our Metrics** — one row per metric (revenue, churn, NPS, CAC, LTV), columns: Q-prev, Q-current, Δ, Δ%
+2. **Industry Benchmark** — pulled from research, one row per benchmark
+
+## Step 4 — Compose the executive summary
+1-page PDF with: headline metric, what changed since last quarter, two takeaways, recommended action.
+Monochrome, no decorative graphics. Use \`pdf_*\` tools.
+
+## Quality checks
+- Every external number has a URL + access date.
+- Every section ends with a one-line takeaway.
+- No section longer than 5 lines without a chart or table.
+`,
+  },
 };
 
 // ─── Scenario B: Marketing Researcher ──────────────────────────────
@@ -147,6 +226,16 @@ const marketingResearcher: Scenario = {
   agent: {
     name: "researcher",
     role: "Marketing researcher — competitive analysis, audience research, and launch briefs.",
+    systemPrompt:
+      "You are a Marketing Researcher running pre-launch competitive intelligence for a B2B SaaS " +
+      "targeting technical founders and early-stage CTOs.\n\n" +
+      "Voice: technical, no-fluff, builder-to-builder. No marketing buzzwords. Contrast against " +
+      "competitors, never list features in a vacuum.\n\n" +
+      "Workflow: audience definition → competitor scan → feature matrix → launch deck. Every external " +
+      "source carries a URL + the date you accessed it. Competitor research must include: name, " +
+      "pricing, killer feature, weakness, primary audience.\n\n" +
+      "Output formats: launch-brief.md (markdown), competitors.md (markdown with URLs), " +
+      "feature-matrix.xlsx (rows=features, cols=competitors + 'Us'), launch-deck.pdf (3 pages max).",
   },
   projectMemory: `# Project — Product Launch Marketing
 
@@ -202,7 +291,7 @@ Anti-patterns to avoid:
           {
             title: "research_competitors",
             description:
-              "Using `search_web` and `browser_*`, identify 5-8 direct competitors. " +
+              "Using `search_web`, identify 5-8 direct competitors. " +
               "For each capture: name, pricing tier, killer feature, weakness, primary audience. " +
               "Save to `.polpo/output/competitors.md` with URLs.",
             assignTo: "researcher",
@@ -233,6 +322,37 @@ Anti-patterns to avoid:
       },
     },
   },
+  skill: {
+    name: "competitor-research",
+    description: "Framework for B2B SaaS competitive analysis — captures features, pricing, gaps, and positioning.",
+    allowedTools: ["search_*", "excel_*", "pdf_*", "read", "write"],
+    content:
+`# Competitor Research Skill
+
+Use this skill when scoping a launch or repositioning. The output is a competitors.md
+file and a feature-matrix.xlsx that can be reviewed by founders + GTM.
+
+## For each competitor, capture
+- **Name + URL**
+- **Pricing**: tier names, monthly price, packaging (seat vs usage), annual discount
+- **Killer feature**: the one thing they do better than anyone
+- **Weakness**: what they don't do — features missing, pricing complaints, support gaps
+- **Primary audience**: who buys (company size, industry, role)
+- **Source**: every claim cites a URL + the date you accessed it
+
+## Workflow
+1. \`search_web("<category> top SaaS")\` → seed list
+2. \`search_web("<competitor> pricing")\` + \`search_web("<competitor> reviews")\` → features + weaknesses
+3. Cross-check against G2 / Capterra / dev.to reviews for the "weakness" column
+4. Build the feature matrix: rows = features, cols = competitors + 'Us', mark ✓/✗/partial
+
+## Anti-patterns
+- Listing features without contrasting against your product
+- Generic positioning that could fit any competitor
+- Pricing data older than 3 months
+- More than 8 competitors in the first pass (you'll never finish)
+`,
+  },
 };
 
 // ─── Scenario C: Product Manager ───────────────────────────────────
@@ -244,6 +364,17 @@ const productManager: Scenario = {
   agent: {
     name: "pm",
     role: "Product manager — prioritizes feature work, writes specs, tracks user needs.",
+    systemPrompt:
+      "You are a Product Manager for an early-stage SaaS (~50 paying customers, 3-engineer team, " +
+      "~6 weeks of effective capacity per quarter).\n\n" +
+      "Frame: always start from user need, not solution. Score every candidate with RICE " +
+      "(Reach × Impact × Confidence / Effort) before committing. Every decision needs a one-line " +
+      "'why now' rationale.\n\n" +
+      "Confidence calibration: 100% = validated with 5+ user interviews + analytics signal; " +
+      "80% = 3+ interviews OR strong analytics signal; 50% = hypothesis with only anecdotal evidence " +
+      "(needs more data before commitment).\n\n" +
+      "Specs include: problem statement, user story, acceptance criteria, out-of-scope, why-now. " +
+      "Output formats: q1-brief.md, user-signals.md, rice-scoring.xlsx, q1-spec.pdf (2-3 pages).",
   },
   projectMemory: `# Project — Q1 Feature Planning
 
@@ -330,6 +461,42 @@ Confidence calibration:
         ],
       },
     },
+  },
+  skill: {
+    name: "rice-prioritization",
+    description: "RICE scoring workflow for feature prioritization — from user signals to spec.",
+    allowedTools: ["search_*", "excel_*", "pdf_*", "read", "write"],
+    content:
+`# RICE Prioritization Skill
+
+Use this skill when scoping a quarter or sprint. Output is a rice-scoring.xlsx and a
+spec PDF for the top candidate.
+
+## The RICE formula
+\`Score = (Reach × Impact × Confidence) / Effort\`
+
+- **Reach**: how many users hit this in one quarter? (absolute count or %)
+- **Impact**: per-user benefit on a 5-point scale (massive=3, large=2, medium=1, small=0.5, minimal=0.25)
+- **Confidence**: 50% / 80% / 100% — based on user-interview + analytics evidence
+- **Effort**: person-weeks (1-12 cap; if >12 split the feature)
+
+## Workflow
+1. Gather demand signals per candidate via \`search_web\` (forums, X threads, GitHub issues, blog comments)
+2. For each candidate fill: Reach (estimate), Impact (rubric above), Confidence (calibration), Effort (eng estimate)
+3. Sort by descending RICE in \`rice-scoring.xlsx\`
+4. Spec the top feature: problem, user story, acceptance criteria, out-of-scope, 'why now'
+
+## Confidence calibration
+- 100% — validated with 5+ user interviews AND a clear analytics signal
+- 80%  — 3+ interviews OR strong analytics signal
+- 50%  — hypothesis with anecdotal evidence only; needs more data before commit
+
+## Anti-patterns
+- High Confidence on a feature you haven't talked to users about
+- "Reach = all users" without quantifying
+- Effort that ignores QA, docs, and migration work
+- Skipping the 'why now' — anything can wait if there's no clock
+`,
   },
 };
 

--- a/packages/cli/src/util/template.ts
+++ b/packages/cli/src/util/template.ts
@@ -104,39 +104,40 @@ export function writeBlankScaffold(targetDir: string, projectName: string, scena
   const agentName = scenario?.agent.name ?? "agent-1";
   const agentRole = scenario?.agent.role ?? "helpful assistant";
 
+  // Full demo-ready palette: every built-in tool category is enabled out of
+  // the box so `polpo create` → first prompt can exercise the whole stack
+  // (browser navigation, doc/sheet/pdf creation, web search, image/audio
+  // generation, vault lookups, email send). For tighter production agents,
+  // strip the categories you don't need.
+  const agentConfig: Record<string, unknown> = {
+    name: agentName,
+    role: agentRole,
+    model: "xai/grok-4.1-fast-non-reasoning",
+    allowedTools: [
+      "bash", "read", "write", "edit", "glob", "grep", "ls",
+      "http_*",
+      "browser_*",
+      "search_*",
+      "vault_*",
+      "image_*",
+      "audio_*",
+      "pdf_*",
+      "docx_*",
+      "excel_*",
+      "email_*",
+      "memory_*",
+    ],
+  };
+  // Persona / instructions specific to the scenario, dropped in only when
+  // a scenario was selected. The blank agent stays minimal.
+  if (scenario?.agent.systemPrompt) {
+    agentConfig.systemPrompt = scenario.agent.systemPrompt;
+  }
+
   fs.writeFileSync(
     path.join(targetDir, ".polpo", "agents.json"),
     JSON.stringify(
-      [
-        {
-          agent: {
-            name: agentName,
-            role: agentRole,
-            model: "xai/grok-4.1-fast-non-reasoning",
-            // Full demo-ready palette: every built-in tool category is
-            // enabled out of the box so `polpo create` → first prompt can
-            // exercise the whole stack (browser navigation, doc/sheet/pdf
-            // creation, web search, image/audio generation, vault lookups,
-            // email send). For tighter production agents, strip the
-            // categories you don't need.
-            allowedTools: [
-              "bash", "read", "write", "edit", "glob", "grep", "ls",
-              "http_*",
-              "browser_*",
-              "search_*",
-              "vault_*",
-              "image_*",
-              "audio_*",
-              "pdf_*",
-              "docx_*",
-              "excel_*",
-              "email_*",
-              "memory_*",
-            ],
-          },
-          teamName: "default",
-        },
-      ],
+      [{ agent: agentConfig, teamName: "default" }],
       null,
       2,
     ) + "\n",
@@ -166,10 +167,10 @@ export function writeBlankScaffold(targetDir: string, projectName: string, scena
 
 /**
  * Write the scenario's seed data: project + agent memory, a single draft
- * task, and a multi-step draft mission. Caller is responsible for picking
- * `includeTasks: true` when deploying so the task gets pushed alongside
- * the mission (missions are part of the default deploy scope; tasks are
- * opt-in).
+ * task, a multi-step draft mission, and one custom skill. Caller is
+ * responsible for picking `includeTasks: true` when deploying so the
+ * task gets pushed alongside the mission (missions + skills are part of
+ * the default deploy scope; tasks are opt-in).
  */
 function writeScenarioSeed(targetDir: string, scenario: Scenario): void {
   const polpoDir = path.join(targetDir, ".polpo");
@@ -197,6 +198,23 @@ function writeScenarioSeed(targetDir: string, scenario: Scenario): void {
     path.join(missionsDir, `${scenario.mission.filename}.json`),
     JSON.stringify(scenario.mission.payload, null, 2) + "\n",
   );
+
+  // Custom skill — one SKILL.md per scenario, scoped to the tools the
+  // mission actually uses. Frontmatter keys match what `deploySkills`
+  // parses (`name`, `description`, `allowed-tools` list).
+  const skillDir = path.join(polpoDir, "skills", scenario.skill.name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  const allowedToolsBlock = scenario.skill.allowedTools
+    .map((t) => `  - ${t}`)
+    .join("\n");
+  const skillFile =
+    `---\n` +
+    `name: ${scenario.skill.name}\n` +
+    `description: ${scenario.skill.description}\n` +
+    `allowed-tools:\n${allowedToolsBlock}\n` +
+    `---\n\n` +
+    scenario.skill.content;
+  fs.writeFileSync(path.join(skillDir, "SKILL.md"), skillFile);
 }
 
 export interface RemoteTemplateOptions {

--- a/packages/cli/tests/template.test.ts
+++ b/packages/cli/tests/template.test.ts
@@ -8,7 +8,7 @@ import {
   writeBlankScaffold,
 } from "../src/util/template.js";
 import { SCENARIOS, findScenario } from "../src/util/scenarios.js";
-import { parseMissionDocument } from "@polpo-ai/core/schemas";
+import { parseMissionDocument, parseExpectation } from "@polpo-ai/core/schemas";
 
 let tmpDir: string;
 
@@ -226,6 +226,63 @@ describe("scenario seeding", () => {
         expect(types).toContain("file_exists");
       });
 
+      it("task expectations use `paths: string[]` shape, validated by parseExpectation", () => {
+        // Regression: the helper used to return `{path: string}` singular,
+        // which the core sanitizer silently dropped. Lock in the plural shape.
+        const taskPath = path.join(tmpDir, ".polpo", "tasks", `${sc.task.filename}.json`);
+        const task = JSON.parse(fs.readFileSync(taskPath, "utf-8"));
+        for (const exp of task.expectations as unknown[]) {
+          const parsed = parseExpectation(exp);
+          expect(parsed).not.toBeNull();
+          if (parsed && (parsed as { type: string }).type === "file_exists") {
+            expect((parsed as { paths: string[] }).paths.length).toBeGreaterThan(0);
+          }
+        }
+      });
+
+      it("agent has a non-empty systemPrompt persona", () => {
+        const agents = JSON.parse(
+          fs.readFileSync(path.join(tmpDir, ".polpo", "agents.json"), "utf-8"),
+        );
+        expect(typeof agents[0].agent.systemPrompt).toBe("string");
+        expect(agents[0].agent.systemPrompt.length).toBeGreaterThan(50);
+      });
+
+      it("scaffolds one SKILL.md with the scenario's tool scope in frontmatter", () => {
+        const skillPath = path.join(tmpDir, ".polpo", "skills", sc.skill.name, "SKILL.md");
+        const raw = fs.readFileSync(skillPath, "utf-8");
+        const fm = raw.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "";
+        expect(fm).toContain(`name: ${sc.skill.name}`);
+        expect(fm).toContain(`description: ${sc.skill.description}`);
+        for (const tool of sc.skill.allowedTools) {
+          expect(fm).toContain(`- ${tool}`);
+        }
+        // Body is non-empty.
+        const body = raw.split(/^---$/m).slice(2).join("---").trim();
+        expect(body.length).toBeGreaterThan(50);
+      });
+
+      it("no seeded task or skill references `browser_*` (kept lightweight per design)", () => {
+        const missionPath = path.join(tmpDir, ".polpo", "missions", `${sc.mission.filename}.json`);
+        const mission = JSON.parse(fs.readFileSync(missionPath, "utf-8"));
+        const allText = JSON.stringify(mission) + "\n" +
+          fs.readFileSync(path.join(tmpDir, ".polpo", "skills", sc.skill.name, "SKILL.md"), "utf-8");
+        expect(allText).not.toMatch(/browser_\*/);
+      });
+
+      it("every mission task and the standalone task assign to the scenario's agent", () => {
+        // assignTo must match the agent name or the orchestrator can't pick the task up.
+        const taskPath = path.join(tmpDir, ".polpo", "tasks", `${sc.task.filename}.json`);
+        const task = JSON.parse(fs.readFileSync(taskPath, "utf-8"));
+        expect(task.assignTo).toBe(sc.agent.name);
+
+        const missionPath = path.join(tmpDir, ".polpo", "missions", `${sc.mission.filename}.json`);
+        const mission = JSON.parse(fs.readFileSync(missionPath, "utf-8"));
+        for (const t of mission.data.tasks) {
+          expect(t.assignTo).toBe(sc.agent.name);
+        }
+      });
+
       it("writes a draft mission whose data parses against missionDocumentSchema", () => {
         const missionPath = path.join(tmpDir, ".polpo", "missions", `${sc.mission.filename}.json`);
         const file = JSON.parse(fs.readFileSync(missionPath, "utf-8"));
@@ -266,9 +323,12 @@ describe("scenario seeding", () => {
     );
     expect(agents[0].agent.name).toBe("agent-1");
     expect(agents[0].agent.role).toBe("helpful assistant");
+    // No systemPrompt on the blank agent — only scenarios scaffold one.
+    expect(agents[0].agent.systemPrompt).toBeUndefined();
     // And no scenario directories are created.
     expect(fs.existsSync(path.join(tmpDir, ".polpo", "tasks"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".polpo", "missions"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, ".polpo", "memory.md"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".polpo", "skills"))).toBe(false);
   });
 });

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Symptom
During \`polpo create\` (which calls \`runDeploy({ silent: true })\` internally) the user sees \`Deploying teams...\` / \`Deploying agents...\` / \`Deploying memory...\` flickering on the same row, sometimes with text bleeding underneath.

## Cause
Two \`clack.spinner()\` instances were live at the same time:
- **Outer**: \`s.start("Deploying agents to cloud...")\` from \`create.ts\`
- **Inner**: \`s.start("Deploying teams...")\` (and friends) from \`runDeploy\`

Both wrote to the same TTY row → animation collision → flicker.

The 0.7.8 pause/resume hooks fixed spinner↔\`clack.confirm\` collisions but not spinner↔spinner.

## Fix
When \`silent: true\`, runDeploy uses a null-spinner whose \`start\`/\`stop\`/\`message\` are no-ops. The outer caller keeps full control of the animation. All existing \`s.start(...)\` / \`s.stop(...)\` call sites stay unchanged.

Direct \`polpo deploy\` (\`silent: false\`) keeps its real spinners — unchanged.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm --filter polpo-ai test\` — 1772 passed, no regressions
- [ ] \`polpo create demo --scenario data-analyst\` shows one spinner only ("Deploying agents to cloud..."), no flicker
- [ ] \`polpo deploy\` directly still shows per-resource spinners (Teams, Agents, Memory, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)