### PR TITLE
[codex] add static loop DSL deploy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Agents get access to tools based on their configuration. Built-in tool groups:
 
 ## Loops Beta
 
-Loops are project-level deterministic graphs stored in `.polpo/loops/*.json` and assigned to agents from `.polpo/agents.json`. This avoids duplicating loop definitions across agents: a loop has `name`, `context`, `start`, and `steps`; an agent has `assignedLoops` and `defaultLoop`.
+Loops are project-level deterministic graphs stored in `.polpo/loops/*.json` or authored as static `.polpo/loops/*.ts` DSL files, then assigned to agents from `.polpo/agents.json`. This avoids duplicating loop definitions across agents: a loop has `name`, `context`, `start`, and `steps`; an agent has `assignedLoops` and `defaultLoop`.
 
 Use `type: "tool"` for deterministic sandbox/tool actions without an LLM turn, and `toolChoice` on `type: "agent"` when the model should still reason but must use a tool. Secrets stay in Vault; loop JSON should only contain non-secret input, while custom tools resolve credentials with `ctx.vault`.
 
@@ -224,17 +224,14 @@ Loops also have first-class governance fields:
 
 When a permission or policy requires approval, the runtime stores a checkpoint on the loop run. Approving the gate moves the run to `approval_approved`; `POST /loop-runs/:id/resume` continues from the saved context and remaining steps without replaying completed steps.
 
-You can also keep loops as code and compile them to the same canonical contract:
+You can also keep loops as static TypeScript source. The CLI validates the file locally, deploys the source to `/v1/loops`, and the server compiles it to the same canonical JSON contract without executing arbitrary code:
 
 ```ts
 // .polpo/loops/router-flow.ts
-import { defineProjectLoop } from "@polpo-ai/core/loop-code";
+import { agentStep, defineProjectLoop, requireTool, toolStep, when, otherwise } from "@polpo-ai/core/loop-code";
 
 export default defineProjectLoop({
-  version: "1",
-  kind: "graph",
   name: "router-flow",
-  context: "shared",
   permissions: [
     {
       id: "router-tool-allowlist",
@@ -246,18 +243,25 @@ export default defineProjectLoop({
   ],
   start: "classify",
   steps: {
-    classify: {
-      type: "agent",
+    classify: agentStep({
+      label: "Classify",
       systemPrompt: "Classify the incoming request.",
       tools: ["read"],
-      next: "answer",
-    },
-    answer: {
-      type: "agent",
+      next: [when("classify.route == 'answer'", "answer"), otherwise("end")],
+    }),
+    answer: agentStep({
+      label: "Answer",
       systemPrompt: "Answer using the selected route.",
       tools: ["write"],
+      toolChoice: requireTool("write"),
+      next: "audit",
+    }),
+    audit: toolStep({
+      label: "Audit",
+      tool: "audit_log",
+      input: { flow: "router" },
       next: "end",
-    },
+    }),
   },
 });
 ```
@@ -266,8 +270,8 @@ CLI support:
 
 ```bash
 polpo loops validate
-polpo loops compile .polpo/loops/router-flow.ts --out .polpo/loops/router-flow.json
-polpo deploy
+polpo loops compile .polpo/loops/router-flow.ts
+polpo deploy   # deploys .json as JSON and .ts/.js/.mjs as source
 ```
 
 Agent-direct chat can target a loop explicitly:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/src/commands/cloud/deploy.ts
+++ b/packages/cli/src/commands/cloud/deploy.ts
@@ -29,7 +29,7 @@ import { resolveOrCreateProject } from "../../util/project.js";
 import { requireAuth } from "../../util/auth.js";
 import { isTTY } from "./prompt.js";
 import { resolveDeployConflict, type ConflictOptions } from "../../util/conflicts.js";
-import { listLoopSourceFiles, loadLoopSource } from "../../util/loops.js";
+import { listLoopSourceFiles, loadLoopDeployPayload } from "../../util/loops.js";
 
 // ── Deploy result tracking ──────────────────────────────
 
