### PR TITLE
feat(core): add loop runner hooks

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,5 +156,22 @@ export type { EventCatalogGroup, EventCatalogEntry } from "./events-catalog.js";
 // Configurable agentic loops (design: loop collection + pipeline + hooks). P0:
 // the safe expression evaluator (replaces the gates' `new Function`) + config types.
 export { evaluateExpression, SafeExpressionEvaluator } from "./loop/expression.js";
-export type { AgentLoopConfig, LoopConfig, Pipeline, Step, SwitchCase, Condition } from "./loop/types.js";
+export type { AgentLoopConfig, ContextBag, LoopConfig, Pipeline, Step, SwitchCase, Condition } from "./loop/types.js";
 export { isLoopStep, isParallelStep, isSwitchStep, isHumanStep } from "./loop/types.js";
+export { LoopHookRegistry } from "./loop/hooks.js";
+export type {
+  LoopBeforeHookResult,
+  LoopHook,
+  LoopHookContext,
+  LoopHookHandler,
+  LoopHookPayloads,
+  LoopHookPhase,
+  LoopHookRegistration,
+  LoopRunStatus,
+  LoopRuntimeConfig,
+  LoopStopReason,
+  LoopToolCall,
+  LoopToolResult,
+} from "./loop/hooks.js";
+export { LoopRunner } from "./loop/runner.js";
+export type { LoopModelInput, LoopModelResult, LoopRunnerOptions, LoopRunResult } from "./loop/runner.js";

