### PR TITLE
feat(tools): defineTool — native custom tools (Phase 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/src/__tests__/custom-tools.test.ts
+++ b/packages/tools/src/__tests__/custom-tools.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Phase 1 of defineTool — the pure-logic foundation (no sandbox, no API):
+ *   - defineTool()           authoring helper → CustomTool + __custom marker
+ *   - getCustomToolErrors()  shape/name validation (reused by the cloud API)
+ *   - isCustomTool()         type guard
+ *   - normalizeToolResult()  string | ToolResult → ToolResult
+ *   - bindCustomTool()       wrap a CustomTool into a runtime PolpoTool (ctx injection)
+ *   - extractCustomTool()    find the tool in a (bundled) module's exports
+ *   - loadCustomToolBundle() import a bundle file + bind → PolpoTool (self-host path)
+ *
+ * Test-first: these encode the contract before the implementation exists.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Type } from "@sinclair/typebox";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  defineTool,
+  getCustomToolErrors,
+  isCustomTool,
+  normalizeToolResult,
+  bindCustomTool,
+  extractCustomTool,
+  loadCustomToolBundle,
+  type CustomTool,
+  type CustomToolContext,
+} from "../custom-tools.js";
+
+/** Minimal ctx — bindCustomTool only passes it through, so stubs suffice. */
+function fakeCtx(overrides: Partial<CustomToolContext> = {}): Omit<CustomToolContext, "signal" | "onUpdate"> {
+  return {
+    fs: { marker: "fs" } as any,
+    shell: { marker: "shell" } as any,
+    vault: { marker: "vault" } as any,
+    env: { FOO: "bar" },
+    workDir: "/work",
+    polpo: { marker: "polpo" },
+    ...overrides,
+  };
+}
+
+const EchoSchema = Type.Object({ msg: Type.String() });
+
+describe("defineTool", () => {
+  it("returns the spec with the __custom marker", () => {
+    const tool = defineTool({
+      name: "echo",
+      description: "Echoes input",
+      parameters: EchoSchema,
+      execute: (_ctx, params) => `echo: ${params.msg}`,
+    });
+    expect(tool.__custom).toBe(true);
+    expect(tool.name).toBe("echo");
+    expect(tool.description).toBe("Echoes input");
+    expect(tool.parameters).toBe(EchoSchema);
+    expect(typeof tool.execute).toBe("function");
+  });
+
+  it("preserves optional label and clientSide", () => {
+    const tool = defineTool({
+      name: "echo",
+      label: "Echo Machine",
+      clientSide: true,
+      description: "d",
+      parameters: EchoSchema,
+      execute: () => "ok",
+    });
+    expect(tool.label).toBe("Echo Machine");
+    expect(tool.clientSide).toBe(true);
+  });
+});
+
+describe("getCustomToolErrors / isCustomTool", () => {
+  const valid = defineTool({
+    name: "do_thing",
+    description: "Does a thing",
+    parameters: EchoSchema,
+    execute: () => "ok",
+  });
+
+  it("accepts a valid tool", () => {
+    expect(getCustomToolErrors(valid)).toEqual([]);
+    expect(isCustomTool(valid)).toBe(true);
+  });
+
+  it("rejects non-objects", () => {
+    expect(getCustomToolErrors(null).length).toBeGreaterThan(0);
+    expect(getCustomToolErrors("nope").length).toBeGreaterThan(0);
+    expect(isCustomTool(null)).toBe(false);
+  });
+
+  it("requires a name", () => {
+    expect(getCustomToolErrors({ ...valid, name: "" }).join()).toMatch(/name/i);
+  });
+
+  it("enforces snake_case names", () => {
+    for (const bad of ["Echo", "my tool", "1tool", "my-tool", "MY_TOOL"]) {
+      expect(getCustomToolErrors({ ...valid, name: bad }).join()).toMatch(/snake_case|name/i);
+    }
+    for (const ok of ["echo", "do_thing", "get_user_v2", "a1_b2"]) {
+      expect(getCustomToolErrors({ ...valid, name: ok })).toEqual([]);
+    }
+  });
+
+  it("requires description, parameters and execute", () => {
+    expect(getCustomToolErrors({ ...valid, description: "  " }).join()).toMatch(/description/i);
+    expect(getCustomToolErrors({ ...valid, parameters: undefined }).join()).toMatch(/parameters/i);
+    expect(getCustomToolErrors({ ...valid, execute: "x" }).join()).toMatch(/execute/i);
+  });
+
+  it("validates optional field types", () => {
+    expect(getCustomToolErrors({ ...valid, label: 5 }).join()).toMatch(/label/i);
+    expect(getCustomToolErrors({ ...valid, clientSide: "yes" }).join()).toMatch(/clientSide/i);
+  });
+
+  it("isCustomTool requires the __custom marker", () => {
+    const { __custom, ...withoutMarker } = valid as any;
+    expect(isCustomTool(withoutMarker)).toBe(false);
+  });
+});
+
+describe("normalizeToolResult", () => {
+  it("wraps a plain string into a text ToolResult", () => {
+    expect(normalizeToolResult("hello")).toEqual({
+      content: [{ type: "text", text: "hello" }],
+      details: null,
+    });
+  });
+
+  it("passes a well-formed ToolResult through unchanged", () => {
+    const r = { content: [{ type: "text" as const, text: "x" }], details: { a: 1 } };
+    expect(normalizeToolResult(r)).toBe(r);
+  });
+
+  it("stringifies unexpected return values as a fallback", () => {
+    const out = normalizeToolResult({ foo: 1 } as any);
+    expect(out.content[0]).toEqual({ type: "text", text: JSON.stringify({ foo: 1 }) });
+  });
+});
+
+describe("bindCustomTool", () => {
+  let tool: CustomTool<typeof EchoSchema>;
+  beforeEach(() => {
+    tool = defineTool({
+      name: "echo",
+      description: "Echoes input",
+      parameters: EchoSchema,
+      execute: (_ctx, params) => `echo: ${params.msg}`,
+    });
+  });
+
+  it("produces a PolpoTool with name/label/description/parameters", () => {
+    const pt = bindCustomTool(tool, fakeCtx());
+    expect(pt.name).toBe("echo");
+    expect(pt.label).toBe("echo"); // defaults to name
+    expect(pt.description).toBe("Echoes input");
+    expect(pt.parameters).toBe(EchoSchema);
+    expect(typeof pt.execute).toBe("function");
+  });
+
+  it("defaults label to name, honors explicit label", () => {
+    expect(bindCustomTool(tool, fakeCtx()).label).toBe("echo");
+    const labeled = bindCustomTool({ ...tool, label: "Echo!" }, fakeCtx());
+    expect(labeled.label).toBe("Echo!");
+  });
+
+  it("runs execute with the injected ctx and normalizes a string result", async () => {
+    const pt = bindCustomTool(tool, fakeCtx());
+    const res = await pt.execute("call-1", { msg: "hi" });
+    expect(res).toEqual({ content: [{ type: "text", text: "echo: hi" }], details: null });
+  });
+
+  it("injects the full ctx (fs/shell/vault/env/workDir/polpo) plus signal & onUpdate", async () => {
+    let received: any;
+    const t = defineTool({
+      name: "spy",
+      description: "captures ctx",
+      parameters: EchoSchema,
+      execute: (ctx) => {
+        received = ctx;
+        return "ok";
+      },
+    });
+    const ctrl = new AbortController();
+    const onUpdate = () => {};
+    const pt = bindCustomTool(t, fakeCtx());
+    await pt.execute("c", { msg: "x" }, ctrl.signal, onUpdate);
+    expect(received.fs).toEqual({ marker: "fs" });
+    expect(received.shell).toEqual({ marker: "shell" });
+    expect(received.vault).toEqual({ marker: "vault" });
+    expect(received.env).toEqual({ FOO: "bar" });
+    expect(received.workDir).toBe("/work");
+    expect(received.polpo).toEqual({ marker: "polpo" });
+    expect(received.signal).toBe(ctrl.signal);
+    expect(received.onUpdate).toBe(onUpdate);
+  });
+
+  it("passes a ToolResult return value through unchanged", async () => {
+    const t = defineTool({
+      name: "rich",
+      description: "rich result",
+      parameters: EchoSchema,
+      execute: () => ({ content: [{ type: "text" as const, text: "rich" }], details: { ok: true } }),
+    });
+    const res = await bindCustomTool(t, fakeCtx()).execute("c", { msg: "x" });
+    expect(res.details).toEqual({ ok: true });
+  });
+
+  it("propagates errors thrown inside execute", async () => {
+    const t = defineTool({
+      name: "boom",
+      description: "throws",
+      parameters: EchoSchema,
+      execute: () => {
+        throw new Error("kaboom");
+      },
+    });
+    await expect(bindCustomTool(t, fakeCtx()).execute("c", { msg: "x" })).rejects.toThrow("kaboom");
+  });
+});
+
+describe("extractCustomTool", () => {
+  const tool = defineTool({
+    name: "echo",
+    description: "d",
+    parameters: EchoSchema,
+    execute: () => "ok",
+  });
+
+  it("finds a tool passed directly", () => {
+    expect(extractCustomTool(tool)).toBe(tool);
+  });
+
+  it("finds a default export", () => {
+    expect(extractCustomTool({ default: tool })).toBe(tool);
+  });
+
+  it("finds a nested default (esbuild interop)", () => {
+    expect(extractCustomTool({ default: { default: tool } })).toBe(tool);
+  });
+
+  it("finds a named export", () => {
+    expect(extractCustomTool({ myTool: tool })).toBe(tool);
+  });
+
+  it("throws a helpful error when no tool is present", () => {
+    expect(() => extractCustomTool({ foo: 1 })).toThrow(/no custom tool|export default/i);
+  });
+
+  it("surfaces validation errors for a near-miss default export", () => {
+    const broken = { __custom: true, name: "Bad Name", description: "d", parameters: EchoSchema, execute: () => "x" };
+    expect(() => extractCustomTool({ default: broken })).toThrow(/snake_case|invalid/i);
+  });
+});
+
+describe("loadCustomToolBundle", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "polpo-tool-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("imports a bundle file, binds ctx, and runs", async () => {
+    const file = join(dir, "echo.mjs");
+    await writeFile(
+      file,
+      `export default {
+        __custom: true,
+        name: "echo",
+        label: "Echo",
+        description: "echoes",
+        parameters: { type: "object", properties: { msg: { type: "string" } } },
+        execute: async (ctx, params) => "echo: " + params.msg + " @ " + ctx.workDir,
+      };`,
+    );
+    const pt = await loadCustomToolBundle(file, fakeCtx({ workDir: "/sandbox" }));
+    expect(pt.name).toBe("echo");
+    expect(pt.label).toBe("Echo");
+    const res = await pt.execute("c", { msg: "hi" });
+    expect(res.content[0]).toEqual({ type: "text", text: "echo: hi @ /sandbox" });
+  });
+
+  it("accepts an already-imported module object", async () => {
+    const tool = defineTool({ name: "echo", description: "d", parameters: EchoSchema, execute: () => "ok" });
+    const pt = await loadCustomToolBundle({ default: tool }, fakeCtx());
+    expect(pt.name).toBe("echo");
+    expect((await pt.execute("c", { msg: "x" })).content[0]).toEqual({ type: "text", text: "ok" });
+  });
+
+  it("rejects a bundle with no valid tool", async () => {
+    const file = join(dir, "bad.mjs");
+    await writeFile(file, `export const notATool = 42;`);
+    await expect(loadCustomToolBundle(file, fakeCtx())).rejects.toThrow(/no custom tool|export default/i);
+  });
+});

