### PR TITLE
Fix provider-executed tool response history

### DIFF
--- a/packages/server/src/routes/completions-provider-tools.test.ts
+++ b/packages/server/src/routes/completions-provider-tools.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { generateTextMock } = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  generateText: generateTextMock,
+  streamText: vi.fn(),
+  jsonSchema: (schema: unknown) => schema,
+}));
+
+import { completionRoutes, type CompletionRouteDeps } from "./completions.js";
+
+describe("completionRoutes provider-executed tools", () => {
+  function makeDeps(): CompletionRouteDeps {
+    return {
+      getAgents: async () => [{
+        name: "researcher",
+        model: "test",
+        assignedLoops: ["research-loop"],
+        defaultLoop: "research-loop",
+        allowedTools: ["search_web"],
+      }],
+      getConfig: () => ({}),
+      getMemoryStore: () => null,
+      getSessionStore: () => null,
+      getStore: () => null,
+      emit: () => {},
+      buildAgentPrompt: () => "You are a researcher.",
+      resolveAgentModel: async () => ({
+        model: {
+          id: "test",
+          provider: "test",
+          aiModel: "test-model",
+          contextWindow: 100_000,
+          maxTokens: 1024,
+        },
+        providerOptions: undefined,
+      }),
+      resolveAgentTools: async () => ({
+        tools: [],
+        extraAiTools: {
+          search_web: { type: "provider-defined", id: "gateway.perplexity_search" },
+        },
+        executor: async (name) => {
+          throw new Error(`provider tool "${name}" should not be executed locally`);
+        },
+      }),
+      getProjectLoop: async (name) => ({
+        name,
+        context: "shared",
+        start: "research",
+        steps: {
+          research: {
+            type: "agent",
+            systemPrompt: "Search the web, then summarize the result.",
+            tools: ["search_web"],
+            maxTurns: 3,
+            next: "end",
+          },
+        },
+      }),
+    };
+  }
+
+  it("feeds provider-executed tool results back through AI SDK responseMessages", async () => {
+    let secondTurnMessages: any[] | undefined;
+    const searchOutput = {
+      results: [{ title: "Polpo", url: "https://polpo.sh", snippet: "Agent backend" }],
+      id: "search_1",
+    };
+
+    generateTextMock
+      .mockResolvedValueOnce({
+        text: "",
+        usage: { inputTokens: 10, outputTokens: 2, totalTokens: 12 },
+        providerMetadata: undefined,
+        toolCalls: [{
+          toolCallId: "call_search",
+          toolName: "search_web",
+          input: { query: "Polpo agent backend" },
+          providerExecuted: true,
+        }],
+        toolResults: [{
+          type: "tool-result",
+          toolCallId: "call_search",
+          toolName: "search_web",
+          output: searchOutput,
+          providerExecuted: true,
+        }],
+        responseMessages: [{
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_search",
+              toolName: "search_web",
+              input: { query: "Polpo agent backend" },
+              providerExecuted: true,
+            },
+            {
+              type: "tool-result",
+              toolCallId: "call_search",
+              toolName: "search_web",
+              output: { type: "json", value: searchOutput },
+              providerExecuted: true,
+            },
+          ],
+        }],
+      })
+      .mockImplementationOnce(async (args: any) => {
+        secondTurnMessages = args.messages;
+        return {
+          text: "Polpo is an agent backend.",
+          usage: { inputTokens: 20, outputTokens: 5, totalTokens: 25 },
+          providerMetadata: undefined,
+          toolCalls: [],
+          toolResults: [],
+          responseMessages: [{
+            role: "assistant",
+            content: "Polpo is an agent backend.",
+          }],
+        };
+      });
+
+    const app = completionRoutes(() => makeDeps());
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        agent: "researcher",
+        messages: [{ role: "user", content: "Research Polpo" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(json.choices[0].message.content).toBe("Polpo is an agent backend.");
+    expect(generateTextMock).toHaveBeenCalledTimes(2);
+
+    expect(secondTurnMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              type: "tool-result",
+              toolName: "search_web",
+              providerExecuted: true,
+            }),
+          ]),
+        }),
+      ]),
+    );
+    expect(
+      secondTurnMessages?.filter((message) =>
+        message.role === "tool" && JSON.stringify(message).includes("search_web"),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -90,6 +90,61 @@ function redactVaultToolCalls(toolCalls: any[]): any[] {
   });
 }
 