--- a/packages/core/src/loop/hooks.ts
+++ b/packages/core/src/loop/hooks.ts
@@ -1,0 +1,244 @@
+import type { AgentConfig } from "../types.js";
+import type { ContextBag, LoopConfig } from "./types.js";
+
+export type LoopHook =
+  | "loop:start"
+  | "step:before"
+  | "model:before"
+  | "tool:before"
+  | "tool:after"
+  | "step:after"
+  | "loop:stop"
+  | "loop:transition"
+  | "loop:end";
+
+export type LoopHookPhase = "before" | "after";
+
+export interface LoopRuntimeConfig extends LoopConfig {
+  name: string;
+}
+
+export interface LoopToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface LoopHookPayloads {
+  "loop:start": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    context: ContextBag;
+    input?: unknown;
+  };
+  "step:before": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    turn: number;
+    context: ContextBag;
+    activeTools?: string[];
+    toolChoice?: unknown;
+  };
+  "model:before": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    turn: number;
+    context: ContextBag;
+    activeTools?: string[];
+    toolChoice?: unknown;
+  };
+  "tool:before": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    turn: number;
+    context: ContextBag;
+    toolCall: LoopToolCall;
+    result?: string;
+  };
+  "tool:after": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    turn: number;
+    context: ContextBag;
+    toolCall: LoopToolCall;
+    result: string;
+    isError: boolean;
+    skipped: boolean;
+  };
+  "step:after": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    turn: number;
+    context: ContextBag;
+    text: string;
+    toolCalls: LoopToolCall[];
+    toolResults: LoopToolResult[];
+    usage?: unknown;
+  };
+  "loop:stop": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    turn: number;
+    context: ContextBag;
+    reason: LoopStopReason;
+    shouldStop: boolean;
+  };
+  "loop:transition": {
+    agent?: AgentConfig;
+    from: string;
+    to: string;
+    context: ContextBag;
+  };
+  "loop:end": {
+    agent?: AgentConfig;
+    loop: LoopRuntimeConfig;
+    context: ContextBag;
+    status: LoopRunStatus;
+    reason: LoopStopReason;
+    turns: number;
+    text: string;
+  };
+}
+
+export type LoopStopReason = "completed" | "max_turns" | "cancelled";
+export type LoopRunStatus = "completed" | "cancelled";
+
+export interface LoopToolResult {
+  toolCall: LoopToolCall;
+  result: string;
+  isError: boolean;
+  skipped: boolean;
+}
+
+export interface LoopHookContext<T = unknown> {
+  readonly hook: LoopHook;
+  readonly phase: LoopHookPhase;
+  data: T;
+  cancel(reason?: string): void;
+  readonly cancelled: boolean;
+  readonly cancelReason?: string;
+  readonly timestamp: string;
+}
+
+export type LoopHookHandler<T = unknown> = (ctx: LoopHookContext<T>) => void | Promise<void>;
+
+export interface LoopHookRegistration<K extends LoopHook = LoopHook> {
+  hook: K;
+  phase: LoopHookPhase;
+  handler: LoopHookHandler<LoopHookPayloads[K]>;
+  priority?: number;
+  name?: string;
+}
+
+export interface LoopBeforeHookResult<T> {
+  cancelled: boolean;
+  cancelReason?: string;
+  data: T;
+}
+
+interface StoredLoopRegistration {
+  hook: LoopHook;
+  phase: LoopHookPhase;
+  handler: LoopHookHandler<any>;
+  priority: number;
+  name?: string;
+}
+
+export class LoopHookRegistry {
+  private registrations: StoredLoopRegistration[] = [];
+
+  register<K extends LoopHook>(reg: LoopHookRegistration<K>): () => void {
+    const stored: StoredLoopRegistration = {
+      hook: reg.hook,
+      phase: reg.phase,
+      handler: reg.handler as LoopHookHandler<any>,
+      priority: reg.priority ?? 100,
+      name: reg.name,
+    };
+
+    this.registrations.push(stored);
+    this.registrations.sort((a, b) => a.priority - b.priority);
+
+    return () => {
+      const idx = this.registrations.indexOf(stored);
+      if (idx >= 0) this.registrations.splice(idx, 1);
+    };
+  }
+
+  async runBefore<K extends LoopHook>(
+    hook: K,
+    data: LoopHookPayloads[K],
+  ): Promise<LoopBeforeHookResult<LoopHookPayloads[K]>> {
+    const handlers = this.registrations.filter(r => r.hook === hook && r.phase === "before");
+    if (handlers.length === 0) return { cancelled: false, data };
+
+    let cancelled = false;
+    let cancelReason: string | undefined;
+    const ctx: LoopHookContext<LoopHookPayloads[K]> = {
+      hook,
+      phase: "before",
+      data,
+      cancel(reason?: string) {
+        cancelled = true;
+        cancelReason = reason;
+      },
+      get cancelled() { return cancelled; },
+      get cancelReason() { return cancelReason; },
+      timestamp: new Date().toISOString(),
+    };
+
+    for (const reg of handlers) {
+      try {
+        await reg.handler(ctx);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[LoopHookRegistry] Error in before:${hook} handler "${reg.name ?? "anonymous"}": ${msg}`);
+      }
+    }
+
+    return { cancelled, cancelReason, data: ctx.data };
+  }
+
+  async runAfter<K extends LoopHook>(
+    hook: K,
+    data: LoopHookPayloads[K],
+  ): Promise<void> {
+    const handlers = this.registrations.filter(r => r.hook === hook && r.phase === "after");
+    if (handlers.length === 0) return;
+
+    const ctx: LoopHookContext<LoopHookPayloads[K]> = {
+      hook,
+      phase: "after",
+      data,
+      cancel() {},
+      get cancelled() { return false; },
+      timestamp: new Date().toISOString(),
+    };
+
+    for (const reg of handlers) {
+      try {
+        await reg.handler(ctx);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[LoopHookRegistry] Error in after:${hook} handler "${reg.name ?? "anonymous"}": ${msg}`);
+      }
+    }
+  }
+
+  get size(): number {
+    return this.registrations.length;
+  }
+
+  list(): Array<{ hook: LoopHook; phase: LoopHookPhase; priority: number; name?: string }> {
+    return this.registrations.map(r => ({
+      hook: r.hook,
+      phase: r.phase,
+      priority: r.priority,
+      name: r.name,
+    }));
+  }
+
+  clear(): void {
+    this.registrations.length = 0;
+  }
+}

