### PR TITLE
Execute loop hooks and policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,62 @@ Agent-direct chat can target a loop explicitly:
 
 At runtime, the selected project loop can narrow the effective prompt, tools, skills, model, reasoning, tool choice, and max turns per agent step. If a step omits `skills`, it inherits the agent-level `skills`. Project loop execution in chat completions uses the shared context graph: deterministic tool steps run first, store outputs in the context bag, and later agent steps receive that context as runtime data in their system prompt. Core keeps a compatibility normalizer for legacy inline `loops` + `pipeline` configs and ships a pure `PipelineExecutor` for sequential, tool, switch, parallel, and human nodes; hosts wire `runLoop`, `runTool`, and `handleHuman` callbacks to their concrete runtime.
 
+Project loops also support governance fields:
+
+```jsonc
+{
+  "version": "1",
+  "kind": "graph",
+  "name": "governed-build",
+  "context": "shared",
+  "hooks": {
+    "loop:start": [
+      { "tool": "unix_time", "saveAs": "timing.start" }
+    ],
+    "tool:after": [
+      { "tool": "audit_step", "input": { "level": "info" }, "saveAs": "audit.last", "onError": "continue" }
+    ],
+    "loop:end": [
+      { "tool": "unix_time", "saveAs": "timing.end" }
+    ]
+  },
+  "policies": [
+    {
+      "id": "only-safe-tools",
+      "hook": "tool:before",
+      "effect": "allow",
+      "when": "tool.name == 'read' || tool.name == 'grep' || tool.name == 'unix_time'"
+    },
+    {
+      "id": "deny-shell",
+      "hook": "tool:before",
+      "effect": "deny",
+      "when": "tool.name == 'bash'",
+      "message": "bash requires an explicit build loop"
+    }
+  ],
+  "start": "capture_start",
+  "steps": {
+    "capture_start": {
+      "type": "tool",
+      "tool": "unix_time",
+      "saveAs": "timing.start",
+      "next": "plan"
+    },
+    "plan": {
+      "type": "agent",
+      "systemPrompt": "Plan the work. Do not edit files.",
+      "tools": ["read", "grep"],
+      "next": "end"
+    }
+  }
+}
+```
+
+Lifecycle hooks are deterministic tool actions run by the host runtime at `loop:start`, `step:before`, `model:before`, `tool:before`, `tool:after`, `step:after`, `loop:transition`, and `loop:end`. Hook `when` guards are evaluated against the shared context plus lifecycle payload such as `step.name`, `step.type`, `tool.name`, `tool.input`, and `transition.from/to`. Hook outputs are saved into the context bag with `saveAs`; `onError: "continue"` turns a failed hook into trace-only telemetry, while the default is fail-closed.
+
+Policies are evaluated before hook actions at the same lifecycle point. `deny` fails the loop, `approval` fails with an explicit approval-required error until an approval queue is wired by the host, and `allow` policies form an allow-list for that lifecycle point when at least one exists. If an allow-list is present and no allow rule matches, the loop is blocked. Chat completions return `loop_trace` events for loop, step, transition, tool, hook, and human activity; streaming completions emit each trace incrementally.
+
 ## SDK
 
 ### Client SDK

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/loop/pipeline.test.ts
+++ b/packages/core/src/loop/pipeline.test.ts
@@ -171,4 +171,150 @@ describe("PipelineExecutor", () => {
       runLoop: async (name) => ({ output: { name } }),
     })).rejects.toThrow('Loop transition from "plan" to "build" cancelled: approval required');
   });
