### PR TITLE
feat: managed image/video via AI Gateway + per-tool cost metering

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -340,6 +340,25 @@ export interface AgentActivity {
   lastUpdate: string;       // ISO timestamp of last activity
   summary?: string;         // agent's last text output / message
   sessionId?: string;       // SDK session ID for transcript access
+  /**
+   * Billable per-tool inference cost captured from a tool's gateway
+   * response (e.g. managed image/video generation). Each entry mirrors the
+   * fields the completions billing path meters. Absent for tools that don't
+   * go through the gateway (BYOK / direct provider). Consumed by the cloud
+   * data plane after a run completes → Autumn + usage_logs.
+   */
+  toolUsage?: ToolUsageRecord[];
+}
+
+/** One billable tool inference, harvested from `result.details.usage`. */
+export interface ToolUsageRecord {
+  toolName: string;
+  generationId?: string;
+  marketCostUsd?: number;
+  actualCostUsd?: number;
+  resolvedModel?: string;
+  finalProvider?: string;
+  credentialType?: string;
 }
 
 export interface AgentProcess {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -32,6 +32,7 @@
     "@ai-sdk/deepgram": "^2.0.31",
     "@ai-sdk/elevenlabs": "^2.0.31",
     "@ai-sdk/fal": "^2.0.31",
+    "@ai-sdk/gateway": "^3.0.83",
     "docx": "^9.5.0",
     "exceljs": "^4.4.0",
     "execa": "^9.0.0",
@@ -40,7 +41,8 @@
     "nodemailer": "^8.0.0",
     "pdf-lib": "^1.17.0",
     "playwright-core": "^1.52.0",
-    "tinyglobby": "^0.2.0"
+    "tinyglobby": "^0.2.0",
+    "undici": "^7.0.0"
   },
   "peerDependencies": {
     "@ai-sdk/openai": "^3.0.48",

--- a/packages/tools/src/image-tools.ts
+++ b/packages/tools/src/image-tools.ts
@@ -34,6 +34,8 @@ import {
   resolveImageProvider,
   resolveVideoProvider,
   resolveVisionProvider,
+  resolveManagedImageProvider,
+  resolveManagedVideoProvider,
   type ImageProviderName,
   type VideoProviderName,
   type VisionProviderName,
@@ -71,6 +73,52 @@ function resolveProviderKey(provider: string, vault?: ResolvedVault): string {
     default:
       throw new Error(`Unknown provider '${provider}': no credential lookup defined`);
   }
+}
+
+/** Non-throwing variant of resolveProviderKey — returns undefined when no
+ *  credential is configured (vault or env), instead of throwing. */
+function tryResolveProviderKey(provider: string, vault?: ResolvedVault): string | undefined {
+  try {
+    return resolveProviderKey(provider, vault);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Managed = route through the Vercel AI Gateway. True only when the agent
+ *  has NO provider key of its own AND an AI_GATEWAY_API_KEY is present (the
+ *  cloud case). BYOK / self-host with a provider key stays on direct-SDK. */
+function shouldUseGateway(provider: string, vault?: ResolvedVault): boolean {
+  return !tryResolveProviderKey(provider, vault) && !!process.env.AI_GATEWAY_API_KEY;
+}
+
+// Managed defaults: gateway model ids (the fal-namespaced defaults have no
+// gateway equivalent, so they can't be used on the gateway path).
+const DEFAULT_MANAGED_IMAGE_MODEL = "bfl/flux-pro-1.1";
+const DEFAULT_MANAGED_VIDEO_MODEL = "google/veo-3.0-fast-generate-001";
+
+/** Build the gateway model id from a parsed model. fal-namespaced models
+ *  have no gateway equivalent → fall back to the managed default. */
+function gatewayModelId(parsed: ParsedModel, managedDefault: string): string {
+  if (parsed.provider === "fal") return managedDefault;
+  return `${parsed.provider}/${parsed.model}`;
+}
+
+/** Extract the billable gateway usage from an AI SDK result's
+ *  providerMetadata (same shape completions meter). Undefined when the call
+ *  didn't go through the gateway (BYOK / direct provider) — then no cost
+ *  rides back and nothing is billed. */
+function extractGatewayUsage(result: any): Record<string, unknown> | undefined {
+  const gw = result?.providerMetadata?.gateway;
+  if (!gw?.generationId) return undefined;
+  return {
+    generationId: gw.generationId,
+    marketCostUsd: parseFloat(gw.marketCost ?? gw.cost ?? "0") || undefined,
+    actualCostUsd: parseFloat(gw.cost ?? "0") || undefined,
+    resolvedModel: gw.routing?.canonicalSlug ?? gw.routing?.originalModelId,
+    finalProvider: gw.routing?.finalProvider,
+    credentialType: gw.routing?.modelAttempts?.[0]?.providerAttempts?.[0]?.credentialType,
+  };
 }
 
 function imageMime(ext: string): string {
@@ -158,23 +206,35 @@ async function generateImageWithSdk(
 ): Promise<ToolResult> {
   const { generateImage } = await import("ai");
 
-  const apiKey = resolveProviderKey(parsed.provider, vault);
-  const provider = await resolveImageProvider(parsed.provider as ImageProviderName, apiKey);
+  const managed = shouldUseGateway(parsed.provider, vault);
 
-  // fal-specific knobs go through providerOptions; the SDK passes them
-  // through to the model's input untouched.
-  const falOptions: Record<string, number> = {};
-  if (params.num_inference_steps != null) falOptions.num_inference_steps = params.num_inference_steps;
-  if (params.guidance_scale != null) falOptions.guidance_scale = params.guidance_scale;
+  let model: unknown;
+  let providerOptions: Record<string, unknown> | undefined;
+  if (managed) {
+    // Managed: route through the gateway (platform key pays, cost metered).
+    const provider = await resolveManagedImageProvider();
+    model = provider.image(gatewayModelId(parsed, DEFAULT_MANAGED_IMAGE_MODEL));
+  } else {
+    // BYOK / self-host: direct provider SDK with the agent's own key.
+    const apiKey = resolveProviderKey(parsed.provider, vault);
+    const provider = await resolveImageProvider(parsed.provider as ImageProviderName, apiKey);
+    model = provider.image(parsed.model);
+    // fal-specific knobs go through providerOptions; the SDK passes them
+    // through to the model's input untouched.
+    const falOptions: Record<string, number> = {};
+    if (params.num_inference_steps != null) falOptions.num_inference_steps = params.num_inference_steps;
+    if (params.guidance_scale != null) falOptions.guidance_scale = params.guidance_scale;
+    providerOptions = parsed.provider === "fal" && Object.keys(falOptions).length
+      ? { fal: falOptions }
+      : undefined;
+  }
 
   const result = await generateImage({
-    model: provider.image(parsed.model) as any,
+    model: model as any,
     prompt: params.prompt,
     size: params.size as `${number}x${number}` | undefined,
     seed: params.seed,
-    providerOptions: parsed.provider === "fal" && Object.keys(falOptions).length
-      ? { fal: falOptions }
-      : undefined,
+    providerOptions: providerOptions as any,
     abortSignal: signal,
   });
 
@@ -199,11 +259,13 @@ async function generateImageWithSdk(
   return {
     content: [{ type: "text", text: info.join("\n") }],
     details: {
-      provider: parsed.provider,
+      provider: managed ? "gateway" : parsed.provider,
       model: parsed.model,
       size: params.size,
       path: filePath,
       bytes: bytes.byteLength,
+      // Billable cost (managed/gateway only) — harvested by the runner.
+      usage: extractGatewayUsage(result),
     },
   };
 }
@@ -282,11 +344,21 @@ async function generateVideoWithSdk(
 ): Promise<ToolResult> {
   const { experimental_generateVideo } = await import("ai");
 
-  const apiKey = resolveProviderKey(parsed.provider, vault);
-  const provider = await resolveVideoProvider(parsed.provider as VideoProviderName, apiKey);
+  const managed = shouldUseGateway(parsed.provider, vault);
+
+  let model: unknown;
+  if (managed) {
+    // Managed: gateway with an extended-timeout fetch (long renders).
+    const provider = await resolveManagedVideoProvider();
+    model = provider.video(gatewayModelId(parsed, DEFAULT_MANAGED_VIDEO_MODEL));
+  } else {
+    const apiKey = resolveProviderKey(parsed.provider, vault);
+    const provider = await resolveVideoProvider(parsed.provider as VideoProviderName, apiKey);
+    model = provider.video(parsed.model);
+  }
 
   const result = await experimental_generateVideo({
-    model: provider.video(parsed.model) as any,
+    model: model as any,
     prompt: params.prompt,
     aspectRatio: params.aspect_ratio as `${number}:${number}` | undefined,
     resolution: params.resolution as `${number}x${number}` | undefined,
@@ -317,10 +389,12 @@ async function generateVideoWithSdk(
   return {
     content: [{ type: "text", text: info.join("\n") }],
     details: {
-      provider: parsed.provider,
+      provider: managed ? "gateway" : parsed.provider,
       model: parsed.model,
       path: filePath,
       bytes: bytes.byteLength,
+      // Billable cost (managed/gateway only) — harvested by the runner.
+      usage: extractGatewayUsage(result),
     },
   };
 }

--- a/packages/tools/src/image-tools.ts
+++ b/packages/tools/src/image-tools.ts
@@ -344,7 +344,18 @@ async function generateVideoWithSdk(
 ): Promise<ToolResult> {
   const { experimental_generateVideo } = await import("ai");
 
-  const managed = shouldUseGateway(parsed.provider, vault);
+  // Managed video is gated behind an explicit opt-in: each clip costs ~$1.20
+  // and there's no in-sandbox balance pre-check, so it must not bill by
+  // accident. Image has no such gate (≈$0.04). Set POLPO_MANAGED_VIDEO=1 to
+  // enable managed video; otherwise the agent must BYOK a fal key.
+  const gatewayAvailable = shouldUseGateway(parsed.provider, vault);
+  const managed = gatewayAvailable && process.env.POLPO_MANAGED_VIDEO === "1";
+  if (gatewayAvailable && !managed) {
+    throw new Error(
+      "Managed video generation is disabled. Set POLPO_MANAGED_VIDEO=1 to enable it " +
+        "(billed per clip), or give the agent a fal key (vault `fal-ai`/`key` or FAL_KEY) for BYOK.",
+    );
+  }
 
   let model: unknown;
   if (managed) {

--- a/packages/tools/src/lib/provider-resolver.ts
+++ b/packages/tools/src/lib/provider-resolver.ts
@@ -86,6 +86,55 @@ export async function resolveVideoProvider(
   return { video: (modelId: string) => fal.video(modelId) };
 }
 
+// ── Managed (Vercel AI Gateway) resolvers ──
+//
+// Used when the runtime has an AI_GATEWAY_API_KEY and the agent has NO
+// provider key of its own (the cloud "managed" case). The gateway pays via
+// the platform key and returns cost in `providerMetadata.gateway`
+// (generationId/marketCost/cost) — the same shape completions already meter.
+// BYOK stays on the direct-SDK path above; this is purely additive.
+
+/** A fetch with an extended Undici timeout. Video generation can take
+ *  5–15 min — well past Undici's default 5-min headers/body timeout, which
+ *  would otherwise abort the request mid-render. Degrades to the default
+ *  fetch if `undici` can't be loaded. */
+async function makeLongTimeoutFetch(
+  timeoutMs: number,
+): Promise<typeof globalThis.fetch | undefined> {
+  try {
+    const undici: any = await import("undici");
+    const dispatcher = new undici.Agent({
+      headersTimeout: timeoutMs,
+      bodyTimeout: timeoutMs,
+    });
+    return ((input: any, init: any = {}) =>
+      undici.fetch(input, { ...init, dispatcher })) as unknown as typeof globalThis.fetch;
+  } catch {
+    return undefined; // undici unavailable — fall back to default fetch
+  }
+}
+
+/** Build a managed image provider routed through the Vercel AI Gateway.
+ *  Authenticates via `AI_GATEWAY_API_KEY` (read by the gateway provider). */
+export async function resolveManagedImageProvider(): Promise<ImageProvider> {
+  const mod = await loadOptional("@ai-sdk/gateway", "managed image_generate");
+  // @ts-ignore — mod typed as `any` from the dynamic import helper
+  const gw = mod.createGatewayProvider();
+  return { image: (modelId: string) => gw.image(modelId) };
+}
+
+/** Build a managed video provider routed through the Vercel AI Gateway,
+ *  with an extended-timeout fetch so long renders aren't cut off. */
+export async function resolveManagedVideoProvider(
+  timeoutMs = 20 * 60 * 1000,
+): Promise<VideoProvider> {
+  const mod = await loadOptional("@ai-sdk/gateway", "managed video_generate");
+  const fetchImpl = await makeLongTimeoutFetch(timeoutMs);
+  // @ts-ignore — mod typed as `any` from the dynamic import helper
+  const gw = mod.createGatewayProvider(fetchImpl ? { fetch: fetchImpl } : undefined);
+  return { video: (modelId: string) => gw.video(modelId) };
+}
+
 /** Build a speech-to-text (transcription) provider. */
 export async function resolveTranscribeProvider(
   name: TranscribeProviderName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
       '@ai-sdk/fal':
         specifier: ^2.0.31
         version: 2.0.31(zod@4.3.6)
+      '@ai-sdk/gateway':
+        specifier: ^3.0.83
+        version: 3.0.83(zod@4.3.6)
       docx:
         specifier: ^9.5.0
         version: 9.5.3
@@ -322,6 +325,9 @@ importers:
       tinyglobby:
         specifier: ^0.2.0
         version: 0.2.15
+      undici:
+        specifier: ^7.0.0
+        version: 7.24.5
 
   packages/vault-crypto:
     devDependencies:
@@ -4013,14 +4019,14 @@ snapshots:
       msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
       vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@25.2.3)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5963,7 +5969,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/src/adapters/engine.ts
+++ b/src/adapters/engine.ts
@@ -546,6 +546,24 @@ export function spawnEngine(agentConfig: AgentConfig, task: Task, cwd: string, c
             }
           }
 
+          // Harvest billable per-tool inference cost (managed image/video via
+          // the gateway). Rides back in `details.usage`; the cloud data plane
+          // reads activity.toolUsage after the run → Autumn + usage_logs.
+          if (!isError && details?.usage && typeof details.usage === "object") {
+            const u = details.usage as Record<string, unknown>;
+            if (u.generationId || typeof u.marketCostUsd === "number") {
+              (activity.toolUsage ??= []).push({
+                toolName,
+                generationId: u.generationId as string | undefined,
+                marketCostUsd: u.marketCostUsd as number | undefined,
+                actualCostUsd: u.actualCostUsd as number | undefined,
+                resolvedModel: u.resolvedModel as string | undefined,
+                finalProvider: u.finalProvider as string | undefined,
+                credentialType: u.credentialType as string | undefined,
+              });
+            }
+          }
+
           // Emit tool result transcript
           const resultText = result.content
             .map((c: any) => c.text ?? "")


### PR DESCRIPTION
## What
Enables **managed** image/video generation through the Vercel AI Gateway and makes per-tool inference cost flow back to the server for metering — without a new sandbox→server channel.

## Routing (conditional / additive — non-breaking for OSS self-hosters)
Media tools use the gateway **only** when `AI_GATEWAY_API_KEY` is set **and** the agent has no provider key of its own (the cloud "managed" case). BYOK / self-host with a fal key stays on the direct-SDK path exactly as before.

## Changes
- **`provider-resolver.ts`**: `resolveManagedImageProvider()` / `resolveManagedVideoProvider()` via `createGatewayProvider()` (auth = `AI_GATEWAY_API_KEY`). Video uses an extended-timeout Undici fetch (~20 min) so long renders don't trip Undici's default 5-min headers/body timeout.
- **`image-tools.ts`**: `shouldUseGateway()` gate; gateway model-id mapping (fal-namespaced defaults → `bfl/flux-pro-1.1` / `google/veo-3.0-fast`); capture `providerMetadata.gateway` → `details.usage`. **Managed video gated behind `POLPO_MANAGED_VIDEO=1`** (≈$1.20/clip, no in-sandbox balance pre-check).
- **`core/types.ts`**: `AgentActivity.toolUsage[]` + `ToolUsageRecord`.
- **`engine.ts`**: harvest `details.usage` → `activity.toolUsage` on each tool result (rides the existing RunRecord → RunStore bus).
- **`tools/package.json`**: `@ai-sdk/gateway` + `undici` added to optionalDependencies.

The cloud data plane reads `activity.toolUsage` after a run → Autumn + `usage_logs` (separate cloud PR).

## Timeout verification
No per-tool timeout in the engine (signal aborts only on SIGTERM); server polling cap 30 min; Daytona session is `runAsync`. The only real risk was the Undici 5-min fetch timeout for long video renders — handled.

## Status
Builds clean, 61 tool tests pass, all tsc green. Not yet published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)