--- a/packages/core/src/loop/runner.test.ts
+++ b/packages/core/src/loop/runner.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { LoopHookRegistry } from "./hooks.js";
+import { LoopRunner } from "./runner.js";
+
+describe("LoopRunner", () => {
+  it("runs the implicit loop with ordered lifecycle hooks", async () => {
+    const events: string[] = [];
+    const hooks = new LoopHookRegistry();
+    hooks.register({ hook: "loop:start", phase: "before", handler: () => { events.push("loop:start"); } });
+    hooks.register({ hook: "step:before", phase: "before", handler: () => { events.push("step:before"); } });
+    hooks.register({ hook: "model:before", phase: "before", handler: () => { events.push("model:before"); } });
+    hooks.register({ hook: "step:after", phase: "after", handler: () => { events.push("step:after"); } });
+    hooks.register({ hook: "loop:stop", phase: "before", handler: () => { events.push("loop:stop"); } });
+    hooks.register({ hook: "loop:end", phase: "after", handler: () => { events.push("loop:end"); } });
+
+    const runner = new LoopRunner(hooks);
+    const result = await runner.run({
+      loop: { name: "default" },
+      model: async () => ({ text: "done" }),
+      executeTool: async () => "unused",
+    });
+
+    expect(result).toMatchObject({ status: "completed", reason: "completed", turns: 1, text: "done" });
+    expect(events).toEqual(["loop:start", "step:before", "model:before", "step:after", "loop:stop", "loop:end"]);
+  });
+
+  it("lets step hooks constrain active tools before the model call", async () => {
+    const hooks = new LoopHookRegistry();
+    hooks.register({
+      hook: "step:before",
+      phase: "before",
+      handler: (ctx) => {
+        ctx.data.activeTools = ["read"];
+      },
+    });
+
+    const seenTools: unknown[] = [];
+    const runner = new LoopRunner(hooks);
+    await runner.run({
+      loop: { name: "plan", tools: ["read", "write"] },
+      model: async (input) => {
+        seenTools.push(input.activeTools);
+        return { text: "planned" };
+      },
+      executeTool: async () => "unused",
+    });
+
+    expect(seenTools).toEqual([["read"]]);
+  });
+
+  it("allows tool:before hooks to deny a tool call without invoking the executor", async () => {
+    const hooks = new LoopHookRegistry();
+    hooks.register({
+      hook: "tool:before",
+      phase: "before",
+      handler: (ctx) => {
+        if (ctx.data.toolCall.name === "write") ctx.cancel("read-only loop");
+      },
+    });
+
+    let executed = false;
+    const runner = new LoopRunner(hooks);
+    const result = await runner.run({
+      loop: { name: "plan", tools: ["read"] },
+      maxTurns: 1,
+      model: async () => ({
+        text: "I will write.",
+        toolCalls: [{ id: "call-1", name: "write", args: { path: "x.txt" } }],
+      }),
+      executeTool: async () => {
+        executed = true;
+        return "should not run";
+      },
+    });
+
+    expect(executed).toBe(false);
+    expect(result.toolResults).toHaveLength(1);
+    expect(result.toolResults[0]).toMatchObject({
+      skipped: true,
+      isError: true,
+      result: 'Error: Tool call "write" denied: read-only loop',
+    });
+  });
+
+  it("continues when loop:stop mutates shouldStop to false", async () => {
+    const hooks = new LoopHookRegistry();
+    hooks.register({
+      hook: "loop:stop",
+      phase: "before",
+      handler: (ctx) => {
+        if (ctx.data.turn === 0) ctx.data.shouldStop = false;
+      },
+    });
+
+    let calls = 0;
+    const runner = new LoopRunner(hooks);
+    const result = await runner.run({
+      loop: { name: "review" },
+      maxTurns: 2,
+      model: async () => {
+        calls++;
+        return { text: String(calls) };
+      },
+      executeTool: async () => "unused",
+    });
+
+    expect(result.text).toBe("12");
+    expect(result.turns).toBe(2);
+    expect(result.reason).toBe("completed");
+  });
+});