+
+  it("runs project hook tool actions and saves their output into context", async () => {
+    const executor = new PipelineExecutor();
+    const calls: Array<{ name: string; input: unknown }> = [];
+
+    const result = await executor.execute({
+      name: "audited-flow",
+      loops: { plan: {} },
+      pipeline: { steps: [{ loop: "plan" }] },
+      projectHooks: {
+        "loop:start": [{ tool: "unix_time", saveAs: "timing.start" }],
+        "step:after": [{ tool: "audit_step", input: { level: "info" }, saveAs: "audit.lastStep" }],
+        "loop:end": [{ tool: "unix_time", saveAs: "timing.end" }],
+      },
+      runTool: async (name, input) => {
+        calls.push({ name, input });
+        return { output: name === "unix_time" ? 123 : { ok: true } };
+      },
+      runLoop: async (name) => ({ output: { name } }),
+    });
+
+    expect(calls).toEqual([
+      { name: "unix_time", input: undefined },
+      { name: "audit_step", input: { level: "info" } },
+      { name: "unix_time", input: undefined },
+    ]);
+    expect(result.context).toMatchObject({
+      timing: { start: 123, end: 123 },
+      audit: { lastStep: { ok: true } },
+    });
+    expect(result.events.filter((event) => event.data?.hook).map((event) => event.type)).toEqual([
+      "tool.call",
+      "tool.result",
+      "tool.call",
+      "tool.result",
+      "tool.call",
+      "tool.result",
+    ]);
+  });
+
+  it("skips project hook actions when their guard does not match", async () => {
+    const executor = new PipelineExecutor();
+    const calls: string[] = [];
+
+    const result = await executor.execute({
+      loops: { plan: {} },
+      pipeline: { steps: [{ loop: "plan" }] },
+      context: { enabled: false },
+      projectHooks: {
+        "loop:start": [{ tool: "should_not_run", when: "enabled == true", saveAs: "hook" }],
+      },
+      runTool: async (name) => {
+        calls.push(name);
+        return { output: { ok: true } };
+      },
+      runLoop: async (name) => ({ output: { name } }),
+    });
+
+    expect(calls).toEqual([]);
+    expect(result.context.hook).toBeUndefined();
+  });
+
+  it("continues project hook execution when onError is continue", async () => {
+    const executor = new PipelineExecutor();
+
+    const result = await executor.execute({
+      loops: {},
+      pipeline: { steps: [{ tool: "work", saveAs: "work" }] },
+      projectHooks: {
+        "tool:before": [{ tool: "flaky_audit", onError: "continue", saveAs: "audit" }],
+      },
+      runTool: async (name) => {
+        if (name === "flaky_audit") throw new Error("audit unavailable");
+        return { output: { ok: true } };
+      },
+      runLoop: async () => ({ output: {} }),
+    });
+
+    expect(result.context).toMatchObject({ work: { ok: true } });
+    expect(result.events.some((event) => event.type === "tool.result" && event.status === "failed" && event.tool === "flaky_audit")).toBe(true);
+  });
+
+  it("fails project hook execution by default when a hook tool fails", async () => {
+    const executor = new PipelineExecutor();
+
+    await expect(executor.execute({
+      loops: {},
+      pipeline: { steps: [{ tool: "work" }] },
+      projectHooks: {
+        "tool:before": [{ tool: "policy_check" }],
+      },
+      runTool: async (name) => {
+        if (name === "policy_check") throw new Error("blocked");
+        return { output: { ok: true } };
+      },
+      runLoop: async () => ({ output: {} }),
+    })).rejects.toThrow('Loop hook "tool:before" action "policy_check" failed: blocked');
+  });
+
+  it("enforces deny and approval project policies at lifecycle points", async () => {
+    const executor = new PipelineExecutor();
+
+    await expect(executor.execute({
+      loops: {},
+      pipeline: { steps: [{ tool: "bash", input: { command: "rm -rf /" } }] },
+      projectPolicies: [
+        { id: "dangerous-bash", effect: "deny", hook: "tool:before", when: "tool.name == 'bash'", message: "bash is restricted" },
+      ],
+      runTool: async () => ({ output: { ok: true } }),
+      runLoop: async () => ({ output: {} }),
+    })).rejects.toThrow('Loop policy "dangerous-bash" denied tool:before: bash is restricted');
+
+    await expect(executor.execute({
+      loops: { deploy: {} },
+      pipeline: { steps: [{ loop: "deploy" }] },
+      projectPolicies: [
+        { id: "deploy-approval", effect: "approval", hook: "step:before", when: "step.name == 'deploy'", message: "deployment requires approval" },
+      ],
+      runLoop: async () => ({ output: {} }),
+    })).rejects.toThrow('Loop policy "deploy-approval" requires approval at step:before: deployment requires approval');
+  });
+
+  it("treats allow policies as an allow-list when present for a lifecycle point", async () => {
+    const executor = new PipelineExecutor();
+
+    const result = await executor.execute({
+      loops: {},
+      pipeline: { steps: [{ tool: "unix_time", saveAs: "time" }] },
+      projectPolicies: [
+        { id: "only-unix-time", effect: "allow", hook: "tool:before", when: "tool.name == 'unix_time'" },
+      ],
+      runTool: async () => ({ output: 123 }),
+      runLoop: async () => ({ output: {} }),
+    });
+    expect(result.context.time).toBe(123);
+
+    await expect(executor.execute({
+      loops: {},
+      pipeline: { steps: [{ tool: "bash" }] },
+      projectPolicies: [
+        { id: "only-unix-time", effect: "allow", hook: "tool:before", when: "tool.name == 'unix_time'" },
+      ],
+      runTool: async () => ({ output: "nope" }),
+      runLoop: async () => ({ output: {} }),
+    })).rejects.toThrow('Loop policy allow-list blocked tool:before: no allow policy matched');
+  });
 });