+async function appendModelResponseMessages(
+  messages: any[],
+  result: any,
+  turnText: string,
+  toolCalls: any[],
+): Promise<void> {
+  try {
+    const responseMessages = await result.responseMessages;
+    if (Array.isArray(responseMessages) && responseMessages.length > 0) {
+      messages.push(...responseMessages);
+      return;
+    }
+  } catch {
+    // Older/partial AI SDK results can still be represented manually below.
+  }
+
+  const assistantContent: any[] = [];
+  if (turnText) assistantContent.push({ type: "text", text: turnText });
+  for (const tc of toolCalls) {
+    assistantContent.push({
+      type: "tool-call",
+      toolCallId: tc.toolCallId,
+      toolName: tc.toolName,
+      input: tc.input,
+    });
+  }
+  messages.push({
+    role: "assistant",
+    content: assistantContent.length === 1 && assistantContent[0].type === "text"
+      ? turnText
+      : assistantContent,
+  });
+}
+
+function indexToolResultsByCallId(toolResults: any[] | undefined): Map<string, any> {
+  const indexed = new Map<string, any>();
+  for (const result of toolResults ?? []) {
+    if (result?.toolCallId) indexed.set(result.toolCallId, result);
+  }
+  return indexed;
+}
+
+function recordProviderToolCall(toolCallsAccum: any[], call: any, toolResults: Map<string, any>): void {
+  const toolResult = toolResults.get(call.toolCallId);
+  const output = toolResult?.output ?? toolResult?.result ?? toolResult?.error;
+  toolCallsAccum.push({
+    id: call.toolCallId,
+    name: call.toolName,
+    arguments: call.input as Record<string, unknown>,
+    result: output === undefined ? undefined : typeof output === "string" ? output : JSON.stringify(output),
+    state: toolResult?.type === "tool-error" || toolResult?.error ? "error" : "completed",
+    providerExecuted: true,
+  });
+}
+
 // ── Zod Schemas ────────────────────────────────────────────────────────
 
 /** OpenAI-compatible content part (text, image_url, or file reference). */
