### PR TITLE
Add loop governance contract and trace events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/client-sdk/src/client/types.ts
+++ b/packages/client-sdk/src/client/types.ts
@@ -223,6 +223,73 @@ export interface LoopConfig {
 export type LoopNext = string | Array<{ when?: string; to: string }>;
 export type LoopToolChoice = "auto" | "none" | "required" | { mode: "auto" | "none" | "required"; tool?: string };
 
+export const LOOP_LIFECYCLE_HOOKS = [
+  "loop:start",
+  "step:before",
+  "model:before",
+  "tool:before",
+  "tool:after",
+  "step:after",
+  "loop:stop",
+  "loop:transition",
+  "loop:end",
+] as const;
+
+export type LoopLifecycleHook = typeof LOOP_LIFECYCLE_HOOKS[number];
+export type ProjectLoopVersion = "1";
+export type ProjectLoopKind = "graph";
+
+export interface LoopHookAction {
+  tool: string;
+  input?: unknown;
+  saveAs?: string;
+  when?: string;
+  onError?: "fail" | "continue";
+}
+
+export type ProjectLoopHooks = Partial<Record<LoopLifecycleHook, LoopHookAction[]>>;
+export type LoopPolicyEffect = "allow" | "deny" | "approval";
+
+export interface ProjectLoopPolicy {
+  id?: string;
+  description?: string;
+  hook?: LoopLifecycleHook;
+  effect: LoopPolicyEffect;
+  when: string;
+  message?: string;
+}
+
+export type LoopTraceEventType =
+  | "loop.start"
+  | "loop.end"
+  | "loop.error"
+  | "step.start"
+  | "step.end"
+  | "step.skip"
+  | "tool.call"
+  | "tool.result"
+  | "human.request"
+  | "human.result"
+  | "transition";
+
+export interface LoopTraceEvent {
+  id: string;
+  type: LoopTraceEventType;
+  ts: string;
+  loop?: string;
+  step?: string;
+  tool?: string;
+  human?: string;
+  from?: string;
+  to?: string;
+  status?: "started" | "completed" | "skipped" | "failed";
+  when?: string;
+  input?: unknown;
+  output?: unknown;
+  error?: string;
+  data?: Record<string, unknown>;
+}
+
 export type LoopStepConfig =
   | (LoopConfig & { type?: "agent"; when?: string; next?: LoopNext })
   | { type: "human"; when?: string; output?: { schema?: unknown }; notify?: string[]; next?: LoopNext }
@@ -230,9 +297,14 @@ export type LoopStepConfig =
   | { type: "tool"; when?: string; tool: string; input?: unknown; saveAs?: string; next?: LoopNext };
 
 export interface ProjectLoopConfig {
+  version?: ProjectLoopVersion;
+  kind?: ProjectLoopKind;
   name: string;
   description?: string;
+  metadata?: Record<string, unknown>;
   context?: "shared";
+  hooks?: ProjectLoopHooks;
+  policies?: ProjectLoopPolicy[];
   start: string;
   steps: Record<string, LoopStepConfig>;
 }
@@ -1426,6 +1498,8 @@ export interface ChatCompletionResponse {
     completion_tokens: number;
     total_tokens: number;
   };
+  /** Polpo extension: structured runtime trace for project loop executions. */
+  loop_trace?: LoopTraceEvent[];
 }
 
 export interface ChatCompletionChunkDelta {
@@ -1480,6 +1554,8 @@ export interface ChatCompletionChunk {
     open_tab?: OpenTabPayload;
     /** Present when the server is executing a tool call. */
     tool_call?: ToolCallEvent;
+    /** Present when a project loop runtime trace event is emitted. */
+    loop_trace?: LoopTraceEvent;
     /** Present when the model is emitting thinking/reasoning tokens. */
     thinking?: string;
   }>;

--- a/packages/client-sdk/src/index.ts
+++ b/packages/client-sdk/src/index.ts
@@ -23,6 +23,7 @@ export {
 } from "./store/selectors.js";
 
 // ── Types ─────────────────────────────────────────────────────
+export { LOOP_LIFECYCLE_HOOKS } from "./client/types.js";
 export type {
   Task,
   TaskStatus,
@@ -102,6 +103,15 @@ export type {
   ChatCompletionChoice,
   ChatCompletionChunk,
   ChatCompletionChunkDelta,
+  LoopHookAction,
+  LoopLifecycleHook,
+  LoopPolicyEffect,
+  LoopTraceEvent,
+  LoopTraceEventType,
+  ProjectLoopHooks,
+  ProjectLoopKind,
+  ProjectLoopPolicy,
+  ProjectLoopVersion,
   ToolCallState,
   ToolCallEvent,
   AskUserOption,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,17 +160,26 @@ export type {
   AgentLoopConfig,
   ContextBag,
   LoopConfig,
+  LoopHookAction,
+  LoopLifecycleHook,
   LoopNext,
+  LoopPolicyEffect,
   LoopStepConfig,
+  LoopTraceEvent,
+  LoopTraceEventType,
   LoopToolChoice,
   Pipeline,
   ProjectLoopConfig,
+  ProjectLoopHooks,
+  ProjectLoopKind,
+  ProjectLoopPolicy,
+  ProjectLoopVersion,
   Step,
   SwitchCase,
   Condition,
   ToolLoopStep,
 } from "./loop/types.js";
-export { isLoopStep, isToolStep, isParallelStep, isSwitchStep, isHumanStep } from "./loop/types.js";
+export { LOOP_LIFECYCLE_HOOKS, isLoopStep, isToolStep, isParallelStep, isSwitchStep, isHumanStep } from "./loop/types.js";
 export { normalizeProjectLoop } from "./loop/normalize.js";
 export { LoopHookRegistry } from "./loop/hooks.js";
 export type {

--- a/packages/core/src/loop/contract.test.ts
+++ b/packages/core/src/loop/contract.test.ts
@@ -109,4 +109,73 @@ describe("agentLoopConfigSchema", () => {
     ]);
     expect(JSON.stringify(normalized.pipeline?.steps)).toContain("clone_repository");
   });
+
+  it("accepts the v1 governance contract fields without changing graph normalization", () => {
+    const loop = projectLoopConfigSchema.parse({
+      version: "1",
+      kind: "graph",
+      name: "governed-flow",
+      description: "A loop with future governance metadata.",
+      metadata: {
+        owner: "platform",
+        source: "dsl",
+      },
+      context: "shared",
+      hooks: {
+        "tool:before": [
+          {
+            tool: "policy_check",
+            input: { mode: "strict" },
+            saveAs: "policy.tool",
+            onError: "fail",
+          },
+        ],
+        "loop:end": [
+          {
+            tool: "audit_log",
+            onError: "continue",
+          },
+        ],
+      },
+      policies: [
+        {
+          id: "deny-dangerous-bash",
+          hook: "tool:before",
+          effect: "deny",
+          when: "tool.name == 'bash' && args.command.includes('rm -rf')",
+          message: "Dangerous shell command blocked.",
+        },
+      ],
+      start: "work",
+      steps: {
+        work: {
+          type: "agent",
+          tools: ["read"],
+          next: "end",
+        },
+      },
+    });
+
+    expect(loop.version).toBe("1");
+    expect(loop.kind).toBe("graph");
+    expect(loop.hooks?.["tool:before"]?.[0]?.tool).toBe("policy_check");
+    expect(loop.policies?.[0]?.effect).toBe("deny");
+    expect(normalizeProjectLoop(loop as ProjectLoopConfig).pipeline?.steps).toEqual([{ loop: "work" }]);
+  });
+
+  it("rejects unknown loop hook names", () => {
+    const parsed = projectLoopConfigSchema.safeParse({
+      name: "bad-hooks",
+      start: "work",
+      hooks: {
+        "before:anything": [{ tool: "policy_check" }],
+      },
+      steps: {
+        work: { type: "agent", next: "end" },
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues[0]?.message).toContain('unknown loop hook "before:anything"');
+  });
 });

--- a/packages/core/src/loop/hooks.ts
+++ b/packages/core/src/loop/hooks.ts
@@ -1,16 +1,7 @@
 import type { AgentConfig } from "../types.js";
-import type { ContextBag, LoopConfig } from "./types.js";
+import type { ContextBag, LoopConfig, LoopLifecycleHook } from "./types.js";
 
-export type LoopHook =
-  | "loop:start"
-  | "step:before"
-  | "model:before"
-  | "tool:before"
-  | "tool:after"
-  | "step:after"
-  | "loop:stop"
-  | "loop:transition"
-  | "loop:end";
+export type LoopHook = LoopLifecycleHook;
 
 export type LoopHookPhase = "before" | "after";
 

--- a/packages/core/src/loop/pipeline.test.ts
+++ b/packages/core/src/loop/pipeline.test.ts
@@ -16,6 +16,16 @@ describe("PipelineExecutor", () => {
       build: { ready: true, name: "build" },
     });
     expect(result.trace.map(e => e.type)).toEqual(["loop", "loop"]);
+    expect(result.events.map(e => e.type)).toEqual([
+      "loop.start",
+      "step.start",
+      "step.end",
+      "transition",
+      "step.start",
+      "step.end",
+      "loop.end",
+    ]);
+    expect(result.events.every(e => typeof e.ts === "string" && e.id.startsWith("trace-"))).toBe(true);
   });
 
   it("routes switch branches deterministically from context", async () => {
@@ -95,6 +105,30 @@ describe("PipelineExecutor", () => {
       plan: { planned: "plan" },
     });
     expect(result.trace.map(e => e.type)).toEqual(["tool", "loop"]);
+    expect(result.events.map(e => e.type)).toContain("tool.call");
+    expect(result.events.map(e => e.type)).toContain("tool.result");
+  });
+
+  it("streams structured trace events through onTrace", async () => {
+    const executor = new PipelineExecutor();
+    const events: string[] = [];
+    const result = await executor.execute({
+      name: "observed-flow",
+      loops: { plan: {} },
+      pipeline: { steps: [{ loop: "plan" }] },
+      onTrace: async (event) => {
+        events.push(`${event.loop}:${event.type}`);
+      },
+      runLoop: async (name) => ({ output: { name } }),
+    });
+
+    expect(events).toEqual([
+      "observed-flow:loop.start",
+      "observed-flow:step.start",
+      "observed-flow:step.end",
+      "observed-flow:loop.end",
+    ]);
+    expect(result.events[0]).toMatchObject({ loop: "observed-flow", type: "loop.start" });
   });
 
   it("fires loop:transition hooks between sequential loop nodes", async () => {

--- a/packages/core/src/loop/pipeline.ts
+++ b/packages/core/src/loop/pipeline.ts
@@ -1,6 +1,17 @@
 import { SafeExpressionEvaluator } from "./expression.js";
 import type { LoopHookRegistry } from "./hooks.js";
-import { isHumanStep, isLoopStep, isParallelStep, isSwitchStep, isToolStep, type ContextBag, type LoopConfig, type Pipeline, type Step } from "./types.js";
+import {
+  isHumanStep,
+  isLoopStep,
+  isParallelStep,
+  isSwitchStep,
+  isToolStep,
+  type ContextBag,
+  type LoopConfig,
+  type LoopTraceEvent,
+  type Pipeline,
+  type Step,
+} from "./types.js";
 
 export interface PipelineLoopResult {
   output?: unknown;
@@ -27,16 +38,25 @@ export interface PipelineTraceEvent {
 export interface PipelineExecutionResult {
   context: ContextBag;
   trace: PipelineTraceEvent[];
+  events: LoopTraceEvent[];
 }
 
 export interface PipelineExecutorOptions {
+  name?: string;
   pipeline: Pipeline;
   loops: Record<string, LoopConfig>;
   context?: ContextBag;
   hooks?: LoopHookRegistry;
+  onTrace?: (event: LoopTraceEvent) => void | Promise<void>;
   runLoop: (name: string, loop: LoopConfig, context: Readonly<ContextBag>) => Promise<PipelineLoopResult>;
   runTool?: (name: string, input: unknown, context: Readonly<ContextBag>, step: Extract<Step, { tool: string }>) => Promise<PipelineToolResult>;
   handleHuman?: (name: string, step: Extract<Step, { human: string }>, context: Readonly<ContextBag>) => Promise<PipelineHumanResult>;
+}
+
+interface PipelineExecutionState {
+  events: LoopTraceEvent[];
+  nextEventId(): string;
+  emit(event: Omit<LoopTraceEvent, "id" | "ts" | "loop">): Promise<void>;
 }
 
 export class PipelineExecutor {
@@ -45,8 +65,35 @@ export class PipelineExecutor {
   async execute(options: PipelineExecutorOptions): Promise<PipelineExecutionResult> {
     const context = { ...(options.context ?? {}) };
     const trace: PipelineTraceEvent[] = [];
-    await this.executeSteps(options.pipeline.steps, context, trace, options);
-    return { context, trace };
+    let nextId = 0;
+    const state: PipelineExecutionState = {
+      events: [],
+      nextEventId: () => `trace-${++nextId}`,
+      emit: async (event) => {
+        const full: LoopTraceEvent = {
+          id: state.nextEventId(),
+          ts: new Date().toISOString(),
+          loop: options.name,
+          ...event,
+        };
+        state.events.push(full);
+        await options.onTrace?.(full);
+      },
+    };
+
+    await state.emit({ type: "loop.start", status: "started" });
+    try {
+      await this.executeSteps(options.pipeline.steps, context, trace, options, state);
+      await state.emit({ type: "loop.end", status: "completed" });
+      return { context, trace, events: state.events };
+    } catch (err) {
+      await state.emit({
+        type: "loop.error",
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
   }
 
   private async executeSteps(
@@ -54,32 +101,38 @@ export class PipelineExecutor {
     context: ContextBag,
     trace: PipelineTraceEvent[],
     options: PipelineExecutorOptions,
+    state: PipelineExecutionState,
     previousNode?: string,
   ): Promise<string | undefined> {
     let lastNode = previousNode;
     for (const step of steps) {
       if (!this.matchesWhen(step.when, context)) {
         trace.push({ type: "skip", when: step.when, matched: false });
+        await state.emit({ type: "step.skip", status: "skipped", when: step.when });
         continue;
       }
 
       if (isLoopStep(step)) {
         const loop = options.loops[step.loop];
         if (!loop) throw new Error(`Pipeline references unknown loop "${step.loop}"`);
-        await this.runTransitionHook(lastNode, step.loop, context, options);
+        await this.runTransitionHook(lastNode, step.loop, context, options, state);
+        await state.emit({ type: "step.start", step: step.loop, status: "started", when: step.when });
         const result = await options.runLoop(step.loop, loop, freezeContext(context));
         mergeLoopResult(context, step.loop, result);
         trace.push({ type: "loop", name: step.loop, when: step.when, matched: true });
+        await state.emit({ type: "step.end", step: step.loop, status: "completed", output: result.output });
         lastNode = step.loop;
         continue;
       }
 
       if (isToolStep(step)) {
         if (!options.runTool) throw new Error(`Pipeline tool step "${step.tool}" requires a tool handler`);
-        await this.runTransitionHook(lastNode, step.tool, context, options);
+        await this.runTransitionHook(lastNode, step.tool, context, options, state);
+        await state.emit({ type: "tool.call", tool: step.tool, step: step.saveAs ?? step.tool, status: "started", input: step.input });
         const result = await options.runTool(step.tool, step.input, freezeContext(context), step);
         mergeStepResult(context, step.saveAs ?? step.tool, result);
         trace.push({ type: "tool", name: step.tool, when: step.when, matched: true });
+        await state.emit({ type: "tool.result", tool: step.tool, step: step.saveAs ?? step.tool, status: "completed", output: result.output });
         lastNode = step.tool;
         continue;
       }
@@ -89,14 +142,14 @@ export class PipelineExecutor {
         for (const branch of step.switch.cases) {
           if (this.matchesWhen(branch.when, context)) {
             trace.push({ type: "switch", when: branch.when, matched: true });
-            lastNode = await this.executeSteps(branch.steps, context, trace, options, lastNode);
+            lastNode = await this.executeSteps(branch.steps, context, trace, options, state, lastNode);
             matched = true;
             break;
           }
         }
         if (!matched && step.switch.default) {
           trace.push({ type: "switch", matched: false });
-          lastNode = await this.executeSteps(step.switch.default.steps, context, trace, options, lastNode);
+          lastNode = await this.executeSteps(step.switch.default.steps, context, trace, options, state, lastNode);
         }
         continue;
       }
@@ -106,7 +159,7 @@ export class PipelineExecutor {
         const branchResults = await Promise.all(step.parallel.map(async (child) => {
           const branchContext = { ...snapshot };
           const branchTrace: PipelineTraceEvent[] = [];
-          await this.executeSteps([child], branchContext, branchTrace, options);
+          await this.executeSteps([child], branchContext, branchTrace, options, state);
           return { branchContext, branchTrace };
         }));
         for (const result of branchResults) {
@@ -119,10 +172,12 @@ export class PipelineExecutor {
 
       if (isHumanStep(step)) {
         if (!options.handleHuman) throw new Error(`Pipeline human step "${step.human}" requires a human handler`);
-        await this.runTransitionHook(lastNode, step.human, context, options);
+        await this.runTransitionHook(lastNode, step.human, context, options, state);
+        await state.emit({ type: "human.request", human: step.human, step: step.human, status: "started", when: step.when });
         const result = await options.handleHuman(step.human, step, freezeContext(context));
         mergeLoopResult(context, step.human, result);
         trace.push({ type: "human", name: step.human, when: step.when, matched: true });
+        await state.emit({ type: "human.result", human: step.human, step: step.human, status: "completed", output: result.output });
         lastNode = step.human;
       }
     }
@@ -139,8 +194,13 @@ export class PipelineExecutor {
     to: string,
     context: ContextBag,
     options: PipelineExecutorOptions,
+    state: PipelineExecutionState,
   ): Promise<void> {
-    if (!from || !options.hooks) return;
+    if (!from) return;
+    if (!options.hooks) {
+      await state.emit({ type: "transition", from, to, status: "completed" });
+      return;
+    }
     const result = await options.hooks.runBefore("loop:transition", {
       from,
       to,
@@ -151,6 +211,7 @@ export class PipelineExecutor {
     }
     Object.assign(context, result.data.context);
     await options.hooks.runAfter("loop:transition", result.data);
+    await state.emit({ type: "transition", from, to, status: "completed" });
   }
 }
 

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -13,6 +13,81 @@ export interface Condition {
 
 export type ContextBag = Record<string, unknown>;
 
+export const LOOP_LIFECYCLE_HOOKS = [
+  "loop:start",
+  "step:before",
+  "model:before",
+  "tool:before",
+  "tool:after",
+  "step:after",
+  "loop:stop",
+  "loop:transition",
+  "loop:end",
+] as const;
+
+export type LoopLifecycleHook = typeof LOOP_LIFECYCLE_HOOKS[number];
+export type ProjectLoopVersion = "1";
+export type ProjectLoopKind = "graph";
+
+export interface LoopHookAction {
+  /** Built-in or custom tool invoked by the hook. */
+  tool: string;
+  /** Static JSON input. Host runtimes may add templating later. */
+  input?: unknown;
+  /** Context path where the hook output should be stored. */
+  saveAs?: string;
+  /** Optional expression over the context bag. */
+  when?: string;
+  /** Whether a hook tool failure should fail the loop or be observed only. */
+  onError?: "fail" | "continue";
+}
+
+export type ProjectLoopHooks = Partial<Record<LoopLifecycleHook, LoopHookAction[]>>;
+
+export type LoopPolicyEffect = "allow" | "deny" | "approval";
+
+export interface ProjectLoopPolicy {
+  id?: string;
+  description?: string;
+  /** Lifecycle point where this policy is evaluated. Defaults to tool:before. */
+  hook?: LoopLifecycleHook;
+  effect: LoopPolicyEffect;
+  /** Expression evaluated against the hook payload/context. */
+  when: string;
+  message?: string;
+}
+
+export type LoopTraceEventType =
+  | "loop.start"
+  | "loop.end"
+  | "loop.error"
+  | "step.start"
+  | "step.end"
+  | "step.skip"
+  | "tool.call"
+  | "tool.result"
+  | "human.request"
+  | "human.result"
+  | "transition";
+
+export interface LoopTraceEvent {
+  id: string;
+  type: LoopTraceEventType;
+  ts: string;
+  loop?: string;
+  step?: string;
+  tool?: string;
+  human?: string;
+  from?: string;
+  to?: string;
+  status?: "started" | "completed" | "skipped" | "failed";
+  when?: string;
+  input?: unknown;
+  output?: unknown;
+  error?: string;
+  data?: Record<string, unknown>;
+}
+
 export type LoopNext =
   | string
   | Array<{
@@ -90,9 +165,14 @@ export type LoopStepConfig = AgentLoopStep | HumanLoopStep | ParallelLoopStep | 
 
 /** Project-level reusable loop graph. Agents assign these by name/id. */
 export interface ProjectLoopConfig {
+  version?: ProjectLoopVersion;
+  kind?: ProjectLoopKind;
   name: string;
   description?: string;
+  metadata?: Record<string, unknown>;
   context?: "shared";
+  hooks?: ProjectLoopHooks;
+  policies?: ProjectLoopPolicy[];
   start: string;
   steps: Record<string, LoopStepConfig>;
 }

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import type { TaskExpectation, MissionCheckpoint, MissionQualityGate } from "./types.js";
+import { LOOP_LIFECYCLE_HOOKS } from "./loop/types.js";
 
 // ── Expectation Schemas (discriminated union on `type`) ──────────────
 
@@ -284,10 +285,49 @@ export const loopStepConfigSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
+const loopLifecycleHookNames = new Set<string>(LOOP_LIFECYCLE_HOOKS);
+
+export const loopHookActionSchema = z.object({
+  tool: z.string().min(1),
+  input: z.unknown().optional(),
+  saveAs: z.string().min(1).optional(),
+  when: z.string().min(1).optional(),
+  onError: z.enum(["fail", "continue"]).optional(),
+});
+
+export const projectLoopHooksSchema = z.record(
+  z.string().min(1),
+  z.array(loopHookActionSchema).min(1),
+).superRefine((hooks, ctx) => {
+  for (const hook of Object.keys(hooks)) {
+    if (!loopLifecycleHookNames.has(hook)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `unknown loop hook "${hook}"`,
+        path: [hook],
+      });
+    }
+  }
+});
+
+export const projectLoopPolicySchema = z.object({
+  id: z.string().min(1).optional(),
+  description: z.string().optional(),
+  hook: z.enum(LOOP_LIFECYCLE_HOOKS).optional(),
+  effect: z.enum(["allow", "deny", "approval"]),
+  when: z.string().min(1),
+  message: z.string().optional(),
+});
+
 export const projectLoopConfigSchema = z.object({
+  version: z.literal("1").optional(),
+  kind: z.literal("graph").optional(),
   name: z.string().min(1),
   description: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   context: z.literal("shared").optional(),
+  hooks: projectLoopHooksSchema.optional(),
+  policies: z.array(projectLoopPolicySchema).optional(),
   start: z.string().min(1),
   steps: z.record(z.string().min(1), z.union([
     loopConfigSchema.extend({

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/routes/completions-loop-runtime.test.ts
+++ b/packages/server/src/routes/completions-loop-runtime.test.ts
@@ -77,6 +77,16 @@ describe("completionRoutes project loop runtime", () => {
         end: "105",
       },
     });
+    expect(json.loop_trace.map((event: any) => event.type)).toEqual([
+      "loop.start",
+      "tool.call",
+      "tool.result",
+      "transition",
+      "tool.call",
+      "tool.result",
+      "loop.end",
+    ]);
+    expect(json.loop_trace[0]).toMatchObject({ loop: "time-tracker", status: "started" });
   });
 
   it("streams project loop step tool call events", async () => {
@@ -104,6 +114,9 @@ describe("completionRoutes project loop runtime", () => {
     const toolEvents = chunks
       .map((chunk) => chunk.choices?.[0]?.tool_call)
       .filter(Boolean);
+    const traceEvents = chunks
+      .map((chunk) => chunk.choices?.[0]?.loop_trace)
+      .filter(Boolean);
 
     expect(toolEvents.map((event: any) => event.state)).toContain("calling");
     expect(toolEvents).toEqual(
@@ -112,5 +125,7 @@ describe("completionRoutes project loop runtime", () => {
         expect.objectContaining({ name: "unix_time", result: "105", state: "completed" }),
       ]),
     );
+    expect(traceEvents.map((event: any) => event.type)).toContain("tool.call");
+    expect(traceEvents.map((event: any) => event.type)).toContain("loop.end");
   });
 });

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -31,6 +31,7 @@ import {
   type CompactionEvent,
   type ContextBag,
   type LoopConfig,
+  type LoopTraceEvent,
   type ProjectLoopConfig,
   type SummarizeFn,
 } from "@polpo-ai/core";
@@ -176,6 +177,7 @@ const completionResponseSchema = z.object({
     completion_tokens: z.number().int(),
     total_tokens: z.number().int(),
   }),
+  loop_trace: z.array(z.unknown()).optional(),
 });
 
 const errorResponseSchema = z.object({
@@ -432,7 +434,7 @@ function modelNotFoundEnvelope(
   };
 }
 
-function completionResponse(id: string, content: string, usage: LanguageModelUsage) {
+function completionResponse(id: string, content: string, usage: LanguageModelUsage, extra?: Record<string, unknown>) {
   return {
     id,
     object: "chat.completion" as const,
@@ -448,6 +450,7 @@ function completionResponse(id: string, content: string, usage: LanguageModelUsa
       completion_tokens: usage.outputTokens ?? 0,
       total_tokens: usage.totalTokens ?? 0,
     },
+    ...extra,
   };
 }
 
@@ -631,6 +634,7 @@ interface ProjectLoopRunResult {
   providerMetadata?: Record<string, unknown>;
   toolCalls: any[];
   context: ContextBag;
+  trace: LoopTraceEvent[];
 }
 
 type LoopRuntimeToolCall = {
@@ -886,8 +890,9 @@ async function runProjectLoopCompletion(options: {
   aiMessages: any[];
   extraSystemParts: string[];
   onToolCall?: (toolCall: LoopRuntimeToolCall) => Promise<void>;
+  onTrace?: (event: LoopTraceEvent) => Promise<void>;
 }): Promise<ProjectLoopRunResult> {
-  const { deps, agentConfig, projectLoop, aiMessages, extraSystemParts, onToolCall } = options;
+  const { deps, agentConfig, projectLoop, aiMessages, extraSystemParts, onToolCall, onTrace } = options;
   const normalized = normalizeProjectLoop(projectLoop);
   if (!normalized.pipeline) throw new Error(`Loop "${projectLoop.name}" does not define a pipeline`);
 
@@ -901,9 +906,11 @@ async function runProjectLoopCompletion(options: {
 
   try {
     const result = await executor.execute({
+      name: projectLoop.name,
       pipeline: normalized.pipeline,
       loops: normalized.loops,
       context: {},
+      onTrace,
       runTool: async (name, input) => {
         const args = normalizeToolInput(input);
         const id = `loop-tool-${nanoid(12)}`;
@@ -975,6 +982,7 @@ async function runProjectLoopCompletion(options: {
       providerMetadata: lastProviderMetadata,
       toolCalls: toolCallsAccum,
       context: result.context,
+      trace: result.events,
     };
   } finally {
     if (rootTools.cleanup) {
@@ -1193,6 +1201,12 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
                   data: sseChunk(completionId, {}, null, { tool_call: toolCall }),
                 });
               },
+              onTrace: async (event) => {
+                if (abortController.signal.aborted) return;
+                await stream.writeSSE({
+                  data: sseChunk(completionId, {}, null, { loop_trace: event }),
+                });
+              },
             });
             finalText = run.text;
             runUsage = run.usage;
@@ -1261,7 +1275,7 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
         runModel = run.model;
         providerMetadata = run.providerMetadata;
         toolCalls = run.toolCalls;
-        return c.json(completionResponse(completionId, finalText, runUsage));
+        return c.json(completionResponse(completionId, finalText, runUsage, { loop_trace: run.trace }));
       } catch (err) {
         const notFound = modelNotFoundEnvelope(err, runModel, body.agent);
         if (notFound) {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- add additive ProjectLoopConfig v1 governance fields: version, kind, metadata, hooks, policies
- expose loop lifecycle hook names/types through core and SDK
- add structured PipelineExecutor trace events and stream/non-stream loop_trace from chat completions
- keep legacy graph normalization and existing loop JSON compatible

## Tests
- pnpm --filter @polpo-ai/core exec vitest run src/loop/contract.test.ts src/loop/pipeline.test.ts
- pnpm --filter @polpo-ai/server exec vitest run src/routes/completions-loop-runtime.test.ts
- pnpm --filter @polpo-ai/core build
- pnpm --filter @polpo-ai/server build
- pnpm --filter @polpo-ai/sdk build
- git diff --check