### PR TITLE
feat(loops): complete selector and pipeline runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,19 @@ Agents can declare a named loop collection plus an optional deterministic pipeli
 ]
 ```
 
-Loop conditions use Polpo's safe expression evaluator instead of JavaScript `eval` or `new Function`. The current OSS surface validates and round-trips the contract through core types, API schemas, SDK types, `polpo deploy`, and `polpo pull`; execution scheduling is being built in the next phases.
+Loop conditions use Polpo's safe expression evaluator instead of JavaScript `eval` or `new Function`. The OSS surface validates and round-trips the contract through core types, API schemas, SDK types, `polpo deploy`, and `polpo pull`.
+
+Agent-direct chat can target a loop explicitly:
+
+```json
+{
+  "agent": "router",
+  "loop": "classify",
+  "messages": [{ "role": "user", "content": "Route this request" }]
+}
+```
+
+At runtime, the selected loop narrows the effective prompt, tools, model, reasoning, and max turns for that request. Core also ships a pure `PipelineExecutor` for sequential, switch, parallel, and human pipeline nodes; hosts wire `runLoop` and `handleHuman` callbacks to their concrete runtime.
 
 ## SDK
 

--- a/packages/client-sdk/src/client/types.ts
+++ b/packages/client-sdk/src/client/types.ts
@@ -212,6 +212,7 @@ export interface LoopConfig {
   tools?: string[];
   model?: string;
   reasoning?: string;
+  temperature?: number;
   maxTurns?: number;
   stopWhen?: Condition;
   output?: { schema?: unknown };
@@ -1351,6 +1352,8 @@ export interface ChatCompletionRequest {
   sessionId?: string;
   /** Target a specific agent by name for direct conversation. Uses the agent's own model, system prompt, and coding tools. Omit to talk to the orchestrator (default). */
   agent?: string;
+  /** Polpo extension: target a configured loop on the selected agent. */
+  loop?: string;
   /**
    * Opaque end-user identifier (OpenAI-compat). Persisted on the session and
    * available for filtering, per-user analytics, and pass-through to billing

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,3 +175,13 @@ export type {
 } from "./loop/hooks.js";
 export { LoopRunner } from "./loop/runner.js";
 export type { LoopModelInput, LoopModelResult, LoopRunnerOptions, LoopRunResult } from "./loop/runner.js";
+export { resolveLoopSelection, resolveActiveLoopTools } from "./loop/selector.js";
+export type { LoopSelection } from "./loop/selector.js";
+export { PipelineExecutor } from "./loop/pipeline.js";
+export type {
+  PipelineExecutionResult,
+  PipelineExecutorOptions,
+  PipelineHumanResult,
+  PipelineLoopResult,
+  PipelineTraceEvent,
+} from "./loop/pipeline.js";

--- a/packages/core/src/loop/pipeline.test.ts
+++ b/packages/core/src/loop/pipeline.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { LoopHookRegistry } from "./hooks.js";
+import { PipelineExecutor } from "./pipeline.js";
+
+describe("PipelineExecutor", () => {
+  it("runs sequential loop steps and accumulates context by loop name", async () => {
+    const executor = new PipelineExecutor();
+    const result = await executor.execute({
+      loops: { plan: {}, build: {} },
+      pipeline: { steps: [{ loop: "plan" }, { loop: "build", when: "plan.ready == true" }] },
+      runLoop: async (name) => ({ output: { ready: true, name } }),
+    });
+
+    expect(result.context).toMatchObject({
+      plan: { ready: true, name: "plan" },
+      build: { ready: true, name: "build" },
+    });
+    expect(result.trace.map(e => e.type)).toEqual(["loop", "loop"]);
+  });
+
+  it("routes switch branches deterministically from context", async () => {
+    const executor = new PipelineExecutor();
+    const result = await executor.execute({
+      loops: { review: {}, fix: {}, ship: {} },
+      context: { review: { passed: false } },
+      pipeline: {
+        steps: [{
+          switch: {
+            cases: [
+              { when: "review.passed == true", steps: [{ loop: "ship" }] },
+              { when: "review.passed == false", steps: [{ loop: "fix" }] },
+            ],
+          },
+        }],
+      },
+      runLoop: async (name) => ({ output: { ran: name } }),
+    });
+
+    expect(result.context.fix).toEqual({ ran: "fix" });
+    expect(result.context.ship).toBeUndefined();
+  });
+
+  it("runs parallel branches against a frozen snapshot and merges by branch output", async () => {
+    const executor = new PipelineExecutor();
+    const result = await executor.execute({
+      loops: { test: {}, typecheck: {} },
+      context: { build: { done: true } },
+      pipeline: { steps: [{ parallel: [{ loop: "test" }, { loop: "typecheck" }], join: "all" }] },
+      runLoop: async (name, _loop, context) => {
+        expect(() => ((context as any).mutated = true)).toThrow();
+        return { output: { passed: name === "test" || name === "typecheck" } };
+      },
+    });
+
+    expect(result.context).toMatchObject({
+      test: { passed: true },
+      typecheck: { passed: true },
+    });
+    expect((result.context as any).mutated).toBeUndefined();
+  });
+
+  it("supports human nodes through an injected handler", async () => {
+    const executor = new PipelineExecutor();
+    const result = await executor.execute({
+      loops: {},
+      pipeline: { steps: [{ human: "underwriter" }] },
+      runLoop: async () => ({ output: {} }),
+      handleHuman: async () => ({ output: { decision: "approve" } }),
+    });
+
+    expect(result.context.underwriter).toEqual({ decision: "approve" });
+  });
+
+  it("fires loop:transition hooks between sequential loop nodes", async () => {
+    const hooks = new LoopHookRegistry();
+    const transitions: string[] = [];
+    hooks.register({
+      hook: "loop:transition",
+      phase: "before",
+      handler: (ctx) => {
+        transitions.push(`${ctx.data.from}->${ctx.data.to}`);
+      },
+    });
+
+    const executor = new PipelineExecutor();
+    await executor.execute({
+      hooks,
+      loops: { plan: {}, build: {} },
+      pipeline: { steps: [{ loop: "plan" }, { loop: "build" }] },
+      runLoop: async (name) => ({ output: { name } }),
+    });
+
+    expect(transitions).toEqual(["plan->build"]);
+  });
+
+  it("blocks a transition when loop:transition is cancelled", async () => {
+    const hooks = new LoopHookRegistry();
+    hooks.register({
+      hook: "loop:transition",
+      phase: "before",
+      handler: (ctx) => {
+        if (ctx.data.from === "plan" && ctx.data.to === "build") ctx.cancel("approval required");
+      },
+    });
+
+    const executor = new PipelineExecutor();
+    await expect(executor.execute({
+      hooks,
+      loops: { plan: {}, build: {} },
+      pipeline: { steps: [{ loop: "plan" }, { loop: "build" }] },
+      runLoop: async (name) => ({ output: { name } }),
+    })).rejects.toThrow('Loop transition from "plan" to "build" cancelled: approval required');
+  });
+});

--- a/packages/core/src/loop/pipeline.ts
+++ b/packages/core/src/loop/pipeline.ts
@@ -1,0 +1,148 @@
+import { SafeExpressionEvaluator } from "./expression.js";
+import type { LoopHookRegistry } from "./hooks.js";
+import { isHumanStep, isLoopStep, isParallelStep, isSwitchStep, type ContextBag, type LoopConfig, type Pipeline, type Step } from "./types.js";
+
+export interface PipelineLoopResult {
+  output?: unknown;
+  context?: ContextBag;
+}
+
+export interface PipelineHumanResult {
+  output?: unknown;
+  context?: ContextBag;
+}
+
+export interface PipelineTraceEvent {
+  type: "loop" | "human" | "switch" | "parallel" | "skip";
+  name?: string;
+  when?: string;
+  matched?: boolean;
+}
+
+export interface PipelineExecutionResult {
+  context: ContextBag;
+  trace: PipelineTraceEvent[];
+}
+
+export interface PipelineExecutorOptions {
+  pipeline: Pipeline;
+  loops: Record<string, LoopConfig>;
+  context?: ContextBag;
+  hooks?: LoopHookRegistry;
+  runLoop: (name: string, loop: LoopConfig, context: Readonly<ContextBag>) => Promise<PipelineLoopResult>;
+  handleHuman?: (name: string, step: Extract<Step, { human: string }>, context: Readonly<ContextBag>) => Promise<PipelineHumanResult>;
+}
+
+export class PipelineExecutor {
+  private readonly evaluator = new SafeExpressionEvaluator();
+
+  async execute(options: PipelineExecutorOptions): Promise<PipelineExecutionResult> {
+    const context = { ...(options.context ?? {}) };
+    const trace: PipelineTraceEvent[] = [];
+    await this.executeSteps(options.pipeline.steps, context, trace, options);
+    return { context, trace };
+  }
+
+  private async executeSteps(
+    steps: Step[],
+    context: ContextBag,
+    trace: PipelineTraceEvent[],
+    options: PipelineExecutorOptions,
+    previousNode?: string,
+  ): Promise<string | undefined> {
+    let lastNode = previousNode;
+    for (const step of steps) {
+      if (!this.matchesWhen(step.when, context)) {
+        trace.push({ type: "skip", when: step.when, matched: false });
+        continue;
+      }
+
+      if (isLoopStep(step)) {
+        const loop = options.loops[step.loop];
+        if (!loop) throw new Error(`Pipeline references unknown loop "${step.loop}"`);
+        await this.runTransitionHook(lastNode, step.loop, context, options);
+        const result = await options.runLoop(step.loop, loop, freezeContext(context));
+        mergeLoopResult(context, step.loop, result);
+        trace.push({ type: "loop", name: step.loop, when: step.when, matched: true });
+        lastNode = step.loop;
+        continue;
+      }
+
+      if (isSwitchStep(step)) {
+        let matched = false;
+        for (const branch of step.switch.cases) {
+          if (this.matchesWhen(branch.when, context)) {
+            trace.push({ type: "switch", when: branch.when, matched: true });
+            lastNode = await this.executeSteps(branch.steps, context, trace, options, lastNode);
+            matched = true;
+            break;
+          }
+        }
+        if (!matched && step.switch.default) {
+          trace.push({ type: "switch", matched: false });
+          lastNode = await this.executeSteps(step.switch.default.steps, context, trace, options, lastNode);
+        }
+        continue;
+      }
+
+      if (isParallelStep(step)) {
+        const snapshot = freezeContext(context);
+        const branchResults = await Promise.all(step.parallel.map(async (child) => {
+          const branchContext = { ...snapshot };
+          const branchTrace: PipelineTraceEvent[] = [];
+          await this.executeSteps([child], branchContext, branchTrace, options);
+          return { branchContext, branchTrace };
+        }));
+        for (const result of branchResults) {
+          Object.assign(context, result.branchContext);
+          trace.push(...result.branchTrace);
+        }
+        trace.push({ type: "parallel", matched: true });
+        continue;
+      }
+
+      if (isHumanStep(step)) {
+        if (!options.handleHuman) throw new Error(`Pipeline human step "${step.human}" requires a human handler`);
+        await this.runTransitionHook(lastNode, step.human, context, options);
+        const result = await options.handleHuman(step.human, step, freezeContext(context));
+        mergeLoopResult(context, step.human, result);
+        trace.push({ type: "human", name: step.human, when: step.when, matched: true });
+        lastNode = step.human;
+      }
+    }
+    return lastNode;
+  }
+
+  private matchesWhen(expression: string | undefined, context: ContextBag): boolean {
+    if (!expression) return true;
+    return this.evaluator.evaluate(expression, context);
+  }
+
+  private async runTransitionHook(
+    from: string | undefined,
+    to: string,
+    context: ContextBag,
+    options: PipelineExecutorOptions,
+  ): Promise<void> {
+    if (!from || !options.hooks) return;
+    const result = await options.hooks.runBefore("loop:transition", {
+      from,
+      to,
+      context,
+    });
+    if (result.cancelled) {
+      throw new Error(`Loop transition from "${from}" to "${to}" cancelled${result.cancelReason ? `: ${result.cancelReason}` : ""}`);
+    }
+    Object.assign(context, result.data.context);
+    await options.hooks.runAfter("loop:transition", result.data);
+  }
+}
+
+function freezeContext(context: ContextBag): Readonly<ContextBag> {
+  return Object.freeze({ ...context });
+}
+
+function mergeLoopResult(context: ContextBag, name: string, result: PipelineLoopResult | PipelineHumanResult): void {
+  if (result.context) Object.assign(context, result.context);
+  if (result.output !== undefined) context[name] = result.output;
+}

--- a/packages/core/src/loop/runner.test.ts
+++ b/packages/core/src/loop/runner.test.ts
@@ -108,4 +108,28 @@ describe("LoopRunner", () => {
     expect(result.turns).toBe(2);
     expect(result.reason).toBe("completed");
   });
+
+  it("uses stopWhen as the deterministic stop condition when configured", async () => {
+    const hooks = new LoopHookRegistry();
+    hooks.register({
+      hook: "step:after",
+      phase: "after",
+      handler: (ctx) => {
+        if (ctx.data.turn === 1) ctx.data.context.done = true;
+      },
+    });
+
+    const runner = new LoopRunner(hooks);
+    const result = await runner.run({
+      loop: { name: "build", stopWhen: { expression: "done == true" } },
+      maxTurns: 3,
+      model: async () => ({ text: "tick" }),
+      executeTool: async () => "unused",
+    });
+
+    expect(result.text).toBe("ticktick");
+    expect(result.turns).toBe(2);
+    expect(result.reason).toBe("completed");
+    expect(result.context.done).toBe(true);
+  });
 });

--- a/packages/core/src/loop/runner.ts
+++ b/packages/core/src/loop/runner.ts
@@ -1,4 +1,5 @@
 import type { AgentConfig } from "../types.js";
+import { SafeExpressionEvaluator } from "./expression.js";
 import type { ContextBag, LoopConfig } from "./types.js";
 import {
   LoopHookRegistry,
@@ -53,14 +54,28 @@ function normalizeLoop(loop: LoopConfig & { name?: string }): LoopRuntimeConfig 
   };
 }
 
-function shouldStopAfterTurn(result: LoopModelResult, turn: number, maxTurns: number): { reason: LoopStopReason; shouldStop: boolean } {
+function shouldStopAfterTurn(
+  loop: LoopRuntimeConfig,
+  context: ContextBag,
+  result: LoopModelResult,
+  turn: number,
+  maxTurns: number,
+  evaluator: SafeExpressionEvaluator,
+): { reason: LoopStopReason; shouldStop: boolean } {
+  const reachedMaxTurns = turn + 1 >= maxTurns;
+  if (loop.stopWhen) {
+    const matched = evaluator.evaluate(loop.stopWhen.expression, context);
+    if (matched) return { reason: "completed", shouldStop: true };
+    return reachedMaxTurns ? { reason: "max_turns", shouldStop: true } : { reason: "completed", shouldStop: false };
+  }
   if ((result.toolCalls ?? []).length === 0) return { reason: "completed", shouldStop: true };
-  if (turn + 1 >= maxTurns) return { reason: "max_turns", shouldStop: true };
+  if (reachedMaxTurns) return { reason: "max_turns", shouldStop: true };
   return { reason: "completed", shouldStop: false };
 }
 
 export class LoopRunner {
   private readonly hooks: LoopHookRegistry;
+  private readonly evaluator = new SafeExpressionEvaluator();
 
   constructor(hooks?: LoopHookRegistry) {
     this.hooks = hooks ?? new LoopHookRegistry();
@@ -196,7 +211,7 @@ export class LoopRunner {
         usage: modelResult.usage,
       });
 
-      const stop = shouldStopAfterTurn(modelResult, turn, maxTurns);
+      const stop = shouldStopAfterTurn(loop, context, modelResult, turn, maxTurns, this.evaluator);
       const stopResult = await hooks.runBefore("loop:stop", {
         agent: options.agent,
         loop,

--- a/packages/core/src/loop/selector.test.ts
+++ b/packages/core/src/loop/selector.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { resolveLoopSelection } from "./selector.js";
+
+describe("resolveLoopSelection", () => {
+  it("keeps current agent behavior when no loop is requested", () => {
+    const agent = { name: "agent", model: "base", allowedTools: ["read"], systemPrompt: "base" };
+    const selected = resolveLoopSelection(agent);
+
+    expect(selected.name).toBe("default");
+    expect(selected.agent).toBe(agent);
+  });
+
+  it("applies requested loop overrides to the effective agent", () => {
+    const selected = resolveLoopSelection({
+      name: "agent",
+      model: "base",
+      reasoning: "low",
+      allowedTools: ["read", "write"],
+      systemPrompt: "base prompt",
+      loops: {
+        plan: {
+          systemPrompt: "plan prompt",
+          tools: ["read"],
+          model: "planner",
+          reasoning: "high",
+          maxTurns: 3,
+        },
+      },
+    }, "plan");
+
+    expect(selected.loop.name).toBe("plan");
+    expect(selected.agent).toMatchObject({
+      model: "planner",
+      reasoning: "high",
+      allowedTools: ["read"],
+      maxTurns: 3,
+    });
+    expect(selected.agent.systemPrompt).toContain("base prompt");
+    expect(selected.agent.systemPrompt).toContain("## Active loop: plan");
+    expect(selected.agent.systemPrompt).toContain("plan prompt");
+  });
+
+  it("throws a clear error for unknown requested loops", () => {
+    expect(() => resolveLoopSelection({
+      name: "agent",
+      loops: { plan: {} },
+    }, "build")).toThrow('Unknown loop "build". Available loops: plan');
+  });
+});

--- a/packages/core/src/loop/selector.ts
+++ b/packages/core/src/loop/selector.ts
@@ -1,0 +1,60 @@
+import type { AgentConfig } from "../types.js";
+import type { ReasoningLevel } from "../types.js";
+import type { LoopConfig } from "./types.js";
+
+export interface LoopSelection {
+  name: string;
+  loop: LoopConfig & { name: string };
+  agent: AgentConfig;
+}
+
+export function resolveActiveLoopTools(agent: AgentConfig, loop?: LoopConfig): string[] | undefined {
+  return loop?.tools ?? agent.allowedTools;
+}
+
+export function resolveLoopSelection(agent: AgentConfig, requestedLoop?: string): LoopSelection {
+  if (!requestedLoop) {
+    const defaultLoop = agent.loops?.default;
+    if (!defaultLoop) {
+      return {
+        name: "default",
+        loop: { name: "default", tools: agent.allowedTools, model: agent.model, reasoning: agent.reasoning, maxTurns: agent.maxTurns },
+        agent,
+      };
+    }
+    return materializeLoopSelection(agent, "default", defaultLoop);
+  }
+
+  const loop = agent.loops?.[requestedLoop];
+  if (!loop) {
+    const available = Object.keys(agent.loops ?? {});
+    throw new Error(
+      available.length > 0
+        ? `Unknown loop "${requestedLoop}". Available loops: ${available.join(", ")}`
+        : `Agent "${agent.name}" does not define configurable loops`,
+    );
+  }
+
+  return materializeLoopSelection(agent, requestedLoop, loop);
+}
+
+function materializeLoopSelection(agent: AgentConfig, name: string, loop: LoopConfig): LoopSelection {
+  const loopWithName = { ...loop, name: loop.name ?? name };
+  const loopPrompt = loop.systemPrompt?.trim();
+  const systemPrompt = loopPrompt
+    ? [agent.systemPrompt, `## Active loop: ${loopWithName.name}`, loopPrompt].filter(Boolean).join("\n\n")
+    : agent.systemPrompt;
+
+  return {
+    name: loopWithName.name,
+    loop: loopWithName,
+    agent: {
+      ...agent,
+      systemPrompt,
+      allowedTools: resolveActiveLoopTools(agent, loop),
+      model: loop.model ?? agent.model,
+      reasoning: (loop.reasoning as ReasoningLevel | undefined) ?? agent.reasoning,
+      maxTurns: loop.maxTurns ?? agent.maxTurns,
+    },
+  };
+}

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -23,6 +23,7 @@ export interface LoopConfig {
   tools?: string[];
   model?: string;
   reasoning?: string;
+  temperature?: number;
   maxTurns?: number;
   /** Deterministic stop condition over the context bag. */
   stopWhen?: Condition;

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -226,6 +226,7 @@ export const loopConfigSchema = z.object({
   tools: z.array(z.string().min(1)).optional(),
   model: z.string().optional(),
   reasoning: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
   maxTurns: z.number().int().positive().optional(),
   stopWhen: conditionSchema.optional(),
   output: z.object({

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -22,7 +22,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { streamSSE } from "hono/streaming";
 import { nanoid } from "nanoid";
-import { agentMemoryScope, compactIfNeeded, type SummarizeFn, type CompactionEvent } from "@polpo-ai/core";
+import { agentMemoryScope, compactIfNeeded, resolveLoopSelection, type SummarizeFn, type CompactionEvent } from "@polpo-ai/core";
 import { streamText, generateText, jsonSchema, type LanguageModel, type LanguageModelUsage } from "ai";
 
 const MAX_TURNS = 20;
@@ -121,6 +121,9 @@ const completionRequestSchema = z.object({
   }),
   agent: z.string().optional().openapi({
     description: "Target a specific agent by name for direct conversation. Uses the agent's own model, system prompt, and coding tools instead of the orchestrator. Omit to talk to the orchestrator (default).",
+  }),
+  loop: z.string().optional().openapi({
+    description: "Optional configurable loop name for agent-direct mode. Applies that loop's prompt, tools, model, reasoning, and maxTurns overrides.",
   }),
   project: z.string().optional().openapi({
     description: "Deprecated. Ignored.",
@@ -633,9 +636,17 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
     if (agentMode) {
       // ── Agent-direct mode ──
       const agents = await deps.getAgents();
-      const agentConfig = agents.find((a: any) => a.name === body.agent);
+      let agentConfig = agents.find((a: any) => a.name === body.agent);
       if (!agentConfig) {
         return c.json({ error: { message: `Agent "${body.agent}" not found`, type: "invalid_request_error", code: "agent_not_found" } }, 404);
+      }
+      try {
+        const selection = resolveLoopSelection(agentConfig, body.loop);
+        agentConfig = selection.agent;
+        c.header("x-loop", selection.name);
+      } catch (loopErr) {
+        const msg = loopErr instanceof Error ? loopErr.message : String(loopErr);
+        return c.json({ error: { message: msg, type: "invalid_request_error", code: "loop_not_found" } }, 400 as any);
       }
 
       // Build system prompt via dep

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -330,6 +330,7 @@ const LoopConfigSchema = z.object({
   tools: z.array(z.string().min(1)).optional(),
   model: z.string().optional(),
   reasoning: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
   maxTurns: z.number().int().positive().optional(),
   stopWhen: LoopConditionSchema.optional(),
   output: LoopOutputSchema.optional(),

--- a/src/__tests__/completions.test.ts
+++ b/src/__tests__/completions.test.ts
@@ -165,6 +165,49 @@ describe("POST /v1/chat/completions", () => {
       // Zod validation: min(1) on messages
       expect(res.status).toBe(400);
     });
+
+    test("selects a configured agent loop when loop is provided", async () => {
+      await app.request("/api/v1/agents", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "loop-agent",
+          role: "Loop test agent",
+          loops: {
+            plan: {
+              systemPrompt: "Plan only.",
+              tools: ["read"],
+              model: "mock/loop-model",
+            },
+          },
+        }),
+      });
+      setMockModel(mockTextModel("Loop selected."));
+
+      const res = await postCompletions({
+        agent: "loop-agent",
+        loop: "plan",
+        messages: [{ role: "user", content: "Use plan loop" }],
+        stream: false,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-loop")).toBe("plan");
+      const body = await parseJson(res);
+      expect((body.choices as any[])[0].message.content).toBe("Loop selected.");
+    });
+
+    test("returns 400 when requested loop is missing", async () => {
+      const res = await postCompletions({
+        loop: "missing",
+        messages: [{ role: "user", content: "Use missing loop" }],
+        stream: false,
+      });
+
+      expect(res.status).toBe(400);
+      const body = await parseJson(res);
+      expect((body.error as any).code).toBe("loop_not_found");
+    });
   });
 
   describe("streaming", () => {

--- a/src/server/schemas.ts
+++ b/src/server/schemas.ts
@@ -255,6 +255,7 @@ const LoopConfigSchema = z.object({
   tools: z.array(z.string().min(1)).optional(),
   model: z.string().optional(),
   reasoning: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
   maxTurns: z.number().int().positive().optional(),
   stopWhen: LoopConditionSchema.optional(),
   output: LoopOutputSchema.optional(),


### PR DESCRIPTION
## Summary\n- add loop selector helpers that materialize per-loop prompt/tools/model/reasoning/maxTurns overrides\n- add pure PipelineExecutor for sequential, switch, parallel, human nodes and loop:transition hooks\n- add stopWhen support to LoopRunner\n- expose chat completions loop selector via request body + SDK type\n- document runtime status in README\n\n## Verification\n- pnpm typecheck\n- pnpm vitest run\n\n## Notes\nThis completes the OSS deterministic loop runtime primitives after #71/#72. Cloud-specific metering/UI wiring remains in polpo-cloud.