### PR TITLE
Expose project loop runtime in chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/src/hooks/use-chat.ts
+++ b/packages/react-sdk/src/hooks/use-chat.ts
@@ -21,6 +21,8 @@ import { ChatCompletionStream } from "@polpo-ai/sdk";
 export interface UseChatOptions {
   /** Target a specific agent for direct conversation. Omit for orchestrator mode. */
   agent?: string;
+  /** Target a project-level loop assigned to the selected agent. */
+  loop?: string;
   /** Resume an existing session by ID. If omitted, the server auto-creates or reuses one (30-min window). */
   sessionId?: string;
   /** Called on each streaming text chunk. */
@@ -173,6 +175,7 @@ export function useChat(options: UseChatOptions = {}): UseChatReturn {
         messages: historyMessages,
         sessionId: sessionIdRef.current ?? undefined,
         agent: optionsRef.current.agent,
+        loop: optionsRef.current.loop,
       });
       streamRef.current = stream;
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/routes/completions-loop-runtime.test.ts
+++ b/packages/server/src/routes/completions-loop-runtime.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { completionRoutes, type CompletionRouteDeps } from "./completions.js";
 
 describe("completionRoutes project loop runtime", () => {
-  it("executes an assigned default project loop and returns shared tool context", async () => {
+  function makeDeps(): CompletionRouteDeps {
     let now = 100;
-    const deps: CompletionRouteDeps = {
+    return {
       getAgents: async () => [{
         name: "timer",
         model: "test",
@@ -52,6 +52,10 @@ describe("completionRoutes project loop runtime", () => {
         },
       }),
     };
+  }
+
+  it("executes an assigned default project loop and returns shared tool context", async () => {
+    const deps = makeDeps();
 
     const app = completionRoutes(() => deps);
     const res = await app.request("/", {
@@ -73,5 +77,40 @@ describe("completionRoutes project loop runtime", () => {
         end: "105",
       },
     });
+  });
+
+  it("streams project loop step tool call events", async () => {
+    const app = completionRoutes(() => makeDeps());
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        agent: "timer",
+        stream: true,
+        messages: [{ role: "user", content: "track it" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-loop")).toBe("time-tracker");
+    const body = await res.text();
+    const chunks = body
+      .split("\n\n")
+      .map((block) => block.trim())
+      .filter((block) => block.startsWith("data: "))
+      .map((block) => block.slice("data: ".length))
+      .filter((data) => data !== "[DONE]")
+      .map((data) => JSON.parse(data));
+    const toolEvents = chunks
+      .map((chunk) => chunk.choices?.[0]?.tool_call)
+      .filter(Boolean);
+
+    expect(toolEvents.map((event: any) => event.state)).toContain("calling");
+    expect(toolEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "unix_time", result: "100", state: "completed" }),
+        expect.objectContaining({ name: "unix_time", result: "105", state: "completed" }),
+      ]),
+    );
   });
 });

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -633,6 +633,14 @@ interface ProjectLoopRunResult {
   context: ContextBag;
 }
 
+type LoopRuntimeToolCall = {
+  id: string;
+  name: string;
+  arguments?: Record<string, unknown>;
+  result?: string;
+  state: "preparing" | "calling" | "completed" | "error" | "interrupted";
+};
+
 function addUsage(a: LanguageModelUsage, b: LanguageModelUsage): LanguageModelUsage {
   return {
     inputTokens: (a.inputTokens ?? 0) + (b.inputTokens ?? 0),
@@ -877,8 +885,9 @@ async function runProjectLoopCompletion(options: {
   projectLoop: ProjectLoopConfig;
   aiMessages: any[];
   extraSystemParts: string[];
+  onToolCall?: (toolCall: LoopRuntimeToolCall) => Promise<void>;
 }): Promise<ProjectLoopRunResult> {
-  const { deps, agentConfig, projectLoop, aiMessages, extraSystemParts } = options;
+  const { deps, agentConfig, projectLoop, aiMessages, extraSystemParts, onToolCall } = options;
   const normalized = normalizeProjectLoop(projectLoop);
   if (!normalized.pipeline) throw new Error(`Loop "${projectLoop.name}" does not define a pipeline`);
 
@@ -897,20 +906,36 @@ async function runProjectLoopCompletion(options: {
       context: {},
       runTool: async (name, input) => {
         const args = normalizeToolInput(input);
+        const id = `loop-tool-${nanoid(12)}`;
+        await onToolCall?.({
+          id,
+          name,
+          arguments: args,
+          state: "calling",
+        });
         const output = await rootTools.executor(name, args);
         const isError = output.startsWith("Error:");
         emitFileChanged(name, args, output, deps.emit);
-        toolCallsAccum.push({
-          id: `loop-tool-${nanoid(12)}`,
+        const event = {
+          id,
           name,
           arguments: args,
           result: output,
-          state: isError ? "error" : "completed",
-        });
+          state: isError ? "error" as const : "completed" as const,
+        };
+        toolCallsAccum.push(event);
+        await onToolCall?.(event);
         if (isError) throw new Error(output);
         return { output: maybeParseJson(output) };
       },
       runLoop: async (name, loop, context) => {
+        const id = `loop-step-${nanoid(12)}`;
+        await onToolCall?.({
+          id,
+          name: `loop:${name}`,
+          arguments: { loop: projectLoop.name, step: name },
+          state: "calling",
+        });
         const stepAgent = buildLoopStepAgent(agentConfig, name, loop);
         const stepResult = await runAgentStepCompletion({
           deps,
@@ -925,6 +950,16 @@ async function runProjectLoopCompletion(options: {
         lastModel = stepResult.model;
         lastProviderMetadata = stepResult.providerMetadata;
         toolCallsAccum.push(...stepResult.toolCalls);
+        const output = stringifyLoopContext({ [name]: stepResult.output });
+        const event = {
+          id,
+          name: `loop:${name}`,
+          arguments: { loop: projectLoop.name, step: name },
+          result: output,
+          state: "completed" as const,
+        };
+        toolCallsAccum.push(event);
+        await onToolCall?.(event);
         return { output: stepResult.output };
       },
       handleHuman: async (name) => {
@@ -1152,6 +1187,12 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
               projectLoop: projectLoopRuntime.projectLoop,
               aiMessages,
               extraSystemParts,
+              onToolCall: async (toolCall) => {
+                if (abortController.signal.aborted) return;
+                await stream.writeSSE({
+                  data: sseChunk(completionId, {}, null, { tool_call: toolCall }),
+                });
+              },
             });
             finalText = run.text;
             runUsage = run.usage;

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- pass selected project loop from @polpo-ai/react useChat into chat completions
- emit project-loop runtime tool-call events during streaming so chat UIs can show executed steps
- add regression coverage for streamed loop tool events
- bump packages to 0.10.1

## Checks
- pnpm --filter @polpo-ai/server exec vitest run src/routes/completions-loop-runtime.test.ts
- pnpm --filter @polpo-ai/react exec tsc --noEmit
- pnpm --filter @polpo-ai/server exec tsc --noEmit
- pnpm build
- git diff --check