--- a/packages/tools/src/custom-tools.ts
+++ b/packages/tools/src/custom-tools.ts
@@ -1,0 +1,227 @@
+/**
+ * defineTool — native custom tools (Phase 1: authoring + validation + binding).
+ *
+ * Devs author a tool with capability-injected `ctx` (no ambient globals):
+ *
+ *   export default defineTool({
+ *     name: "create_invoice",
+ *     description: "Create an invoice for a customer",
+ *     parameters: Type.Object({ customerId: Type.String(), amount: Type.Number() }),
+ *     async execute(ctx, params) {
+ *       const res = await ctx.polpo.invoices.create(params);
+ *       return `Created invoice ${res.id}`;
+ *     },
+ *   });
+ *
+ * At runtime the cloud bundles + executes this inside the per-project sandbox
+ * (Phases 2–3); for OSS self-host it runs in-process via {@link loadCustomToolBundle}.
+ * Both paths converge on {@link bindCustomTool}, which adapts the ctx-based
+ * `execute(ctx, params)` to the standard {@link PolpoTool} signature.
+ */
+import type { TSchema, Static } from "@sinclair/typebox";
+import { pathToFileURL } from "node:url";
+
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import type { Shell } from "@polpo-ai/core/shell";
+import type { PolpoTool, ToolResult, ToolUpdateCallback } from "@polpo-ai/core";
+import type { ResolvedVault } from "./types.js";
+
+/**
+ * Capabilities injected into a custom tool's `execute`. Everything a tool can
+ * touch arrives here — there are no ambient globals or platform env access.
+ */
+export interface CustomToolContext {
+  /** Sandboxed filesystem rooted at the project workspace. */
+  fs: FileSystem;
+  /** Shell for running commands in the workspace. */
+  shell: Shell;
+  /** Agent vault — resolved credentials (API keys, SMTP, …). */
+  vault: ResolvedVault;
+  /** Safe environment variables (platform secrets stripped). */
+  env: Record<string, string | undefined>;
+  /** Absolute working directory inside the workspace. */
+  workDir: string;
+  /** Preconfigured Polpo SDK client, scoped to the project. Typed loosely in v1. */
+  polpo?: unknown;
+  /** Abort signal for this tool call. */
+  signal?: AbortSignal;
+  /** Stream partial results back to the runtime. */
+  onUpdate?: ToolUpdateCallback;
+}
+
+/** A custom tool's return value — a plain string (wrapped as text) or a full ToolResult. */
+export type CustomToolExecuteResult = string | ToolResult;
+
+/** The object passed to {@link defineTool}. */
+export interface CustomToolSpec<T extends TSchema = TSchema> {
+  /** Unique, snake_case identifier exposed to the model. */
+  name: string;
+  /** What the tool does — shown to the model. */
+  description: string;
+  /** TypeBox schema for the tool arguments. */
+  parameters: T;
+  /** Human-friendly label for UIs. Defaults to `name`. */
+  label?: string;
+  /** Run on the client instead of the sandbox (plumbed in a later phase). */
+  clientSide?: boolean;
+  /** Tool body. Receives injected capabilities + validated params. */
+  execute: (
+    ctx: CustomToolContext,
+    params: Static<T>,
+  ) => CustomToolExecuteResult | Promise<CustomToolExecuteResult>;
+}
+
+/** A defined custom tool — a {@link CustomToolSpec} tagged with the `__custom` marker. */
+export interface CustomTool<T extends TSchema = TSchema> extends CustomToolSpec<T> {
+  readonly __custom: true;
+}
+
+/** snake_case: lowercase letter start, then lowercase / digits / underscores. */
+const NAME_RE = /^[a-z][a-z0-9_]*$/;
+
+/**
+ * Authoring helper. Returns the spec tagged with `__custom: true` so the loader
+ * and the cloud registry can recognize it. Pure — no side effects.
+ */
+export function defineTool<T extends TSchema>(spec: CustomToolSpec<T>): CustomTool<T> {
+  return { ...spec, __custom: true };
+}
+
+/**
+ * Validate a candidate tool's shape. Returns human-readable error strings
+ * (empty array = valid). Reused by the loader and the cloud `POST /v1/tools`
+ * endpoint so authors get identical feedback in the CLI, dashboard and at load.
+ */
+export function getCustomToolErrors(value: unknown): string[] {
+  if (typeof value !== "object" || value === null) {
+    return ["Tool must be an object (did you `export default defineTool({...})`?)"];
+  }
+  const t = value as Record<string, unknown>;
+  const errors: string[] = [];
+
+  if (typeof t.name !== "string" || t.name.length === 0) {
+    errors.push("`name` is required and must be a non-empty string");
+  } else if (!NAME_RE.test(t.name)) {
+    errors.push(
+      `\`name\` must be snake_case (lowercase letters, digits, underscores; starting with a letter): got "${t.name}"`,
+    );
+  }
+  if (typeof t.description !== "string" || t.description.trim().length === 0) {
+    errors.push("`description` is required and must be a non-empty string");
+  }
+  if (typeof t.parameters !== "object" || t.parameters === null) {
+    errors.push("`parameters` is required and must be a TypeBox schema object");
+  }
+  if (typeof t.execute !== "function") {
+    errors.push("`execute` is required and must be a function `(ctx, params) => result`");
+  }
+  if (t.label !== undefined && typeof t.label !== "string") {
+    errors.push("`label` must be a string when provided");
+  }
+  if (t.clientSide !== undefined && typeof t.clientSide !== "boolean") {
+    errors.push("`clientSide` must be a boolean when provided");
+  }
+  return errors;
+}
+
+/** Type guard: a valid custom tool carrying the `__custom` marker. */
+export function isCustomTool(value: unknown): value is CustomTool {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<string, unknown>).__custom === true &&
+    getCustomToolErrors(value).length === 0
+  );
+}
+
+/** Coerce a custom tool's return value into a {@link ToolResult}. */
+export function normalizeToolResult(result: CustomToolExecuteResult): ToolResult {
+  if (typeof result === "string") {
+    return { content: [{ type: "text", text: result }], details: null };
+  }
+  if (
+    result &&
+    typeof result === "object" &&
+    Array.isArray((result as ToolResult).content)
+  ) {
+    return result as ToolResult;
+  }
+  // Lenient fallback: a tool returned something unexpected — surface it as text
+  // rather than crashing the run.
+  return { content: [{ type: "text", text: JSON.stringify(result) }], details: result ?? null };
+}
+
+/** ctx without the per-call fields, which {@link bindCustomTool} supplies itself. */
+export type CustomToolBindContext = Omit<CustomToolContext, "signal" | "onUpdate">;
+
+/**
+ * Adapt a {@link CustomTool} (ctx-based `execute`) into a runtime {@link PolpoTool}
+ * (`execute(toolCallId, params, signal?, onUpdate?)`), binding the injected ctx.
+ * This is the "wrap at registration" step that lets custom and built-in tools
+ * coexist without touching the built-ins.
+ */
+export function bindCustomTool<T extends TSchema>(
+  tool: CustomTool<T>,
+  ctx: CustomToolBindContext,
+): PolpoTool<T> {
+  return {
+    name: tool.name,
+    label: tool.label ?? tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+    async execute(_toolCallId, params, signal, onUpdate) {
+      const result = await tool.execute(
+        { ...ctx, signal, onUpdate },
+        params as Static<T>,
+      );
+      return normalizeToolResult(result);
+    },
+  };
+}
+
+/**
+ * Find the custom tool inside a (possibly bundled) module's exports. Accepts a
+ * tool passed directly, a default export, a nested default (esbuild interop),
+ * or the first matching named export. Throws a helpful error otherwise.
+ */
+export function extractCustomTool(moduleOrTool: unknown): CustomTool {
+  if (isCustomTool(moduleOrTool)) return moduleOrTool;
+
+  if (typeof moduleOrTool === "object" && moduleOrTool !== null) {
+    const mod = moduleOrTool as Record<string, unknown>;
+    const nestedDefault = (mod.default as Record<string, unknown> | undefined)?.default;
+    const candidates: unknown[] = [mod.default, nestedDefault, ...Object.values(mod)];
+    for (const c of candidates) {
+      if (isCustomTool(c)) return c;
+    }
+    // Near-miss: a __custom-tagged export that failed validation → surface why.
+    const near = candidates.find(
+      (c) => typeof c === "object" && c !== null && (c as Record<string, unknown>).__custom === true,
+    );
+    if (near) {
+      const errs = getCustomToolErrors(near);
+      throw new Error(`Invalid custom tool:\n- ${errs.join("\n- ")}`);
+    }
+  }
+
+  throw new Error(
+    "No custom tool found in module. Expected `export default defineTool({...})`.",
+  );
+}
+
+/**
+ * Load a custom tool bundle and bind it to a runtime ctx → {@link PolpoTool}.
+ * Accepts either a filesystem path to a bundled module (dynamic import — the
+ * OSS self-host path) or an already-imported module/tool object.
+ */
+export async function loadCustomToolBundle(
+  pathOrModule: string | object,
+  ctx: CustomToolBindContext,
+): Promise<PolpoTool> {
+  const mod =
+    typeof pathOrModule === "string"
+      ? await import(pathToFileURL(pathOrModule).href)
+      : pathOrModule;
+  const tool = extractCustomTool(mod);
+  return bindCustomTool(tool, ctx);
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -44,5 +44,23 @@ export { assertPathAllowed, resolveAllowedPaths, isPathAllowed } from "./path-sa
 export { safeEnv, bashSafeEnv } from "./safe-env.js";
 export { assertUrlAllowed } from "./ssrf-guard.js";
 
+// Custom tools (defineTool)
+export {
+  defineTool,
+  getCustomToolErrors,
+  isCustomTool,
+  normalizeToolResult,
+  bindCustomTool,
+  extractCustomTool,
+  loadCustomToolBundle,
+} from "./custom-tools.js";
+export type {
+  CustomTool,
+  CustomToolSpec,
+  CustomToolContext,
+  CustomToolBindContext,
+  CustomToolExecuteResult,
+} from "./custom-tools.js";
+
 // Types
 export type { ResolvedVault } from "./types.js";

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.7.18",
+  "version": "0.8.0",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What
Phase 1 of `defineTool` — the pure-logic foundation for **native custom tools**. Devs author a tool with capability-injected `ctx` (no ambient globals); the cloud will bundle + execute it inside the per-project sandbox (Phases 2–4), and OSS self-host runs it in-process.

```ts
export default defineTool({
  name: "create_invoice",
  description: "Create an invoice for a customer",
  parameters: Type.Object({ customerId: Type.String(), amount: Type.Number() }),
  async execute(ctx, params) {
    const res = await ctx.polpo.invoices.create(params);
    return `Created invoice ${res.id}`;
  },
});
```

## API (`@polpo-ai/tools`)
- `defineTool(spec)` → `CustomTool` (+ `__custom` marker)
- `getCustomToolErrors` / `isCustomTool` — shape + snake_case validation (reused by the cloud `POST /v1/tools`)
- `normalizeToolResult` — `string | ToolResult` → `ToolResult`
- `bindCustomTool` — adapt ctx-based `execute(ctx, params)` to the `PolpoTool` signature (wrap-at-registration; built-ins untouched)
- `extractCustomTool` / `loadCustomToolBundle` — load a bundle (path or module) + bind (self-host path)
- `CustomToolContext`: `{ fs, shell, vault, env, workDir, polpo, signal?, onUpdate? }`

## Tests
27 new tests (TDD), **381 total green**, typecheck clean. Version bumped to **0.8.0**.

## Follow-up (cloud, separate repo)
- Phase 2: `routes/tools.ts` — bundle-in-sandbox (esbuild) + validate + store (R2) + register
- Phase 3: execution in sandbox via ProxyTool (isolation)
- Phase 4: CLI (`polpo tools push/test`) + dashboard Monaco editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)