### PR TITLE
Make loop trace persistence best-effort

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/routes/completions-loop-runtime.test.ts
+++ b/packages/server/src/routes/completions-loop-runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MemoryLoopRunStore, type LoopTraceEvent } from "@polpo-ai/core";
 import { completionRoutes, type CompletionRouteDeps } from "./completions.js";
 
 describe("completionRoutes project loop runtime", () => {
@@ -88,6 +89,51 @@ describe("completionRoutes project loop runtime", () => {
       "loop.end",
     ]);
     expect(json.loop_trace[0]).toMatchObject({ loop: "time-tracker", status: "started" });
+  });
+
+  it("continues project loop execution when trace persistence fails", async () => {
+    class FailingTraceStore extends MemoryLoopRunStore {
+      async appendTrace(_runId: string, _event: LoopTraceEvent): Promise<void> {
+        throw new Error("trace db unavailable");
+      }
+    }
+
+    const diagnostics: { event: string; data: any }[] = [];
+    const deps = makeDeps();
+    deps.getLoopRunStore = () => new FailingTraceStore();
+    deps.emit = (event, data) => diagnostics.push({ event, data });
+
+    const app = completionRoutes(() => deps);
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        agent: "timer",
+        messages: [{ role: "user", content: "track it" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(JSON.parse(json.choices[0].message.content)).toEqual({
+      timing: {
+        start: "100",
+        end: "105",
+      },
+    });
+    expect(json.loop_run_id).toMatch(/^looprun-/);
+    expect(json.loop_trace.map((event: any) => event.type)).toContain("loop.end");
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "loop_run:trace_persist_failed",
+          data: expect.objectContaining({
+            loop: "time-tracker",
+            error: "trace db unavailable",
+          }),
+        }),
+      ]),
+    );
   });
 
   it("streams project loop step tool call events", async () => {

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -982,6 +982,32 @@ async function runProjectLoopCompletion(options: {
   const toolCallsAccum: any[] = [];
   const events: LoopTraceEvent[] = [];
 
+  const emitTrace = async (event: LoopTraceEvent) => {
+    events.push(event);
+    if (loopRunStore && loopRunId) {
+      try {
+        await loopRunStore.appendTrace(loopRunId, event);
+      } catch (err) {
+        deps.emit("loop_run:trace_persist_failed", {
+          loopRunId,
+          loop: projectLoop.name,
+          eventType: event.type,
+          error: (err as Error).message,
+        });
+      }
+    }
+    try {
+      await onTrace?.(event);
+    } catch (err) {
+      deps.emit("loop_run:trace_delivery_failed", {
+        loopRunId,
+        loop: projectLoop.name,
+        eventType: event.type,
+        error: (err as Error).message,
+      });
+    }
+  };
+
   try {
     const result = await executor.execute({
       name: projectLoop.name,
@@ -996,9 +1022,7 @@ async function runProjectLoopCompletion(options: {
         approvedGates: resumeState.approvedGates,
       } : undefined,
       onTrace: async (event) => {
-        events.push(event);
-        if (loopRunStore && loopRunId) await loopRunStore.appendTrace(loopRunId, event);
-        await onTrace?.(event);
+        await emitTrace(event);
       },
       runTool: async (name, input) => {
         const args = normalizeToolInput(input);

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- keep project loop execution running when durable trace append fails
- emit diagnostic events for trace persistence/delivery failures
- add regression coverage for completions returning loop_trace even when appendTrace throws
- bump Polpo packages to 0.10.7 for patch release

## Tests
- pnpm vitest run packages/server/src/routes/completions-loop-runtime.test.ts
- pnpm --filter @polpo-ai/server build
- pnpm --filter @polpo-ai/core build
- pnpm build