@@ -242,13 +242,20 @@ async function deployLoops(client: ApiClient, polpoDir: string): Promise<DeployR
   const result = emptyResult();
   const files = listLoopSourceFiles(polpoDir);
   for (const file of files) {
-    const loop = await loadLoopSource(file);
-    if (!loop?.name) {
+    let loop: Awaited<ReturnType<typeof loadLoopDeployPayload>>;
+    try {
+      loop = await loadLoopDeployPayload(file);
+    } catch (err) {
+      result.errors.push(`loop "${path.basename(file)}": validation failed — ${friendlyError(err)}`);
+      result.failed++;
+      continue;
+    }
+    if (!loop.name) {
       result.errors.push(`loop "${path.basename(file)}": missing name`);
       result.failed++;
       continue;
     }
-    const res = await client.post("/v1/loops", loop);
+    const res = await client.post("/v1/loops", loop.body);
     if (res.status >= 200 && res.status < 300) result.updated++;
     else {
       const msg = readErrorBody(res.data, res.status);

--- a/packages/cli/src/commands/cloud/loops.ts
+++ b/packages/cli/src/commands/cloud/loops.ts
@@ -1,5 +1,5 @@
 /**
- * polpo loops — validate and compile agentic loop definitions.
+ * polpo loops — validate and compile project-level agentic loop sources.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -19,12 +19,19 @@ export function registerLoopsCommand(program: Command): void {
 
   loops
     .command("validate")
-    .description("Validate .polpo/loops definitions")
+    .description("Validate .polpo/loops JSON or TypeScript definitions")
     .option("--dir <path>", "Project directory", process.cwd())
     .action(async (opts: { dir?: string }) => {
       clack.intro(pc.bold("polpo loops validate"));
       const polpoDir = resolvePolpoDir(opts.dir);
-      const files = listLoopSourceFiles(polpoDir);
+      let files: string[];
+      try {
+        files = listLoopSourceFiles(polpoDir);
+      } catch (err) {
+        clack.log.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+        return;
+      }
       if (files.length === 0) {
         clack.log.info("No loop definitions found in .polpo/loops.");
         clack.outro("Done.");
@@ -52,13 +59,20 @@ export function registerLoopsCommand(program: Command): void {
 
   loops
     .command("compile [file]")
-    .description("Compile a loop module or JSON file to canonical JSON")
+    .description("Compile a loop source or JSON file to canonical JSON")
     .option("--dir <path>", "Project directory", process.cwd())
     .option("-o, --out <file>", "Write compiled JSON to a file")
     .action(async (file: string | undefined, opts: { dir?: string; out?: string }) => {
       clack.intro(pc.bold("polpo loops compile"));
       const polpoDir = resolvePolpoDir(opts.dir);
-      const files = file ? [path.resolve(file)] : listLoopSourceFiles(polpoDir);
+      let files: string[];
+      try {
+        files = file ? [path.resolve(file)] : listLoopSourceFiles(polpoDir);
+      } catch (err) {
+        clack.log.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+        return;
+      }
       if (files.length === 0) {
         clack.log.info("No loop definitions found in .polpo/loops.");
         clack.outro("Done.");

--- a/packages/cli/src/util/loops.ts
+++ b/packages/cli/src/util/loops.ts
@@ -1,16 +1,41 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { pathToFileURL } from "node:url";
 import { projectLoopConfigSchema } from "@polpo-ai/core/schemas";
 import type { ProjectLoopConfig } from "@polpo-ai/core";
+import { compileLoopSource } from "@polpo-ai/server";
 
 export const LOOP_SOURCE_EXTENSIONS = [".json", ".js", ".mjs", ".ts"] as const;
+export type LoopDeployPayload =
+  | { name: string; body: ProjectLoopConfig }
+  | { name: string; body: { source: string; fileName: string } };
+
+function loopSourceExtension(file: string): string | undefined {
+  return LOOP_SOURCE_EXTENSIONS.find((ext) => file.endsWith(ext));
+}
+
+function loopSourceKey(file: string): string {
+  const ext = loopSourceExtension(file);
+  return ext ? path.basename(file, ext) : path.basename(file);
+}
 
 export function listLoopSourceFiles(polpoDir: string): string[] {
   const dir = path.join(polpoDir, "loops");
   if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter((file) => LOOP_SOURCE_EXTENSIONS.some((ext) => file.endsWith(ext)))
+  const files = fs.readdirSync(dir)
+    .filter((file) => loopSourceExtension(file))
+    .sort();
+
+  const seen = new Map<string, string>();
+  for (const file of files) {
+    const key = loopSourceKey(file);
+    const previous = seen.get(key);
+    if (previous) {
+      throw new Error(`Duplicate loop definition "${key}": choose either ${previous} or ${file}, not both.`);
+    }
+    seen.set(key, file);
+  }
+
+  return files
     .map((file) => path.join(dir, file))
     .sort();
 }
@@ -21,10 +46,19 @@ export async function loadLoopSource(file: string): Promise<ProjectLoopConfig> {
     return projectLoopConfigSchema.parse(raw) as ProjectLoopConfig;
   }
 
-  const mod = await import(pathToFileURL(path.resolve(file)).href);
-  const raw = mod.default ?? mod.loop ?? mod.projectLoop;
-  if (!raw) {
-    throw new Error("Loop module must export default, loop, or projectLoop");
+  return compileLoopSource(fs.readFileSync(file, "utf-8"), path.basename(file));
+}
+
+export async function loadLoopDeployPayload(file: string): Promise<LoopDeployPayload> {
+  const loop = await loadLoopSource(file);
+  if (file.endsWith(".json")) {
+    return { name: loop.name, body: loop };
   }
-  return projectLoopConfigSchema.parse(raw) as ProjectLoopConfig;
+  return {
+    name: loop.name,
+    body: {
+      source: fs.readFileSync(file, "utf-8"),
+      fileName: path.basename(file),
+    },
+  };
 }

--- a/packages/cli/src/util/pull.ts
+++ b/packages/cli/src/util/pull.ts
@@ -71,8 +71,6 @@ export async function pullProject(
             runtime: a.runtime,
             assignedLoops: a.assignedLoops,
             defaultLoop: a.defaultLoop,
-            loops: a.loops,
-            pipeline: a.pipeline,
             reportsTo: a.reportsTo,
             identity: a.identity,
             browserProfile: a.browserProfile,

--- a/packages/cli/tests/loops.test.ts
+++ b/packages/cli/tests/loops.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { listLoopSourceFiles, loadLoopDeployPayload, loadLoopSource } from "../src/util/loops.js";
+
+describe("loop source utilities", () => {
+  it("compiles TypeScript loop sources statically for validation", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "polpo-loops-"));
+    const polpoDir = join(dir, ".polpo");
+    const loopsDir = join(polpoDir, "loops");
+    const file = join(loopsDir, "coding-flow.ts");
+
+    try {
+      await mkdir(loopsDir, { recursive: true });
+      await writeFile(file, `
+        import { defineProjectLoop, agentStep, toolStep } from "@polpo-ai/core/loop-code";
+
+        export default defineProjectLoop({
+          name: "coding-flow",
+          start: "plan",
+          steps: {
+            plan: agentStep({ label: "Plan", tools: ["read"], next: "build" }),
+            build: toolStep({ label: "Build", tool: "bash", input: { command: "pnpm build" }, next: "end" })
+          }
+        });
+      `);
+
+      const loop = await loadLoopSource(file);
+      expect(loop.steps.plan).toMatchObject({ type: "agent", label: "Plan" });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deploys TypeScript loop sources as source payloads", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "polpo-loops-"));
+    const polpoDir = join(dir, ".polpo");
+    const loopsDir = join(polpoDir, "loops");
+    const file = join(loopsDir, "support-flow.ts");
+
+    try {
+      await mkdir(loopsDir, { recursive: true });
+      await writeFile(file, `
+        import { defineLoop, agentStep } from "@polpo-ai/core/loop-code";
+
+        export default defineLoop({
+          name: "support-flow",
+          start: "triage",
+          steps: {
+            triage: agentStep({ next: "end" })
+          }
+        });
+      `);
+
+      const payload = await loadLoopDeployPayload(file);
+      expect(payload.name).toBe("support-flow");
+      expect(payload.body).toMatchObject({ fileName: "support-flow.ts" });
+      expect("source" in payload.body).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deploys JSON loop sources as canonical JSON payloads", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "polpo-loops-"));
+    const file = join(dir, "loop.json");
+
+    try {
+      await writeFile(file, JSON.stringify({
+        name: "json-flow",
+        start: "work",
+        steps: { work: { type: "agent", next: "end" } },
+      }));
+
+      const payload = await loadLoopDeployPayload(file);
+      expect(payload.name).toBe("json-flow");
+      expect(payload.body).toMatchObject({ name: "json-flow" });
+      expect("source" in payload.body).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate loop files with the same basename", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "polpo-loops-"));
+    const polpoDir = join(dir, ".polpo");
+    const loopsDir = join(polpoDir, "loops");
+
+    try {
+      await mkdir(loopsDir, { recursive: true });
+      await writeFile(join(loopsDir, "flow.json"), "{}");
+      await writeFile(join(loopsDir, "flow.ts"), "export default {};");
+
+      expect(() => listLoopSourceFiles(polpoDir)).toThrow('Duplicate loop definition "flow"');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/pull.test.ts
+++ b/packages/cli/tests/pull.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { pullProject } from "../src/util/pull.js";
 
 describe("pullProject", () => {
-  it("preserves agent loops and pipeline in agents.json", async () => {
+  it("pulls project loops separately from agent assignments", async () => {
     const dir = await mkdtemp(join(tmpdir(), "polpo-pull-"));
     const polpoDir = join(dir, ".polpo");
     const client = {
@@ -18,12 +18,23 @@ describe("pullProject", () => {
                 name: "loop-agent",
                 role: "router",
                 runtime: "polpo-runner",
-                loops: {
-                  classify: { systemPrompt: "Classify.", tools: ["read"] },
-                  answer: { systemPrompt: "Answer." },
-                },
-                pipeline: {
-                  steps: [{ loop: "classify" }, { loop: "answer" }],
+                assignedLoops: ["router-flow"],
+                defaultLoop: "router-flow",
+                teamName: "platform",
+              }],
+            },
+          };
+        }
+        if (path === "/v1/loops") {
+          return {
+            status: 200,
+            data: {
+              data: [{
+                name: "router-flow",
+                start: "classify",
+                steps: {
+                  classify: { type: "agent", systemPrompt: "Classify.", tools: ["read"], next: "answer" },
+                  answer: { type: "agent", systemPrompt: "Answer.", next: "end" },
                 },
               }],
             },
@@ -38,8 +49,14 @@ describe("pullProject", () => {
 
       const agents = JSON.parse(await readFile(join(polpoDir, "agents.json"), "utf-8"));
       expect(agents[0].agent.runtime).toBe("polpo-runner");
-      expect(agents[0].agent.loops.classify.tools).toEqual(["read"]);
-      expect(agents[0].agent.pipeline.steps).toEqual([{ loop: "classify" }, { loop: "answer" }]);
+      expect(agents[0].agent.assignedLoops).toEqual(["router-flow"]);
+      expect(agents[0].agent.defaultLoop).toBe("router-flow");
+      expect(agents[0].agent.loops).toBeUndefined();
+      expect(agents[0].agent.pipeline).toBeUndefined();
+      expect(agents[0].teamName).toBe("platform");
+
+      const loop = JSON.parse(await readFile(join(polpoDir, "loops", "router-flow.json"), "utf-8"));
+      expect(loop.steps.classify.tools).toEqual(["read"]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,41 +10,61 @@ npm install @polpo-ai/core
 
 ## Agentic loops
 
-Use `defineProjectLoop` for code-first loop definitions that compile to the same JSON-compatible contract used by the API, CLI, dashboard, and runtime:
+Use `defineProjectLoop` for code-first loop definitions that compile to the same JSON-compatible contract used by the API, CLI, dashboard, and runtime. Project files can live in `.polpo/loops/*.ts`; `polpo deploy` sends the source to the server, which compiles it statically and persists canonical JSON.
 
 ```ts
-import { defineProjectLoop } from "@polpo-ai/core/loop-code";
+import {
+  agentStep,
+  bash,
+  defineProjectLoop,
+  permission,
+  requireTool,
+  toolStep,
+  when,
+  otherwise,
+} from "@polpo-ai/core/loop-code";
 
 export default defineProjectLoop({
-  version: "1",
-  kind: "graph",
   name: "support-flow",
-  context: "shared",
+  hooks: {
+    "loop:start": [bash("echo support loop started", { saveAs: "audit.start" })],
+  },
   permissions: [
-    {
+    permission({
       id: "support-tools",
       resource: "tool",
       action: "call",
       effect: "allow",
       match: { tool: ["read", "search_docs"] },
-    },
-    {
+    }),
+    permission({
       id: "refund-approval",
       resource: "tool",
       action: "call",
       effect: "approval",
       match: { tool: "issue_refund" },
       message: "Refunds require human approval.",
-    },
+    }),
   ],
   start: "triage",
   steps: {
-    triage: {
-      type: "agent",
+    triage: agentStep({
+      label: "Triage",
       systemPrompt: "Classify the support request.",
       tools: ["read"],
+      next: [when("triage.needsRefund == true", "refund"), otherwise("answer")],
+    }),
+    answer: agentStep({
+      label: "Answer",
+      tools: ["read", "search_docs"],
+      toolChoice: requireTool("search_docs"),
       next: "end",
-    },
+    }),
+    refund: toolStep({
+      label: "Issue refund",
+      tool: "issue_refund",
+      next: "end",
+    }),
   },
 });
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -185,7 +185,21 @@ export type {
 } from "./loop/types.js";
 export { LOOP_LIFECYCLE_HOOKS, isLoopStep, isToolStep, isParallelStep, isSwitchStep, isHumanStep } from "./loop/types.js";
 export { normalizeProjectLoop } from "./loop/normalize.js";
-export { defineLoop, defineProjectLoop } from "./loop/code.js";
+export {
+  agentStep,
+  bash,
+  defineLoop,
+  defineProjectLoop,
+  humanStep,
+  otherwise,
+  parallelStep,
+  permission,
+  policy,
+  requireTool,
+  toolAction,
+  toolStep,
+  when,
+} from "./loop/code.js";
 export { LoopHookRegistry } from "./loop/hooks.js";
 export type {
   LoopBeforeHookResult,

--- a/packages/core/src/loop/code.ts
+++ b/packages/core/src/loop/code.ts
@@ -1,5 +1,15 @@
 import { projectLoopConfigSchema } from "../schemas.js";
-import type { ProjectLoopConfig } from "./types.js";
+import type {
+  AgentLoopStep,
+  HumanLoopStep,
+  LoopHookAction,
+  LoopNext,
+  ParallelLoopStep,
+  ProjectLoopConfig,
+  ProjectLoopPermission,
+  ProjectLoopPolicy,
+  ToolLoopStep,
+} from "./types.js";
 
 /**
  * Code-first loop definition helper.
@@ -9,9 +19,62 @@ import type { ProjectLoopConfig } from "./types.js";
  * dashboard, API, and audit logs keep one declarative contract.
  */
 export function defineProjectLoop(config: ProjectLoopConfig): ProjectLoopConfig {
-  return projectLoopConfigSchema.parse(config) as ProjectLoopConfig;
+  return projectLoopConfigSchema.parse({
+    version: "1",
+    kind: "graph",
+    context: "shared",
+    ...config,
+  }) as ProjectLoopConfig;
 }
 
 export function defineLoop(config: ProjectLoopConfig): ProjectLoopConfig {
   return defineProjectLoop(config);
+}
+
+export function agentStep(step: Omit<AgentLoopStep, "type"> & { type?: "agent" }): AgentLoopStep {
+  return { type: "agent", ...step };
+}
+
+export function toolStep(step: Omit<ToolLoopStep, "type">): ToolLoopStep {
+  return { type: "tool", ...step };
+}
+
+export function humanStep(step: Omit<HumanLoopStep, "type">): HumanLoopStep {
+  return { type: "human", ...step };
+}
+
+export function parallelStep(step: Omit<ParallelLoopStep, "type">): ParallelLoopStep {
+  return { type: "parallel", ...step };
+}
+
+export function when(expression: string, to: string): Exclude<LoopNext, string>[number] {
+  return { when: expression, to };
+}
+
+export function otherwise(to: string): Exclude<LoopNext, string>[number] {
+  return { to };
+}
+
+export function requireTool(tool: string): { mode: "required"; tool: string } {
+  return { mode: "required", tool };
+}
+
+export function toolAction(
+  tool: string,
+  input?: unknown,
+  options: Omit<LoopHookAction, "tool" | "input"> = {},
+): LoopHookAction {
+  return { tool, ...(input !== undefined ? { input } : {}), ...options };
+}
+
+export function bash(command: string, options: Omit<LoopHookAction, "tool" | "input"> = {}): LoopHookAction {
+  return toolAction("bash", { command }, options);
+}
+
+export function permission(config: ProjectLoopPermission): ProjectLoopPermission {
+  return config;
+}
+
+export function policy(config: ProjectLoopPolicy): ProjectLoopPolicy {
+  return config;
 }

--- a/packages/core/src/loop/contract.test.ts
+++ b/packages/core/src/loop/contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { agentLoopConfigSchema, projectLoopConfigSchema } from "../schemas.js";
+import { agentStep, bash, defineProjectLoop, otherwise, requireTool, toolStep, when } from "./code.js";
 import { normalizeProjectLoop } from "./normalize.js";
 import type { ProjectLoopConfig } from "./types.js";
 
@@ -196,5 +197,55 @@ describe("agentLoopConfigSchema", () => {
 
     expect(parsed.success).toBe(false);
     expect(parsed.error?.issues[0]?.message).toContain('unknown loop hook "before:anything"');
+  });
+
+  it("builds code-first loop definitions without losing readable step metadata", () => {
+    const loop = defineProjectLoop({
+      name: "coding-flow",
+      hooks: {
+        "loop:start": [bash("echo start", { saveAs: "audit.start" })],
+      },
+      start: "plan",
+      steps: {
+        plan: agentStep({
+          label: "Plan",
+          description: "Inspect the request and prepare the implementation.",
+          tools: ["read", "grep"],
+          toolChoice: requireTool("grep"),
+          next: "build",
+        }),
+        build: toolStep({
+          label: "Build check",
+          description: "Run the deterministic build command.",
+          tool: "bash",
+          input: { command: "pnpm build" },
+          saveAs: "build",
+          next: [when("build.exitCode != 0", "plan"), otherwise("end")],
+        }),
+      },
+    });
+
+    expect(loop).toMatchObject({
+      version: "1",
+      kind: "graph",
+      context: "shared",
+      hooks: {
+        "loop:start": [{ tool: "bash", input: { command: "echo start" }, saveAs: "audit.start" }],
+      },
+      steps: {
+        plan: {
+          type: "agent",
+          label: "Plan",
+          description: "Inspect the request and prepare the implementation.",
+          toolChoice: { mode: "required", tool: "grep" },
+        },
+        build: {
+          type: "tool",
+          label: "Build check",
+          description: "Run the deterministic build command.",
+          next: [{ when: "build.exitCode != 0", to: "plan" }, { to: "end" }],
+        },
+      },
+    });
   });
 });

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -135,6 +135,10 @@ export type LoopToolChoice =
 export interface LoopConfig {
   /** Optional — the loops-map key is the canonical name. */
   name?: string;
+  /** Human-readable label for visualizers and editors. */
+  label?: string;
+  /** Human-readable description for visualizers, docs, and audit UI. */
+  description?: string;
   systemPrompt?: string;
   /** Tool subset active in this loop (restriction = determinism/safety). */
   tools?: string[];
@@ -162,6 +166,8 @@ export interface AgentLoopStep extends LoopConfig {
 
 export interface HumanLoopStep {
   type: "human";
+  label?: string;
+  description?: string;
   when?: string;
   output?: { schema?: unknown };
   notify?: string[];
@@ -170,6 +176,8 @@ export interface HumanLoopStep {
 
 export interface ParallelLoopStep {
   type: "parallel";
+  label?: string;
+  description?: string;
   when?: string;
   branches: string[];
   join?: "all" | "any" | number;
@@ -178,6 +186,8 @@ export interface ParallelLoopStep {
 
 export interface ToolLoopStep {
   type: "tool";
+  label?: string;
+  description?: string;
   when?: string;
   /** Built-in or custom tool name to execute directly, without an LLM turn. */
   tool: string;

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -231,6 +231,8 @@ export const loopToolChoiceSchema = z.union([
 
 export const loopConfigSchema = z.object({
   name: z.string().min(1).optional(),
+  label: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
   systemPrompt: z.string().optional(),
   tools: z.array(z.string().min(1)).optional(),
   skills: z.array(z.string().min(1)).optional(),
@@ -261,6 +263,8 @@ export const loopStepConfigSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("human"),
+    label: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
     when: z.string().min(1).optional(),
     output: z.object({
       schema: z.unknown().optional(),
@@ -270,6 +274,8 @@ export const loopStepConfigSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("parallel"),
+    label: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
     when: z.string().min(1).optional(),
     branches: z.array(z.string().min(1)).min(1),
     join: z.union([z.literal("all"), z.literal("any"), z.number().int().positive()]).optional(),
@@ -277,6 +283,8 @@ export const loopStepConfigSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("tool"),
+    label: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
     when: z.string().min(1).optional(),
     tool: z.string().min(1),
     input: z.unknown().optional(),
@@ -357,6 +365,8 @@ export const projectLoopConfigSchema = z.object({
     }),
     z.object({
       type: z.literal("human"),
+      label: z.string().min(1).optional(),
+      description: z.string().min(1).optional(),
       when: z.string().min(1).optional(),
       output: z.object({ schema: z.unknown().optional() }).optional(),
       notify: z.array(z.string().min(1)).optional(),
@@ -364,6 +374,8 @@ export const projectLoopConfigSchema = z.object({
     }),
     z.object({
       type: z.literal("parallel"),
+      label: z.string().min(1).optional(),
+      description: z.string().min(1).optional(),
       when: z.string().min(1).optional(),
       branches: z.array(z.string().min(1)).min(1),
       join: z.union([z.literal("all"), z.literal("any"), z.number().int().positive()]).optional(),
@@ -371,6 +383,8 @@ export const projectLoopConfigSchema = z.object({
     }),
     z.object({
       type: z.literal("tool"),
+      label: z.string().min(1).optional(),
+      description: z.string().min(1).optional(),
       when: z.string().min(1).optional(),
       tool: z.string().min(1),
       input: z.unknown().optional(),

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -1183,6 +1183,31 @@ describe("DrizzleAgentStore", () => {
     expect(updated.name).toBe("claude");
   });
 
+  it("does not persist legacy inline loop definitions on agents", async () => {
+    await stores.agentStore.createAgent({
+      name: "claude",
+      assignedLoops: ["Coding Loop"],
+      defaultLoop: "Coding Loop",
+      loops: { plan: { systemPrompt: "Plan" } },
+      pipeline: { steps: [{ loop: "plan" }] },
+    } as any, "alpha");
+
+    const created = await stores.agentStore.getAgent("claude") as any;
+    expect(created.assignedLoops).toEqual(["Coding Loop"]);
+    expect(created.defaultLoop).toBe("Coding Loop");
+    expect(created.loops).toBeUndefined();
+    expect(created.pipeline).toBeUndefined();
+
+    const updated = await stores.agentStore.updateAgent("claude", {
+      role: "coder",
+      loops: { implement: { systemPrompt: "Build" } },
+      pipeline: { steps: [{ loop: "implement" }] },
+    } as any) as any;
+    expect(updated.role).toBe("coder");
+    expect(updated.loops).toBeUndefined();
+    expect(updated.pipeline).toBeUndefined();
+  });
+
   it("moveAgent changes team", async () => {
     await stores.teamStore.createTeam({ name: "beta", agents: [] });
     await stores.agentStore.createAgent({ name: "claude" } as any, "alpha");

--- a/packages/drizzle/src/stores/agent-store.ts
+++ b/packages/drizzle/src/stores/agent-store.ts
@@ -5,6 +5,11 @@ import { type Dialect, serializeJson, deserializeJson, isUniqueViolation } from 
 
 type AnyTable = any;
 
+function stripInlineLoopFields(agent: AgentConfig): AgentConfig {
+  const { loops: _loops, pipeline: _pipeline, ...clean } = agent;
+  return clean as AgentConfig;
+}
+
 export class DrizzleAgentStore implements AgentStore {
   constructor(
     private db: any,
@@ -37,7 +42,8 @@ export class DrizzleAgentStore implements AgentStore {
     const now = new Date().toISOString();
     if (!agent.createdAt) agent.createdAt = now;
 
-    const { name, ...rest } = agent;
+    const cleanAgent = stripInlineLoopFields(agent);
+    const { name, ...rest } = cleanAgent;
     try {
       await this.db.insert(this.agentsTable).values({
         name,
@@ -52,14 +58,14 @@ export class DrizzleAgentStore implements AgentStore {
       }
       throw err;
     }
-    return agent;
+    return cleanAgent;
   }
 
   async updateAgent(name: string, updates: Partial<Omit<AgentConfig, "name">>): Promise<AgentConfig> {
     const existing = await this.getAgent(name);
     if (!existing) throw new Error(`Agent "${name}" not found`);
 
-    const merged = { ...existing, ...updates, name };
+    const merged = stripInlineLoopFields({ ...existing, ...updates, name } as AgentConfig);
     const { name: _n, ...rest } = merged;
     const now = new Date().toISOString();
 
@@ -122,6 +128,6 @@ export class DrizzleAgentStore implements AgentStore {
     const cfg = deserializeJson<Record<string, unknown>>(row.config, {}, this.dialect);
     const agent = { name: row.name, ...cfg } as AgentConfig & { teamName?: string };
     if (row.teamName) agent.teamName = row.teamName;
-    return agent;
+    return stripInlineLoopFields(agent);
   }
 }

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",
@@ -24,7 +24,8 @@
     "@polpo-ai/core": "workspace:*",
     "@polpo-ai/tools": "workspace:*",
     "hono": ">=4.0.0",
-    "nanoid": ">=5.0.0"
+    "nanoid": ">=5.0.0",
+    "typescript": "^5.7.3"
   },
   "peerDependencies": {
     "ai": ">=6.0.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,6 +45,7 @@ export type {
 
 // Validation schemas (Zod — reusable by CLI for pre-flight validation)
 export { AddAgentSchema, UpdateAgentSchema, RenameTeamSchema } from "./schemas.js";
+export { compileLoopSource, LoopDslCompileError } from "./loop-dsl-compiler.js";
 
 // Playbook utilities (pure logic, edge-compatible)
 export { validateParams, instantiatePlaybook } from "./playbook-utils.js";

--- a/packages/server/src/loop-contract.test.ts
+++ b/packages/server/src/loop-contract.test.ts
@@ -26,7 +26,7 @@ describe("agent loop API contract", () => {
     expect(parsed.error?.issues[0]?.message).toContain("is not in assignedLoops");
   });
 
-  it("accepts loops on agent create/update payloads", () => {
+  it("strips legacy inline loops from agent create/update payloads", () => {
     const loops = {
       classify: {
         systemPrompt: "Classify the incoming request.",
@@ -54,22 +54,11 @@ describe("agent loop API contract", () => {
       runtime: "polpo-runner",
       loops,
       pipeline,
-    })).toMatchObject({ runtime: "polpo-runner", loops, pipeline });
+    })).toEqual({ name: "loop-agent", runtime: "polpo-runner" });
 
     expect(UpdateAgentSchema.parse({
       loops,
       pipeline,
-    })).toMatchObject({ loops, pipeline });
-  });
-
-  it("rejects create payloads whose pipeline points at a missing loop", () => {
-    const parsed = AddAgentSchema.safeParse({
-      name: "loop-agent",
-      loops: { classify: {} },
-      pipeline: { steps: [{ loop: "missing" }] },
-    });
-
-    expect(parsed.success).toBe(false);
-    expect(parsed.error?.issues[0]?.message).toContain('unknown loop "missing"');
+    })).toEqual({});
   });
 });

--- a/packages/server/src/loop-dsl-compiler.test.ts
+++ b/packages/server/src/loop-dsl-compiler.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import type { FileEntry, FileStat, FileSystem } from "@polpo-ai/core";
+import { compileLoopSource, LoopDslCompileError } from "./loop-dsl-compiler.js";
+import { loopRoutes } from "./routes/loops.js";
+
+class MemoryFileSystem implements FileSystem {
+  files = new Map<string, string>();
+  dirs = new Set<string>();
+
+  async readFile(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`not found: ${path}`);
+    return content;
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return this.files.has(path) || this.dirs.has(path);
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    const prefix = `${path}/`;
+    return [...this.files.keys()]
+      .filter((file) => file.startsWith(prefix))
+      .map((file) => file.slice(prefix.length).split("/")[0])
+      .filter((file, index, files) => files.indexOf(file) === index);
+  }
+
+  async readdirWithTypes(path: string): Promise<FileEntry[]> {
+    return (await this.readdir(path)).map((name) => ({ name, isDirectory: false, isFile: true }));
+  }
+
+  async mkdir(path: string): Promise<void> {
+    this.dirs.add(path);
+  }
+
+  async remove(path: string): Promise<void> {
+    this.files.delete(path);
+    this.dirs.delete(path);
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    return { size: this.files.get(path)?.length ?? 0, isDirectory: this.dirs.has(path), isFile: this.files.has(path) };
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    const content = this.files.get(oldPath);
+    if (content !== undefined) {
+      this.files.set(newPath, content);
+      this.files.delete(oldPath);
+    }
+  }
+}
+
+describe("loop DSL compiler", () => {
+  it("compiles static TypeScript loop DSL to canonical JSON", () => {
+    const loop = compileLoopSource(`
+      import { defineProjectLoop, agentStep, toolStep, when, otherwise, bash } from "@polpo-ai/core/loop-code";
+
+      export default defineProjectLoop({
+        name: "ts-coding-flow",
+        description: "Typed authoring, JSON runtime.",
+        hooks: {
+          "loop:end": [bash("echo done")]
+        },
+        start: "plan",
+        steps: {
+          plan: agentStep({
+            label: "Plan",
+            tools: ["read", "grep"],
+            next: "build"
+          }),
+          build: toolStep({
+            label: "Build",
+            tool: "bash",
+            input: { command: "pnpm build" },
+            saveAs: "build",
+            next: [
+              when("build.exitCode != 0", "plan"),
+              otherwise("end")
+            ]
+          })
+        }
+      });
+    `);
+
+    expect(loop).toMatchObject({
+      version: "1",
+      kind: "graph",
+      context: "shared",
+      name: "ts-coding-flow",
+      hooks: {
+        "loop:end": [{ tool: "bash", input: { command: "echo done" } }],
+      },
+      steps: {
+        plan: { type: "agent", label: "Plan", tools: ["read", "grep"], next: "build" },
+        build: {
+          type: "tool",
+          label: "Build",
+          tool: "bash",
+          next: [{ when: "build.exitCode != 0", to: "plan" }, { to: "end" }],
+        },
+      },
+    });
+  });
+
+  it("rejects free-form code instead of executing it", () => {
+    expect(() =>
+      compileLoopSource(`
+        const start = "plan";
+        export default defineProjectLoop({
+          name: "bad",
+          start,
+          steps: { plan: agentStep({ next: "end" }) }
+        });
+      `),
+    ).toThrow(LoopDslCompileError);
+  });
+
+  it("accepts source payloads on the loops route and persists canonical JSON", async () => {
+    const fs = new MemoryFileSystem();
+    const app = loopRoutes(() => ({ fs, polpoDir: "/project/.polpo" }));
+    const res = await app.request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source: `
+          import { defineLoop, agentStep } from "@polpo-ai/core/loop-code";
+
+          export default defineLoop({
+            name: "route-ts-loop",
+            start: "work",
+            steps: {
+              work: agentStep({ label: "Work", next: "end" })
+            }
+          });
+        `,
+        fileName: "route-ts-loop.ts",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const saved = JSON.parse(await fs.readFile("/project/.polpo/loops/route-ts-loop.json"));
+    expect(saved).toMatchObject({
+      name: "route-ts-loop",
+      steps: { work: { type: "agent", label: "Work", next: "end" } },
+    });
+  });
+});

--- a/packages/server/src/loop-dsl-compiler.ts
+++ b/packages/server/src/loop-dsl-compiler.ts
@@ -1,0 +1,161 @@
+import ts from "typescript";
+import {
+  agentStep,
+  bash,
+  defineLoop,
+  defineProjectLoop,
+  humanStep,
+  otherwise,
+  parallelStep,
+  permission,
+  policy,
+  requireTool,
+  toolAction,
+  toolStep,
+  when,
+  type ProjectLoopConfig,
+} from "@polpo-ai/core";
+
+export class LoopDslCompileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LoopDslCompileError";
+  }
+}
+
+type JsonObject = Record<string, unknown>;
+
+const CALLS: Record<string, (...args: unknown[]) => unknown> = {
+  defineLoop: (loop) => defineLoop(asObject(loop, "defineLoop argument") as unknown as ProjectLoopConfig),
+  defineProjectLoop: (loop) =>
+    defineProjectLoop(asObject(loop, "defineProjectLoop argument") as unknown as ProjectLoopConfig),
+  agentStep: (step) => agentStep(asObject(step, "agentStep argument") as any),
+  toolStep: (step) => toolStep(asObject(step, "toolStep argument") as any),
+  humanStep: (step) => humanStep(asObject(step, "humanStep argument") as any),
+  parallelStep: (step) => parallelStep(asObject(step, "parallelStep argument") as any),
+  when: (expression, to) => when(asString(expression, "when expression"), asString(to, "when target")),
+  otherwise: (to) => otherwise(asString(to, "otherwise target")),
+  requireTool: (tool) => requireTool(asString(tool, "required tool")),
+  toolAction: (tool, input, options) =>
+    toolAction(asString(tool, "toolAction tool"), input, options === undefined ? {} : asObject(options, "toolAction options") as any),
+  bash: (command, options) =>
+    bash(asString(command, "bash command"), options === undefined ? {} : asObject(options, "bash options") as any),
+  permission: (config) => permission(asObject(config, "permission argument") as any),
+  policy: (config) => policy(asObject(config, "policy argument") as any),
+};
+
+function asObject(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new LoopDslCompileError(`${label} must be an object literal.`);
+  }
+  return value as JsonObject;
+}
+
+function asString(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new LoopDslCompileError(`${label} must be a non-empty string literal.`);
+  }
+  return value;
+}
+
+function propertyName(name: ts.PropertyName, source: ts.SourceFile): string {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  throw errorAt(source, name, "Computed property names are not supported in loop DSL source.");
+}
+
+function callName(expression: ts.Expression): string | undefined {
+  if (ts.isIdentifier(expression)) return expression.text;
+  return undefined;
+}
+
+function unwrap(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function errorAt(source: ts.SourceFile, node: ts.Node, message: string): LoopDslCompileError {
+  const { line, character } = source.getLineAndCharacterOfPosition(node.getStart(source));
+  return new LoopDslCompileError(`${message} (${source.fileName}:${line + 1}:${character + 1})`);
+}
+
+function expressionToValue(expression: ts.Expression, source: ts.SourceFile): unknown {
+  const expr = unwrap(expression);
+
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) return expr.text;
+  if (ts.isNumericLiteral(expr)) return Number(expr.text);
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return null;
+  if (ts.isIdentifier(expr) && expr.text === "undefined") return undefined;
+
+  if (ts.isPrefixUnaryExpression(expr)) {
+    const value = expressionToValue(expr.operand, source);
+    if (typeof value !== "number") throw errorAt(source, expr, "Unary operators are only supported for number literals.");
+    if (expr.operator === ts.SyntaxKind.MinusToken) return -value;
+    if (expr.operator === ts.SyntaxKind.PlusToken) return value;
+    throw errorAt(source, expr, "Unsupported unary operator in loop DSL source.");
+  }
+
+  if (ts.isArrayLiteralExpression(expr)) {
+    return expr.elements.map((item) => expressionToValue(item, source)).filter((value) => value !== undefined);
+  }
+
+  if (ts.isObjectLiteralExpression(expr)) {
+    const out: JsonObject = {};
+    for (const property of expr.properties) {
+      if (ts.isPropertyAssignment(property)) {
+        const value = expressionToValue(property.initializer, source);
+        if (value !== undefined) out[propertyName(property.name, source)] = value;
+        continue;
+      }
+      if (ts.isShorthandPropertyAssignment(property)) {
+        throw errorAt(source, property, "Shorthand properties are not supported in loop DSL source.");
+      }
+      if (ts.isSpreadAssignment(property)) {
+        throw errorAt(source, property, "Spread properties are not supported in loop DSL source.");
+      }
+      throw errorAt(source, property, "Only plain object properties are supported in loop DSL source.");
+    }
+    return out;
+  }
+
+  if (ts.isCallExpression(expr)) {
+    const name = callName(expr.expression);
+    if (!name || !CALLS[name]) {
+      throw errorAt(source, expr, "Only Polpo loop DSL helper calls are supported.");
+    }
+    return CALLS[name](...expr.arguments.map((arg) => expressionToValue(arg, source)));
+  }
+
+  throw errorAt(source, expr, "Unsupported expression in loop DSL source.");
+}
+
+function readDefaultExport(source: ts.SourceFile): ts.Expression {
+  for (const statement of source.statements) {
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals) return statement.expression;
+  }
+  throw new LoopDslCompileError("Loop DSL source must default-export defineLoop({...}) or a loop object.");
+}
+
+export function compileLoopSource(sourceText: string, fileName = "loop.ts"): ProjectLoopConfig {
+  const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const diagnostics = (source as ts.SourceFile & { parseDiagnostics?: readonly ts.DiagnosticWithLocation[] }).parseDiagnostics ?? [];
+  if (diagnostics.length > 0) {
+    const first = diagnostics[0]!;
+    const message = ts.flattenDiagnosticMessageText(first.messageText, "\n");
+    const position = first.start === undefined ? "" : ` at ${fileName}:${source.getLineAndCharacterOfPosition(first.start).line + 1}`;
+    throw new LoopDslCompileError(`Invalid TypeScript loop DSL source${position}: ${message}`);
+  }
+
+  const exported = expressionToValue(readDefaultExport(source), source);
+  return defineProjectLoop(asObject(exported, "default export") as unknown as ProjectLoopConfig);
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -97,8 +97,6 @@ export function agentRoutes(getDeps: () => {
       runtime: body.runtime,
       assignedLoops: body.assignedLoops,
       defaultLoop: body.defaultLoop,
-      loops: body.loops,
-      pipeline: body.pipeline,
       browserProfile: body.browserProfile,
       mcpServers: body.mcpServers,
     }, teamName);
@@ -401,8 +399,6 @@ export function agentRoutes(getDeps: () => {
       ...(body.runtime !== undefined && { runtime: body.runtime }),
       ...(body.assignedLoops !== undefined && { assignedLoops: body.assignedLoops }),
       ...(body.defaultLoop !== undefined && { defaultLoop: body.defaultLoop }),
-      ...(body.loops !== undefined && { loops: body.loops }),
-      ...(body.pipeline !== undefined && { pipeline: body.pipeline }),
       ...(body.maxTurns !== undefined && { maxTurns: body.maxTurns }),
       ...(body.maxConcurrency !== undefined && { maxConcurrency: body.maxConcurrency }),
       ...(body.browserProfile !== undefined && { browserProfile: body.browserProfile }),

--- a/packages/server/src/routes/loops.ts
+++ b/packages/server/src/routes/loops.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { join } from "node:path";
 import type { FileSystem, ProjectLoopConfig } from "@polpo-ai/core";
 import { projectLoopConfigSchema } from "@polpo-ai/core/schemas";
+import { compileLoopSource, LoopDslCompileError } from "../loop-dsl-compiler.js";
 
 export interface LoopRouteDeps {
   polpoDir: string;
@@ -17,6 +18,28 @@ async function readLoop(fs: FileSystem, polpoDir: string, name: string): Promise
   if (!(await fs.exists(path))) return null;
   const raw = await fs.readFile(path);
   return projectLoopConfigSchema.parse(JSON.parse(raw)) as ProjectLoopConfig;
+}
+
+function parseLoopPayload(payload: unknown): ProjectLoopConfig {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    typeof (payload as { source?: unknown }).source === "string"
+  ) {
+    const { source, fileName } = payload as { source: string; fileName?: unknown };
+    return compileLoopSource(source, typeof fileName === "string" ? fileName : "loop.ts");
+  }
+  return projectLoopConfigSchema.parse(payload) as ProjectLoopConfig;
+}
+
+function validationMessage(error: unknown): string {
+  if (error instanceof LoopDslCompileError) return error.message;
+  if (error && typeof error === "object" && "issues" in error && Array.isArray((error as { issues?: unknown }).issues)) {
+    return (error as { issues: Array<{ path: Array<string | number>; message: string }> }).issues
+      .map((issue) => `${issue.path.join(".") || "loop"}: ${issue.message}`)
+      .join("; ");
+  }
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function loopRoutes(getDeps: () => LoopRouteDeps): OpenAPIHono {
@@ -67,7 +90,16 @@ export function loopRoutes(getDeps: () => LoopRouteDeps): OpenAPIHono {
 
   const upsert = async (c: any) => {
     const { fs, polpoDir } = getDeps();
-    const parsed = projectLoopConfigSchema.parse(await c.req.json());
+    let parsed: ProjectLoopConfig;
+    try {
+      parsed = parseLoopPayload(await c.req.json());
+    } catch (error) {
+      return c.json({
+        ok: false,
+        error: validationMessage(error),
+        code: error instanceof LoopDslCompileError ? "LOOP_DSL_COMPILE_ERROR" : "INVALID_LOOP",
+      }, 400);
+    }
     await fs.mkdir(join(polpoDir, "loops")).catch(() => {});
     await fs.writeFile(loopPath(polpoDir, parsed.name), JSON.stringify(parsed, null, 2) + "\n");
     return c.json({ ok: true, data: parsed });

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -483,8 +483,6 @@ const AgentLoopFieldsSchema = z.object({
   runtime: z.string().optional(),
   assignedLoops: z.array(z.string().min(1)).optional(),
   defaultLoop: z.string().min(1).optional(),
-  loops: z.record(z.string().min(1), LoopConfigSchema).optional(),
-  pipeline: PipelineSchema.optional(),
 }).superRefine((config, ctx) => {
   if (config.defaultLoop && config.assignedLoops && !config.assignedLoops.includes(config.defaultLoop)) {
     ctx.addIssue({
@@ -492,19 +490,6 @@ const AgentLoopFieldsSchema = z.object({
       message: `defaultLoop "${config.defaultLoop}" is not in assignedLoops`,
       path: ["defaultLoop"],
     });
-  }
-  if (!config.loops || !config.pipeline) return;
-  const knownLoops = new Set(Object.keys(config.loops));
-  const refs: string[] = [];
-  for (const step of config.pipeline.steps) collectLoopRefs(step, refs);
-  for (const ref of refs) {
-    if (!knownLoops.has(ref)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `pipeline references unknown loop "${ref}"`,
-        path: ["pipeline"],
-      });
-    }
   }
 });
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       nanoid:
         specifier: '>=5.0.0'
         version: 5.1.6
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
       zod:
         specifier: '>=3.0.0 || >=4.0.0'
         version: 4.3.6
@@ -4022,14 +4025,14 @@ snapshots:
       msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
       vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@25.2.3)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5972,7 +5975,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/src/__tests__/completions.test.ts
+++ b/src/__tests__/completions.test.ts
@@ -167,19 +167,31 @@ describe("POST /v1/chat/completions", () => {
     });
 
     test("selects a configured agent loop when loop is provided", async () => {
+      await app.request("/api/v1/loops", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "plan",
+          start: "plan",
+          steps: {
+            plan: {
+              type: "agent",
+              systemPrompt: "Plan only.",
+              tools: ["read"],
+              model: "mock/loop-model",
+              next: "end",
+            },
+          },
+        }),
+      });
       await app.request("/api/v1/agents", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: "loop-agent",
           role: "Loop test agent",
-          loops: {
-            plan: {
-              systemPrompt: "Plan only.",
-              tools: ["read"],
-              model: "mock/loop-model",
-            },
-          },
+          assignedLoops: ["plan"],
+          defaultLoop: "plan",
         }),
       });
       setMockModel(mockTextModel("Loop selected."));

--- a/src/__tests__/server-api.test.ts
+++ b/src/__tests__/server-api.test.ts
@@ -482,18 +482,15 @@ describe("Agents API", () => {
     expect(agent2.role).toBe("helper");
   });
 
-  test("POST /agents preserves loop contract fields", async () => {
+  test("POST /agents preserves project loop assignment fields", async () => {
     const res = await app.request(
       api("/agents"),
       jsonReq("POST", {
         name: "agent-loop-create",
         role: "loop router",
         runtime: "polpo-runner",
-        loops: {
-          classify: { systemPrompt: "Classify.", tools: ["read"] },
-          answer: { systemPrompt: "Answer." },
-        },
-        pipeline: { steps: [{ loop: "classify" }, { loop: "answer" }] },
+        assignedLoops: ["router-flow"],
+        defaultLoop: "router-flow",
       }),
     );
     expect(res.status).toBe(201);
@@ -502,8 +499,10 @@ describe("Agents API", () => {
     const listBody = await listRes.json();
     const agent = listBody.data.find((a: any) => a.name === "agent-loop-create");
     expect(agent.runtime).toBe("polpo-runner");
-    expect(agent.loops.classify.tools).toEqual(["read"]);
-    expect(agent.pipeline.steps).toEqual([{ loop: "classify" }, { loop: "answer" }]);
+    expect(agent.assignedLoops).toEqual(["router-flow"]);
+    expect(agent.defaultLoop).toBe("router-flow");
+    expect(agent.loops).toBeUndefined();
+    expect(agent.pipeline).toBeUndefined();
   });
 
   test("DELETE /agents/:name removes an agent", async () => {
@@ -1159,25 +1158,25 @@ describe("Update Agent API", () => {
     await app.request(api("/agents/agent-update-test"), { method: "DELETE" });
   });
 
-  test("PATCH /agents/:name updates loop contract fields", async () => {
+  test("PATCH /agents/:name updates project loop assignment fields", async () => {
     await app.request(api("/agents"), jsonReq("POST", { name: "agent-loop-update", role: "original" }));
 
     const res = await app.request(
       api("/agents/agent-loop-update"),
       jsonReq("PATCH", {
         runtime: "polpo-runner",
-        loops: {
-          classify: { systemPrompt: "Classify.", tools: ["read"] },
-        },
-        pipeline: { steps: [{ loop: "classify" }] },
+        assignedLoops: ["classify-flow"],
+        defaultLoop: "classify-flow",
       }),
     );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.runtime).toBe("polpo-runner");
-    expect(body.data.loops.classify.tools).toEqual(["read"]);
-    expect(body.data.pipeline.steps).toEqual([{ loop: "classify" }]);
+    expect(body.data.assignedLoops).toEqual(["classify-flow"]);
+    expect(body.data.defaultLoop).toBe("classify-flow");
+    expect(body.data.loops).toBeUndefined();
+    expect(body.data.pipeline).toBeUndefined();
 
     await app.request(api("/agents/agent-loop-update"), { method: "DELETE" });
   });

--- a/src/server/schemas.ts
+++ b/src/server/schemas.ts
@@ -408,8 +408,6 @@ const AgentLoopFieldsSchema = z.object({
   runtime: z.string().optional(),
   assignedLoops: z.array(z.string().min(1)).optional(),
   defaultLoop: z.string().min(1).optional(),
-  loops: z.record(z.string().min(1), LoopConfigSchema).optional(),
-  pipeline: PipelineSchema.optional(),
 }).superRefine((config, ctx) => {
   if (config.defaultLoop && config.assignedLoops && !config.assignedLoops.includes(config.defaultLoop)) {
     ctx.addIssue({
@@ -417,19 +415,6 @@ const AgentLoopFieldsSchema = z.object({
       message: `defaultLoop "${config.defaultLoop}" is not in assignedLoops`,
       path: ["defaultLoop"],
     });
-  }
-  if (!config.loops || !config.pipeline) return;
-  const knownLoops = new Set(Object.keys(config.loops));
-  const refs: string[] = [];
-  for (const step of config.pipeline.steps) collectLoopRefs(step, refs);
-  for (const ref of refs) {
-    if (!knownLoops.has(ref)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `pipeline references unknown loop "${ref}"`,
-        path: ["pipeline"],
-      });
-    }
   }
 });
 


### PR DESCRIPTION
## What changed

- Adds static TypeScript authoring for project loops through `@polpo-ai/core/loop-code` helpers (`agentStep`, `toolStep`, `when`, `bash`, `permission`, etc.).
- Adds a server-side static loop DSL compiler and lets `/v1/loops` accept `{ source, fileName }` while persisting canonical JSON.
- Updates `polpo deploy` so `.polpo/loops/*.json` deploys as JSON and `.polpo/loops/*.ts/.js/.mjs` deploys as source for server-side compilation.
- Keeps project loops as project-level resources and prevents legacy inline `agent.loops/pipeline` from being persisted on agents.
- Bumps all published workspace packages to `0.10.8` for the tag-driven release workflow.

## Why

Developers can now keep loop definitions in code without turning loop runtime into arbitrary executable TypeScript. The runtime contract remains deterministic JSON, while CLI/API/server all use the same validation path.

## Validation

- `pnpm typecheck`
- `pnpm --filter @polpo-ai/cli test`
- `pnpm exec vitest run packages/server/src packages/core/src/loop`
- `pnpm test run`

Note: local full test run skipped the Postgres-only suite because `TEST_DATABASE_URL` was not set, matching its existing skip behavior.

## Release

After merge to `main`, push tag `v0.10.8` to trigger `.github/workflows/release.yml` and publish npm packages plus the runner image.