@@ -844,45 +899,17 @@ async function runAgentStepCompletion(options: {
       totalUsage = addUsage(totalUsage, genResult.usage);
       try { lastProviderMetadata = genResult.providerMetadata as Record<string, unknown>; } catch { /* best effort */ }
 
-      const assistantContent: any[] = [];
-      if (turnText) assistantContent.push({ type: "text", text: turnText });
-      for (const tc of genResult.toolCalls) {
-        assistantContent.push({
-          type: "tool-call",
-          toolCallId: tc.toolCallId,
-          toolName: tc.toolName,
-          input: tc.input,
-        });
-      }
-      messages.push({
-        role: "assistant",
-        content: assistantContent.length === 1 && assistantContent[0].type === "text"
-          ? turnText
-          : assistantContent,
-      });
+      await appendModelResponseMessages(messages, genResult, turnText, genResult.toolCalls);
       finalText += turnText;
 
       if (genResult.toolCalls.length === 0) break;
 
-      const providerToolResults = new Map<string, any>();
-      for (const tr of (genResult.toolResults as any[] | undefined) ?? []) {
-        providerToolResults.set(tr.toolCallId, tr);
-      }
+      const providerToolResults = indexToolResultsByCallId(genResult.toolResults as any[] | undefined);
 
       for (const call of genResult.toolCalls) {
         const callArgs = call.input as Record<string, unknown>;
         if (providerToolNames.has(call.toolName)) {
-          const tr = providerToolResults.get(call.toolCallId);
-          const value = tr?.output ?? tr?.result ?? null;
-          messages.push({
-            role: "tool",
-            content: [{
-              type: "tool-result",
-              toolCallId: call.toolCallId,
-              toolName: call.toolName,
-              output: { type: "json" as const, value },
-            }],
-          });
+          recordProviderToolCall(toolCallsAccum, call, providerToolResults);
           continue;
         }
 
@@ -1712,26 +1739,7 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
             } as LanguageModelUsage;
             try { lastProviderMetadata = (await result.providerMetadata) as Record<string, unknown>; } catch { /* best effort */ }
 
-            // Push assistant response message into conversation history
-            // AI SDK format: assistant message with text + tool calls
-            const assistantContent: any[] = [];
-            if (turnText) {
-              assistantContent.push({ type: "text", text: turnText });
-            }
-            for (const tc of toolCalls) {
-              assistantContent.push({
-                type: "tool-call",
-                toolCallId: tc.toolCallId,
-                toolName: tc.toolName,
-                input: tc.input,
-              });
-            }
-            messages.push({
-              role: "assistant",
-              content: assistantContent.length === 1 && assistantContent[0].type === "text"
-                ? turnText
-                : assistantContent,
-            });
+            await appendModelResponseMessages(messages, result, turnText, toolCalls);
 
             finalText += turnText;
 
@@ -1853,15 +1861,14 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
               return; // finally block will persist whatever finalText we have
             }
 
-            // Provider tools (extraAiTools) are executed by the SDK / gateway
-            // inside generateText itself — their results are already on
-            // `result.toolResults`. Skip them in our manual dispatcher; just
-            // forward the result message into history for the next turn.
+            // Provider tools (extraAiTools) are executed by the SDK / gateway.
+            // Their tool results are already preserved in responseMessages,
+            // so only record them for observability and skip local dispatch.
             const providerToolNames = new Set(Object.keys(extraAiTools ?? {}));
-            const providerToolResults = new Map<string, any>();
+            let providerToolResults = new Map<string, any>();
             try {
               const settled = (await (result as any).toolResults) as any[] | undefined;
-              for (const tr of settled ?? []) providerToolResults.set(tr.toolCallId, tr);
+              providerToolResults = indexToolResultsByCallId(settled);
             } catch { /* best effort */ }
 
             for (const call of toolCalls) {
@@ -1871,17 +1878,7 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
               const callArgs = call.input as Record<string, unknown>;
 
               if (providerToolNames.has(call.toolName)) {
-                const tr = providerToolResults.get(call.toolCallId);
-                const value = tr?.output ?? tr?.result ?? null;
-                messages.push({
-                  role: "tool",
-                  content: [{
-                    type: "tool-result",
-                    toolCallId: call.toolCallId,
-                    toolName: call.toolName,
-                    output: { type: "json" as const, value },
-                  }],
-                });
+                recordProviderToolCall(toolCallsAccum, call, providerToolResults);
                 continue;
               }
 
@@ -2037,25 +2034,7 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
           } as LanguageModelUsage;
           try { lastProviderMetadata = genResult.providerMetadata as Record<string, unknown>; } catch { /* best effort */ }
 
-          // Push assistant response message into conversation history
-          const assistantContent: any[] = [];
-          if (turnText) {
-            assistantContent.push({ type: "text", text: turnText });
-          }
-          for (const tc of genResult.toolCalls) {
-            assistantContent.push({
-              type: "tool-call",
-              toolCallId: tc.toolCallId,
-              toolName: tc.toolName,
-              input: tc.input,
-            });
-          }
-          messages.push({
-            role: "assistant",
-            content: assistantContent.length === 1 && assistantContent[0].type === "text"
-              ? turnText
-              : assistantContent,
-          });
+          await appendModelResponseMessages(messages, genResult, turnText, genResult.toolCalls);
 
           finalText += turnText;
 
@@ -2233,30 +2212,17 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
             // Note: finally block persists finalText + toolCallsAccum
           }
 
-          // Provider tools (extraAiTools) are executed by the SDK / gateway
-          // inside generateText itself — their results are already on
-          // `genResult.toolResults`. Skip them in the manual dispatcher.
+          // Provider tools (extraAiTools) are executed by the SDK / gateway.
+          // Their tool results are already preserved in responseMessages,
+          // so only record them for observability and skip local dispatch.
           const providerToolNames = new Set(Object.keys(extraAiTools ?? {}));
-          const providerToolResults = new Map<string, any>();
-          for (const tr of (genResult.toolResults as any[] | undefined) ?? []) {
-            providerToolResults.set(tr.toolCallId, tr);
-          }
+          const providerToolResults = indexToolResultsByCallId(genResult.toolResults as any[] | undefined);
 
           for (const call of toolCalls) {
             const callArgs = call.input as Record<string, unknown>;
 
             if (providerToolNames.has(call.toolName)) {
-              const tr = providerToolResults.get(call.toolCallId);
-              const value = tr?.output ?? tr?.result ?? null;
-              messages.push({
-                role: "tool",
-                content: [{
-                  type: "tool-result",
-                  toolCallId: call.toolCallId,
-                  toolName: call.toolName,
-                  output: { type: "json" as const, value },
-                }],
-              });
+              recordProviderToolCall(toolCallsAccum, call, providerToolResults);
               continue;
             }
 


### PR DESCRIPTION
## Summary
- preserve AI SDK responseMessages after model turns so provider-executed tools stay in the assistant message history
- stop injecting provider-executed tool results as separate role=tool messages
- record provider-executed tool calls for session/runtime observability
- add regression coverage for search_web-style provider tools inside project loops

## Tests
- pnpm --filter @polpo-ai/server build
- pnpm vitest run packages/server/src
