### PR TITLE
fix: runner sessionId propagation + Docker supply chain (0.7.10)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,11 +130,25 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          file: ./docker/runner/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
+          # POLPO_VERSION drives `npm install polpo-ai@${POLPO_VERSION}` inside
+          # the Dockerfile. Without this build-arg the Dockerfile fell back to
+          # its hardcoded `ARG POLPO_VERSION=0.7.0` and every image we ever
+          # pushed (regardless of tag) contained polpo-ai@0.7.0. That's why the
+          # Daytona sandbox runtime stayed pinned to 0.7.0 even after months of
+          # npm releases.
+          build-args: |
+            POLPO_VERSION=${{ steps.version.outputs.VERSION }}
+          # Image name aligned with what the cloud snapshot script pulls
+          # (`ghcr.io/lumea-labs/polpo-runner:<v>`). Before this change the
+          # workflow published as `ghcr.io/lumea-labs/polpo:<v>` — different
+          # package — so the cloud either 404'd or pulled some manually-
+          # published copy that never got refreshed.
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
+            ghcr.io/${{ github.repository_owner }}/polpo-runner:latest
+            ghcr.io/${{ github.repository_owner }}/polpo-runner:${{ steps.version.outputs.VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -177,7 +177,19 @@ async function main(): Promise<void> {
     status: "running",
     startedAt: now,
     updatedAt: now,
-    activity: { filesCreated: [], filesEdited: [], toolCalls: 0, totalTokens: 0, lastUpdate: now },
+    // sessionId starts at the LogStore session we just opened, so the
+    // run record is linked to its transcript from the very first poll.
+    // Without this, downstream readers (the cloud task-activity endpoint,
+    // a future dashboard, anything that joins runs to log sessions) have
+    // to guess by time-proximity — fragile on cold sandboxes where the
+    // log session is created hundreds of ms before the first stream
+    // chunk lands. In file mode this is mostly cosmetic because
+    // RunActivityLog writes a parallel JSONL side-channel; in DB mode
+    // (cloud) it's the only link that ever gets persisted.
+    activity: {
+      filesCreated: [], filesEdited: [], toolCalls: 0, totalTokens: 0, lastUpdate: now,
+      ...(logSessionId ? { sessionId: logSessionId } : {}),
+    },
     configPath: isDbMode ? `db://${config.runId}` : join(process.argv[process.argv.indexOf("--config") + 1]),
   };
   // In DB mode, run record already exists (created by spawner) — update it with PID
@@ -206,6 +218,14 @@ async function main(): Promise<void> {
       shell: new NodeShell(),
     };
     handle = spawnEngine(config.agent, config.task, config.cwd, spawnCtx);
+    // Propagate the LogStore sessionId onto the agent's activity blob so
+    // the poll loop's updateActivity() persists it on every tick. Without
+    // this the run record has activity.sessionId = undefined forever, and
+    // downstream readers (cloud task-activity endpoint, dashboards) can't
+    // resolve the transcript except via fragile time-proximity fallback.
+    if (logSessionId) {
+      handle.activity.sessionId = logSessionId;
+    }
     // Wire transcript persistence — every agent message gets written to the run log
     handle.onTranscript = (entry) => {
       actLog.logTranscript(entry);


### PR DESCRIPTION
## The bug

Cloud dashboard shows "No activity recorded for this task yet" for every task — even completed ones — on Koyeb prod. Locally (\`pnpm dev\` cloud) it works inconsistently because a fallback time-match in the cloud's activity endpoint succeeds when cold-start is fast, fails when it isn't.

## Root cause: 3 bugs stacked

### 1. Runner never writes \`run.sessionId\`
\`src/core/runner.ts\` opens a LogStore session (\`logSessionId = await logStore.startSession()\`) but never copies it onto the \`RunRecord\`. The DrizzleRunStore.updateActivity persists \`activity.sessionId\` to the DB column — but \`handle.activity.sessionId\` is \`undefined\` for the entire run lifetime.

### 2. CI doesn't pass \`POLPO_VERSION\` to the Docker build
\`docker/runner/Dockerfile\` has \`ARG POLPO_VERSION=0.7.0\` then \`npm install polpo-ai@${POLPO_VERSION}\`. The release workflow never sets \`build-args\`, so every image we've ever published — regardless of tag — contains \`polpo-ai@0.7.0\` baked in. npm publishes worked; Docker image stayed pinned.

### 3. CI image name mismatch
Workflow publishes \`ghcr.io/lumea-labs/polpo:<v>\` but the cloud's \`create-snapshot-v7.ts\` pulls \`ghcr.io/lumea-labs/polpo-runner:<v>\`. Different package name — the cloud was either 404'ing or pulling a manually-pushed copy nobody updated.

## Combined effect of all three

Even if you bumped a tag every day, the Daytona sandbox runtime was stuck on polpo-ai@0.7.0 forever, AND that 0.7.0 runner never wrote \`run.sessionId\`, so the cloud activity endpoint had nothing to resolve against, so the dashboard showed empty entries.

## Fix

- \`src/core/runner.ts\`: set \`activity.sessionId = logSessionId\` on both \`initialRecord\` and \`handle.activity\`. One line each. The poll loop's existing \`updateActivity()\` then persists it from the first tick.
- \`.github/workflows/release.yml\`: add \`build-args: POLPO_VERSION=${{ steps.version.outputs.VERSION }}\` so the image actually contains the version it's tagged with. Also explicitly point \`file: ./docker/runner/Dockerfile\` so the workflow doesn't fall back to whatever root-level Dockerfile it finds.
- \`.github/workflows/release.yml\`: rename published image to \`ghcr.io/${{ github.repository_owner }}/polpo-runner:<v>\` to match what the cloud snapshot script pulls.

## After merge

OSS 0.7.10 release will:
1. Publish npm: \`polpo-ai@0.7.10\` (with the session-id fix)
2. Publish GHCR: \`polpo-runner:0.7.10\` (with polpo-ai@0.7.10 actually installed inside)

Then on the cloud side (separate PR):
3. Bump deps 0.7.9 → 0.7.10
4. Run \`POLPO_VERSION=0.7.10 pnpm tsx create-snapshot-v8.ts\` to register the new Daytona snapshot
5. Set \`DAYTONA_SNAPSHOT=polpo-runner-v8\` env on Koyeb
6. Next sandbox cold-start picks up the new image → \`run.sessionId\` is written from the first tick → cloud activity endpoint resolves it deterministically → dashboard shows the actual transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)