--- a/packages/core/src/loop/pipeline.ts
+++ b/packages/core/src/loop/pipeline.ts
@@ -8,6 +8,10 @@ import {
   isToolStep,
   type ContextBag,
   type LoopConfig,
+  type LoopHookAction,
+  type LoopLifecycleHook,
+  type ProjectLoopHooks,
+  type ProjectLoopPolicy,
   type LoopTraceEvent,
   type Pipeline,
   type Step,
@@ -47,6 +51,8 @@ export interface PipelineExecutorOptions {
   loops: Record<string, LoopConfig>;
   context?: ContextBag;
   hooks?: LoopHookRegistry;
+  projectHooks?: ProjectLoopHooks;
+  projectPolicies?: ProjectLoopPolicy[];
   onTrace?: (event: LoopTraceEvent) => void | Promise<void>;
   runLoop: (name: string, loop: LoopConfig, context: Readonly<ContextBag>) => Promise<PipelineLoopResult>;
   runTool?: (name: string, input: unknown, context: Readonly<ContextBag>, step: Extract<Step, { tool: string }>) => Promise<PipelineToolResult>;
@@ -83,7 +89,9 @@ export class PipelineExecutor {
 
     await state.emit({ type: "loop.start", status: "started" });
     try {
+      await this.runLifecyclePoint("loop:start", context, options, state, { loop: { name: options.name } });
       await this.executeSteps(options.pipeline.steps, context, trace, options, state);
+      await this.runLifecyclePoint("loop:end", context, options, state, { loop: { name: options.name }, status: "completed" });
       await state.emit({ type: "loop.end", status: "completed" });
       return { context, trace, events: state.events };
     } catch (err) {
@@ -116,10 +124,13 @@ export class PipelineExecutor {
         const loop = options.loops[step.loop];
         if (!loop) throw new Error(`Pipeline references unknown loop "${step.loop}"`);
         await this.runTransitionHook(lastNode, step.loop, context, options, state);
+        await this.runLifecyclePoint("step:before", context, options, state, { step: { name: step.loop, type: "agent" } });
+        await this.runLifecyclePoint("model:before", context, options, state, { step: { name: step.loop, type: "agent" } });
         await state.emit({ type: "step.start", step: step.loop, status: "started", when: step.when });
         const result = await options.runLoop(step.loop, loop, freezeContext(context));
         mergeLoopResult(context, step.loop, result);
         trace.push({ type: "loop", name: step.loop, when: step.when, matched: true });
+        await this.runLifecyclePoint("step:after", context, options, state, { step: { name: step.loop, type: "agent" }, output: result.output });
         await state.emit({ type: "step.end", step: step.loop, status: "completed", output: result.output });
         lastNode = step.loop;
         continue;
@@ -128,10 +139,15 @@ export class PipelineExecutor {
       if (isToolStep(step)) {
         if (!options.runTool) throw new Error(`Pipeline tool step "${step.tool}" requires a tool handler`);
         await this.runTransitionHook(lastNode, step.tool, context, options, state);
+        const stepName = step.saveAs ?? step.tool;
+        await this.runLifecyclePoint("step:before", context, options, state, { step: { name: stepName, type: "tool" }, tool: { name: step.tool, input: step.input } });
+        await this.runLifecyclePoint("tool:before", context, options, state, { step: { name: stepName, type: "tool" }, tool: { name: step.tool, input: step.input } });
         await state.emit({ type: "tool.call", tool: step.tool, step: step.saveAs ?? step.tool, status: "started", input: step.input });
         const result = await options.runTool(step.tool, step.input, freezeContext(context), step);
         mergeStepResult(context, step.saveAs ?? step.tool, result);
         trace.push({ type: "tool", name: step.tool, when: step.when, matched: true });
+        await this.runLifecyclePoint("tool:after", context, options, state, { step: { name: stepName, type: "tool" }, tool: { name: step.tool, input: step.input }, output: result.output });
+        await this.runLifecyclePoint("step:after", context, options, state, { step: { name: stepName, type: "tool" }, tool: { name: step.tool, input: step.input }, output: result.output });
         await state.emit({ type: "tool.result", tool: step.tool, step: step.saveAs ?? step.tool, status: "completed", output: result.output });
         lastNode = step.tool;
         continue;
@@ -155,6 +171,7 @@ export class PipelineExecutor {
       }
 
       if (isParallelStep(step)) {
+        await this.runLifecyclePoint("step:before", context, options, state, { step: { name: "parallel", type: "parallel" } });
         const snapshot = freezeContext(context);
         const branchResults = await Promise.all(step.parallel.map(async (child) => {
           const branchContext = { ...snapshot };
@@ -167,16 +184,19 @@ export class PipelineExecutor {
           trace.push(...result.branchTrace);
         }
         trace.push({ type: "parallel", matched: true });
+        await this.runLifecyclePoint("step:after", context, options, state, { step: { name: "parallel", type: "parallel" } });
         continue;
       }
 
       if (isHumanStep(step)) {
         if (!options.handleHuman) throw new Error(`Pipeline human step "${step.human}" requires a human handler`);
         await this.runTransitionHook(lastNode, step.human, context, options, state);
+        await this.runLifecyclePoint("step:before", context, options, state, { step: { name: step.human, type: "human" } });
         await state.emit({ type: "human.request", human: step.human, step: step.human, status: "started", when: step.when });
         const result = await options.handleHuman(step.human, step, freezeContext(context));
         mergeLoopResult(context, step.human, result);
         trace.push({ type: "human", name: step.human, when: step.when, matched: true });
+        await this.runLifecyclePoint("step:after", context, options, state, { step: { name: step.human, type: "human" }, output: result.output });
         await state.emit({ type: "human.result", human: step.human, step: step.human, status: "completed", output: result.output });
         lastNode = step.human;
       }
@@ -197,6 +217,7 @@ export class PipelineExecutor {
     state: PipelineExecutionState,
   ): Promise<void> {
     if (!from) return;
+    await this.runLifecyclePoint("loop:transition", context, options, state, { transition: { from, to } });
     if (!options.hooks) {
       await state.emit({ type: "transition", from, to, status: "completed" });
       return;
@@ -212,6 +233,119 @@ export class PipelineExecutor {
     Object.assign(context, result.data.context);
     await options.hooks.runAfter("loop:transition", result.data);
     await state.emit({ type: "transition", from, to, status: "completed" });
+  }
+
+  private async runLifecyclePoint(
+    hook: LoopLifecycleHook,
+    context: ContextBag,
+    options: PipelineExecutorOptions,
+    state: PipelineExecutionState,
+    payload: Record<string, unknown> = {},
+  ): Promise<void> {
+    this.enforcePolicies(hook, context, options.projectPolicies ?? [], payload);
+
+    const actions = options.projectHooks?.[hook] ?? [];
+    for (const action of actions) {
+      if (!this.matchesWhen(action.when, this.policyContext(context, hook, payload))) continue;
+      await this.runHookAction(hook, action, context, options, state, payload);
+    }
+  }
+
+  private async runHookAction(
+    hook: LoopLifecycleHook,
+    action: LoopHookAction,
+    context: ContextBag,
+    options: PipelineExecutorOptions,
+    state: PipelineExecutionState,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    if (!options.runTool) {
+      throw new Error(`Loop hook "${hook}" action "${action.tool}" requires a tool handler`);
+    }
+
+    const step: Extract<Step, { tool: string }> = {
+      tool: action.tool,
+      input: action.input,
+      saveAs: action.saveAs,
+    };
+
+    await state.emit({
+      type: "tool.call",
+      tool: action.tool,
+      step: action.saveAs ?? action.tool,
+      status: "started",
+      input: action.input,
+      data: { hook, kind: "hook", payload },
+    });
+
+    try {
+      const result = await options.runTool(action.tool, action.input, freezeContext(context), step);
+      mergeStepResult(context, action.saveAs ?? action.tool, result);
+      await state.emit({
+        type: "tool.result",
+        tool: action.tool,
+        step: action.saveAs ?? action.tool,
+        status: "completed",
+        output: result.output,
+        data: { hook, kind: "hook", payload },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await state.emit({
+        type: "tool.result",
+        tool: action.tool,
+        step: action.saveAs ?? action.tool,
+        status: "failed",
+        error: message,
+        data: { hook, kind: "hook", payload },
+      });
+      if (action.onError !== "continue") {
+        throw new Error(`Loop hook "${hook}" action "${action.tool}" failed: ${message}`);
+      }
+    }
+  }
+
+  private enforcePolicies(
+    hook: LoopLifecycleHook,
+    context: ContextBag,
+    policies: ProjectLoopPolicy[],
+    payload: Record<string, unknown>,
+  ): void {
+    const relevant = policies.filter((policy) => (policy.hook ?? "tool:before") === hook);
+    if (relevant.length === 0) return;
+
+    const policyContext = this.policyContext(context, hook, payload);
+    const allowPolicies = relevant.filter((policy) => policy.effect === "allow");
+    let allowMatched = false;
+
+    for (const policy of relevant) {
+      const matched = this.matchesWhen(policy.when, policyContext);
+      if (!matched) continue;
+
+      if (policy.effect === "allow") {
+        allowMatched = true;
+        continue;
+      }
+
+      const id = policy.id ?? "anonymous";
+      const suffix = policy.message ? `: ${policy.message}` : "";
+      if (policy.effect === "deny") {
+        throw new Error(`Loop policy "${id}" denied ${hook}${suffix}`);
+      }
+      throw new Error(`Loop policy "${id}" requires approval at ${hook}${suffix}`);
+    }
+
+    if (allowPolicies.length > 0 && !allowMatched) {
+      throw new Error(`Loop policy allow-list blocked ${hook}: no allow policy matched`);
+    }
+  }
+
+  private policyContext(context: ContextBag, hook: LoopLifecycleHook, payload: Record<string, unknown>): ContextBag {
+    return {
+      ...context,
+      hook,
+      ...payload,
+    };
   }
 }
 

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/routes/completions-loop-runtime.test.ts
+++ b/packages/server/src/routes/completions-loop-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { completionRoutes, type CompletionRouteDeps } from "./completions.js";
 
 describe("completionRoutes project loop runtime", () => {
-  function makeDeps(): CompletionRouteDeps {
+  function makeDeps(projectLoop?: any): CompletionRouteDeps {
     let now = 100;
     return {
       getAgents: async () => [{
@@ -25,14 +25,15 @@ describe("completionRoutes project loop runtime", () => {
       },
       resolveAgentTools: async () => ({
         tools: [],
-        executor: async (name) => {
+        executor: async (name, args) => {
+          if (name === "audit_step") return JSON.stringify({ ok: true, args });
           if (name !== "unix_time") return `Error: Unknown tool "${name}"`;
           const value = now;
           now += 5;
           return String(value);
         },
       }),
-      getProjectLoop: async (name) => ({
+      getProjectLoop: async (name) => projectLoop ?? ({
         name,
         context: "shared",
         start: "capture_start",
@@ -127,5 +128,82 @@ describe("completionRoutes project loop runtime", () => {
     );
     expect(traceEvents.map((event: any) => event.type)).toContain("tool.call");
     expect(traceEvents.map((event: any) => event.type)).toContain("loop.end");
+  });
+
+  it("executes project loop hook tool actions through the completion runtime", async () => {
+    const app = completionRoutes(() => makeDeps({
+      name: "time-tracker",
+      context: "shared",
+      start: "capture_start",
+      hooks: {
+        "tool:after": [{ tool: "audit_step", input: { source: "hook" }, saveAs: "audit.last" }],
+      },
+      steps: {
+        capture_start: {
+          type: "tool",
+          tool: "unix_time",
+          saveAs: "timing.start",
+          next: "end",
+        },
+      },
+    }));
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        agent: "timer",
+        messages: [{ role: "user", content: "track it" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(JSON.parse(json.choices[0].message.content)).toMatchObject({
+      timing: { start: "100" },
+      audit: { last: { ok: true, args: { source: "hook" } } },
+    });
+    expect(json.loop_trace).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "tool.call", tool: "audit_step", data: expect.objectContaining({ hook: "tool:after" }) }),
+        expect.objectContaining({ type: "tool.result", tool: "audit_step", data: expect.objectContaining({ hook: "tool:after" }) }),
+      ]),
+    );
+  });
+
+  it("blocks project loop execution when a runtime policy denies a lifecycle point", async () => {
+    const app = completionRoutes(() => makeDeps({
+      name: "time-tracker",
+      context: "shared",
+      start: "capture_start",
+      policies: [
+        { id: "block-time", effect: "deny", hook: "tool:before", when: "tool.name == 'unix_time'", message: "time capture disabled" },
+      ],
+      steps: {
+        capture_start: {
+          type: "tool",
+          tool: "unix_time",
+          saveAs: "timing.start",
+          next: "end",
+        },
+      },
+    }));
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        agent: "timer",
+        messages: [{ role: "user", content: "track it" }],
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    const json = await res.json() as any;
+    expect(json.error).toMatchObject({
+      type: "loop_runtime_error",
+      code: "loop_policy_blocked",
+      message: 'Loop policy "block-time" denied tool:before: time capture disabled',
+    });
   });
 });

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -434,6 +434,19 @@ function modelNotFoundEnvelope(
   };
 }
 
+function loopRuntimeErrorEnvelope(
+  err: unknown,
+): { message: string; type: "loop_runtime_error"; code: "loop_policy_blocked" | "loop_hook_failed" } | null {
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.startsWith("Loop policy ")) {
+    return { message, type: "loop_runtime_error", code: "loop_policy_blocked" };
+  }
+  if (message.startsWith("Loop hook ")) {
+    return { message, type: "loop_runtime_error", code: "loop_hook_failed" };
+  }
+  return null;
+}
+
 function completionResponse(id: string, content: string, usage: LanguageModelUsage, extra?: Record<string, unknown>) {
   return {
     id,
@@ -910,6 +923,8 @@ async function runProjectLoopCompletion(options: {
       pipeline: normalized.pipeline,
       loops: normalized.loops,
       context: {},
+      projectHooks: projectLoop.hooks,
+      projectPolicies: projectLoop.policies,
       onTrace,
       runTool: async (name, input) => {
         const args = normalizeToolInput(input);
@@ -1231,6 +1246,12 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
               await stream.writeSSE({ data: "[DONE]" });
               return;
             }
+            const loopError = loopRuntimeErrorEnvelope(err);
+            if (loopError) {
+              await stream.writeSSE({ data: sseChunk(completionId, {}, "stop", { error: loopError }) });
+              await stream.writeSSE({ data: "[DONE]" });
+              return;
+            }
             throw err;
           } finally {
             clearInterval(heartbeatInterval);
@@ -1280,6 +1301,10 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
         const notFound = modelNotFoundEnvelope(err, runModel, body.agent);
         if (notFound) {
           return c.json({ error: notFound }, 400 as any);
+        }
+        const loopError = loopRuntimeErrorEnvelope(err);
+        if (loopError) {
+          return c.json({ error: loopError }, 403 as any);
         }
         throw err;
       } finally {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- execute ProjectLoopConfig hooks as deterministic tool actions at lifecycle points
- enforce project loop policies with deny, approval-required, and allow-list semantics
- return structured loop runtime errors from chat completions
- document loop governance semantics and bump packages to v0.10.3

## Verification
- pnpm --filter @polpo-ai/core exec vitest run src/loop/pipeline.test.ts src/loop/contract.test.ts
- pnpm --filter @polpo-ai/server exec vitest run src/routes/completions-loop-runtime.test.ts
- pnpm --filter @polpo-ai/core build
- pnpm --filter @polpo-ai/server build
- pnpm --filter @polpo-ai/sdk build
- git diff --check