--- a/packages/core/src/loop/runner.ts
+++ b/packages/core/src/loop/runner.ts
@@ -1,0 +1,269 @@
+import type { AgentConfig } from "../types.js";
+import type { ContextBag, LoopConfig } from "./types.js";
+import {
+  LoopHookRegistry,
+  type LoopRuntimeConfig,
+  type LoopRunStatus,
+  type LoopStopReason,
+  type LoopToolCall,
+  type LoopToolResult,
+} from "./hooks.js";
+
+export interface LoopModelInput {
+  agent?: AgentConfig;
+  loop: LoopRuntimeConfig;
+  turn: number;
+  context: ContextBag;
+  activeTools?: string[];
+  toolChoice?: unknown;
+}
+
+export interface LoopModelResult {
+  text: string;
+  toolCalls?: LoopToolCall[];
+  usage?: unknown;
+}
+
+export interface LoopRunResult {
+  status: LoopRunStatus;
+  reason: LoopStopReason;
+  turns: number;
+  text: string;
+  context: ContextBag;
+  toolResults: LoopToolResult[];
+}
+
+export interface LoopRunnerOptions {
+  agent?: AgentConfig;
+  loop: LoopConfig & { name?: string };
+  context?: ContextBag;
+  input?: unknown;
+  hooks?: LoopHookRegistry;
+  maxTurns?: number;
+  model: (input: LoopModelInput) => Promise<LoopModelResult>;
+  executeTool: (toolCall: LoopToolCall, input: LoopModelInput) => Promise<string>;
+}
+
+const DEFAULT_MAX_TURNS = 20;
+
+function normalizeLoop(loop: LoopConfig & { name?: string }): LoopRuntimeConfig {
+  return {
+    ...loop,
+    name: loop.name ?? "default",
+  };
+}
+
+function shouldStopAfterTurn(result: LoopModelResult, turn: number, maxTurns: number): { reason: LoopStopReason; shouldStop: boolean } {
+  if ((result.toolCalls ?? []).length === 0) return { reason: "completed", shouldStop: true };
+  if (turn + 1 >= maxTurns) return { reason: "max_turns", shouldStop: true };
+  return { reason: "completed", shouldStop: false };
+}
+
+export class LoopRunner {
+  private readonly hooks: LoopHookRegistry;
+
+  constructor(hooks?: LoopHookRegistry) {
+    this.hooks = hooks ?? new LoopHookRegistry();
+  }
+
+  async run(options: LoopRunnerOptions): Promise<LoopRunResult> {
+    const hooks = options.hooks ?? this.hooks;
+    const loop = normalizeLoop(options.loop);
+    const context = options.context ?? {};
+    const maxTurns = options.maxTurns ?? loop.maxTurns ?? DEFAULT_MAX_TURNS;
+    let finalText = "";
+    let turns = 0;
+    const allToolResults: LoopToolResult[] = [];
+
+    const start = await hooks.runBefore("loop:start", {
+      agent: options.agent,
+      loop,
+      context,
+      input: options.input,
+    });
+    if (start.cancelled) {
+      return this.finish(hooks, {
+        agent: options.agent,
+        loop,
+        context,
+        status: "cancelled",
+        reason: "cancelled",
+        turns,
+        text: finalText,
+        toolResults: allToolResults,
+      });
+    }
+
+    for (let turn = 0; turn < maxTurns; turn++) {
+      turns = turn + 1;
+      const step = await hooks.runBefore("step:before", {
+        agent: options.agent,
+        loop,
+        turn,
+        context,
+        activeTools: loop.tools,
+      });
+      if (step.cancelled) {
+        return this.finish(hooks, {
+          agent: options.agent,
+          loop,
+          context,
+          status: "cancelled",
+          reason: "cancelled",
+          turns,
+          text: finalText,
+          toolResults: allToolResults,
+        });
+      }
+
+      const modelBefore = await hooks.runBefore("model:before", {
+        agent: options.agent,
+        loop,
+        turn,
+        context,
+        activeTools: step.data.activeTools,
+        toolChoice: step.data.toolChoice,
+      });
+      if (modelBefore.cancelled) {
+        return this.finish(hooks, {
+          agent: options.agent,
+          loop,
+          context,
+          status: "cancelled",
+          reason: "cancelled",
+          turns,
+          text: finalText,
+          toolResults: allToolResults,
+        });
+      }
+
+      const modelInput: LoopModelInput = {
+        agent: options.agent,
+        loop,
+        turn,
+        context,
+        activeTools: modelBefore.data.activeTools,
+        toolChoice: modelBefore.data.toolChoice,
+      };
+      const modelResult = await options.model(modelInput);
+      finalText += modelResult.text;
+
+      const toolResults: LoopToolResult[] = [];
+      for (const rawCall of modelResult.toolCalls ?? []) {
+        const before = await hooks.runBefore("tool:before", {
+          agent: options.agent,
+          loop,
+          turn,
+          context,
+          toolCall: { ...rawCall, args: { ...rawCall.args } },
+        });
+
+        const toolCall = before.data.toolCall;
+        const skipped = before.cancelled;
+        const result = skipped
+          ? before.data.result ?? `Error: Tool call "${toolCall.name}" denied${before.cancelReason ? `: ${before.cancelReason}` : ""}`
+          : await options.executeTool(toolCall, modelInput);
+        const toolResult: LoopToolResult = {
+          toolCall,
+          result,
+          isError: result.startsWith("Error:"),
+          skipped,
+        };
+
+        toolResults.push(toolResult);
+        allToolResults.push(toolResult);
+
+        await hooks.runAfter("tool:after", {
+          agent: options.agent,
+          loop,
+          turn,
+          context,
+          toolCall,
+          result,
+          isError: toolResult.isError,
+          skipped,
+        });
+      }
+
+      await hooks.runAfter("step:after", {
+        agent: options.agent,
+        loop,
+        turn,
+        context,
+        text: modelResult.text,
+        toolCalls: modelResult.toolCalls ?? [],
+        toolResults,
+        usage: modelResult.usage,
+      });
+
+      const stop = shouldStopAfterTurn(modelResult, turn, maxTurns);
+      const stopResult = await hooks.runBefore("loop:stop", {
+        agent: options.agent,
+        loop,
+        turn,
+        context,
+        reason: stop.reason,
+        shouldStop: stop.shouldStop,
+      });
+      if (stopResult.cancelled) {
+        return this.finish(hooks, {
+          agent: options.agent,
+          loop,
+          context,
+          status: "cancelled",
+          reason: "cancelled",
+          turns,
+          text: finalText,
+          toolResults: allToolResults,
+        });
+      }
+      if (stopResult.data.shouldStop) {
+        return this.finish(hooks, {
+          agent: options.agent,
+          loop,
+          context,
+          status: "completed",
+          reason: stopResult.data.reason,
+          turns,
+          text: finalText,
+          toolResults: allToolResults,
+        });
+      }
+    }
+
+    return this.finish(hooks, {
+      agent: options.agent,
+      loop,
+      context,
+      status: "completed",
+      reason: "max_turns",
+      turns,
+      text: finalText,
+      toolResults: allToolResults,
+    });
+  }
+
+  private async finish(
+    hooks: LoopHookRegistry,
+    result: LoopRunResult & { agent?: AgentConfig; loop: LoopRuntimeConfig },
+  ): Promise<LoopRunResult> {
+    await hooks.runAfter("loop:end", {
+      agent: result.agent,
+      loop: result.loop,
+      context: result.context,
+      status: result.status,
+      reason: result.reason,
+      turns: result.turns,
+      text: result.text,
+    });
+
+    return {
+      status: result.status,
+      reason: result.reason,
+      turns: result.turns,
+      text: result.text,
+      context: result.context,
+      toolResults: result.toolResults,
+    };
+  }
+}

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -13,6 +13,8 @@ export interface Condition {
   expression: string;
 }
 
+export type ContextBag = Record<string, unknown>;
+
 export interface LoopConfig {
   /** Optional — the loops-map key is the canonical name. */
   name?: string;


### PR DESCRIPTION
## Summary\n- add LoopHookRegistry with loop/start/step/model/tool/stop/end hook catalog\n- add pure LoopRunner adapter for the implicit single-loop runtime\n- cover hook order, active tool mutation, tool denial, and loop:stop continuation\n\n## Verification\n- pnpm typecheck\n- pnpm vitest run\n\nDepends on #71.