### PR TITLE
feat: add while loop step support

### DIFF
--- a/packages/client-sdk/src/client/types.ts
+++ b/packages/client-sdk/src/client/types.ts
@@ -383,6 +383,7 @@ export type LoopStepConfig =
   | (LoopConfig & { type?: "agent"; when?: string; next?: LoopNext })
   | { type: "human"; when?: string; output?: { schema?: unknown }; notify?: string[]; next?: LoopNext }
   | { type: "parallel"; when?: string; branches: string[]; join?: "all" | "any" | number; next?: LoopNext }
+  | { type: "while"; when?: string; condition?: string; until?: string; body: string | string[]; maxIterations?: number; next?: LoopNext }
   | { type: "tool"; when?: string; tool: string; input?: unknown; saveAs?: string; next?: LoopNext };
 
 export interface ProjectLoopConfig {
@@ -404,11 +405,19 @@ export interface SwitchCase {
   steps: Step[];
 }
 
+export interface WhileBlock {
+  condition?: string;
+  until?: string;
+  maxIterations?: number;
+  steps: Step[];
+}
+
 export type Step =
   | { loop: string; when?: string }
   | { tool: string; input?: unknown; saveAs?: string; when?: string }
   | { parallel: Step[]; join?: "all" | "any" | number; when?: string }
   | { switch: { cases: SwitchCase[]; default?: { steps: Step[] } }; when?: string }
+  | { while: WhileBlock; when?: string }
   | { human: string; output?: { schema?: unknown }; notify?: string[]; when?: string };
 
 export interface Pipeline {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -182,8 +182,9 @@ export type {
   SwitchCase,
   Condition,
   ToolLoopStep,
+  WhileLoopStep,
 } from "./loop/types.js";
-export { LOOP_LIFECYCLE_HOOKS, isLoopStep, isToolStep, isParallelStep, isSwitchStep, isHumanStep } from "./loop/types.js";
+export { LOOP_LIFECYCLE_HOOKS, isLoopStep, isToolStep, isParallelStep, isSwitchStep, isWhileStep, isHumanStep } from "./loop/types.js";
 export { normalizeProjectLoop } from "./loop/normalize.js";
 export {
   agentStep,
@@ -198,6 +199,7 @@ export {
   requireTool,
   toolAction,
   toolStep,
+  whileStep,
   when,
 } from "./loop/code.js";
 export { LoopHookRegistry } from "./loop/hooks.js";

--- a/packages/core/src/loop/code.ts
+++ b/packages/core/src/loop/code.ts
@@ -9,6 +9,7 @@ import type {
   ProjectLoopPermission,
   ProjectLoopPolicy,
   ToolLoopStep,
+  WhileLoopStep,
 } from "./types.js";
 
 /**
@@ -45,6 +46,10 @@ export function humanStep(step: Omit<HumanLoopStep, "type">): HumanLoopStep {
 
 export function parallelStep(step: Omit<ParallelLoopStep, "type">): ParallelLoopStep {
   return { type: "parallel", ...step };
+}
+
+export function whileStep(step: Omit<WhileLoopStep, "type">): WhileLoopStep {
+  return { type: "while", ...step };
 }
 
 export function when(expression: string, to: string): Exclude<LoopNext, string>[number] {

--- a/packages/core/src/loop/contract.test.ts
+++ b/packages/core/src/loop/contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { agentLoopConfigSchema, projectLoopConfigSchema } from "../schemas.js";
-import { agentStep, bash, defineProjectLoop, otherwise, requireTool, toolStep, when } from "./code.js";
+import { agentStep, bash, defineProjectLoop, otherwise, requireTool, toolStep, when, whileStep } from "./code.js";
 import { normalizeProjectLoop } from "./normalize.js";
 import type { ProjectLoopConfig } from "./types.js";
 
@@ -247,5 +247,46 @@ describe("agentLoopConfigSchema", () => {
         },
       },
     });
+  });
+
+  it("accepts explicit project-level while steps and normalizes their body", () => {
+    const loop = defineProjectLoop({
+      name: "retry-build",
+      start: "retry_until_green",
+      steps: {
+        retry_until_green: whileStep({
+          label: "Retry until green",
+          description: "Repeat fix and build until the build passes.",
+          until: "build.passed == true",
+          maxIterations: 3,
+          body: "fix",
+          next: "finalize",
+        }),
+        fix: agentStep({
+          systemPrompt: "Fix the failure.",
+          next: "build_check",
+        }),
+        build_check: toolStep({
+          tool: "build_check",
+          saveAs: "build",
+          next: "end",
+        }),
+        finalize: agentStep({
+          systemPrompt: "Summarize.",
+          next: "end",
+        }),
+      },
+    });
+
+    expect(normalizeProjectLoop(loop).pipeline?.steps).toMatchObject([
+      {
+        while: {
+          until: "build.passed == true",
+          maxIterations: 3,
+          steps: [{ loop: "fix" }, { tool: "build_check", saveAs: "build" }],
+        },
+      },
+      { loop: "finalize" },
+    ]);
   });
 });

--- a/packages/core/src/loop/normalize.ts
+++ b/packages/core/src/loop/normalize.ts
@@ -56,6 +56,23 @@ function stepFor(id: string, loop: ProjectLoopConfig, seen = new Set<string>()):
     ];
   }
 
+  if (node.type === "while") {
+    const body = (Array.isArray(node.body) ? node.body : [node.body])
+      .flatMap((entry) => stepFor(entry, loop, new Set(seen)));
+    return [
+      {
+        while: {
+          condition: node.condition,
+          until: node.until,
+          maxIterations: node.maxIterations,
+          steps: body,
+        },
+        when: node.when,
+      },
+      ...transitionSteps(node.next, loop, seen),
+    ];
+  }
+
   if (node.type === "tool") {
     return [
       {
@@ -78,7 +95,7 @@ function stepFor(id: string, loop: ProjectLoopConfig, seen = new Set<string>()):
 export function normalizeProjectLoop(loop: ProjectLoopConfig): AgentLoopConfig {
   const loops: AgentLoopConfig["loops"] = {};
   for (const [id, step] of Object.entries(loop.steps)) {
-    if (step.type === "human" || step.type === "parallel" || step.type === "tool") continue;
+    if (step.type === "human" || step.type === "parallel" || step.type === "while" || step.type === "tool") continue;
     const { type: _type, when: _when, next: _next, ...config } = step;
     loops[id] = config;
   }

--- a/packages/core/src/loop/pipeline.test.ts
+++ b/packages/core/src/loop/pipeline.test.ts
@@ -174,6 +174,54 @@ describe("PipelineExecutor", () => {
     expect(result.context.underwriter).toEqual({ decision: "approve" });
   });
 
+  it("runs while blocks until the exit condition is satisfied", async () => {
+    const executor = new PipelineExecutor();
+    let attempts = 0;
+    const result = await executor.execute({
+      loops: {},
+      pipeline: {
+        steps: [
+          {
+            while: {
+              until: "build.passed == true",
+              maxIterations: 3,
+              steps: [{ tool: "build_check", saveAs: "build" }],
+            },
+          },
+        ],
+      },
+      runLoop: async () => ({ output: {} }),
+      runTool: async () => {
+        attempts += 1;
+        return { output: { passed: attempts >= 2 } };
+      },
+    });
+
+    expect(attempts).toBe(2);
+    expect(result.context.build).toEqual({ passed: true });
+    expect(result.trace.filter((event) => event.type === "while" && event.matched)).toHaveLength(2);
+  });
+
+  it("fails while blocks when maxIterations is exhausted", async () => {
+    const executor = new PipelineExecutor();
+    await expect(executor.execute({
+      loops: {},
+      pipeline: {
+        steps: [
+          {
+            while: {
+              until: "build.passed == true",
+              maxIterations: 2,
+              steps: [{ tool: "build_check", saveAs: "build" }],
+            },
+          },
+        ],
+      },
+      runLoop: async () => ({ output: {} }),
+      runTool: async () => ({ output: { passed: false } }),
+    })).rejects.toThrow("maxIterations");
+  });
+
   it("throws typed errors for deny and approval policies", async () => {
     const executor = new PipelineExecutor();
 

--- a/packages/core/src/loop/pipeline.ts
+++ b/packages/core/src/loop/pipeline.ts
@@ -12,6 +12,7 @@ import {
   isLoopStep,
   isParallelStep,
   isSwitchStep,
+  isWhileStep,
   isToolStep,
   type ContextBag,
   type LoopConfig,
@@ -41,10 +42,11 @@ export interface PipelineToolResult {
 }
 
 export interface PipelineTraceEvent {
-  type: "loop" | "tool" | "human" | "switch" | "parallel" | "skip";
+  type: "loop" | "tool" | "human" | "switch" | "while" | "parallel" | "skip";
   name?: string;
   when?: string;
   matched?: boolean;
+  iteration?: number;
 }
 
 export interface PipelineExecutionResult {
@@ -191,6 +193,44 @@ export class PipelineExecutor {
           continue;
         }
 
+        if (isWhileStep(step)) {
+          await this.runLifecyclePoint("step:before", context, options, state, { step: { name: "while", type: "while" } });
+          await state.emit({
+            type: "step.start",
+            step: "while",
+            status: "started",
+            when: step.when,
+            data: { condition: step.while.condition, until: step.while.until, maxIterations: step.while.maxIterations },
+          });
+          const maxIterations = step.while.maxIterations ?? 5;
+          let iterations = 0;
+          while (this.shouldRunWhile(step.while.condition, step.while.until, context)) {
+            if (iterations >= maxIterations) {
+              throw new Error(`Loop while step exceeded maxIterations (${maxIterations}) before its exit condition was satisfied`);
+            }
+            iterations += 1;
+            trace.push({ type: "while", when: step.while.condition ?? step.while.until, matched: true, iteration: iterations });
+            await state.emit({
+              type: "step.start",
+              step: "while",
+              status: "started",
+              data: { iteration: iterations, condition: step.while.condition, until: step.while.until },
+            });
+            lastNode = await this.executeSteps(step.while.steps, context, trace, options, state, lastNode);
+            await state.emit({
+              type: "step.end",
+              step: "while",
+              status: "completed",
+              data: { iteration: iterations },
+            });
+          }
+          trace.push({ type: "while", when: step.while.condition ?? step.while.until, matched: false, iteration: iterations });
+          await this.runLifecyclePoint("step:after", context, options, state, { step: { name: "while", type: "while" }, output: { iterations } });
+          await state.emit({ type: "step.end", step: "while", status: "completed", output: { iterations } });
+          lastNode = "while";
+          continue;
+        }
+
         if (isParallelStep(step)) {
           await this.runLifecyclePoint("step:before", context, options, state, { step: { name: "parallel", type: "parallel" } });
           await state.emit({ type: "step.start", step: "parallel", status: "started", when: step.when });
@@ -236,6 +276,12 @@ export class PipelineExecutor {
   private matchesWhen(expression: string | undefined, context: ContextBag): boolean {
     if (!expression) return true;
     return this.evaluator.evaluate(expression, context);
+  }
+
+  private shouldRunWhile(condition: string | undefined, until: string | undefined, context: ContextBag): boolean {
+    if (until && this.matchesWhen(until, context)) return false;
+    if (condition) return this.matchesWhen(condition, context);
+    return !!until;
   }
 
   private async runTransitionHook(

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -184,6 +184,22 @@ export interface ParallelLoopStep {
   next?: LoopNext;
 }
 
+export interface WhileLoopStep {
+  type: "while";
+  label?: string;
+  description?: string;
+  when?: string;
+  /** Run the body while this expression evaluates true. Mutually optional with `until`. */
+  condition?: string;
+  /** Run the body until this expression evaluates true. Mutually optional with `condition`. */
+  until?: string;
+  /** First body step id, or multiple independent entry step ids executed sequentially per iteration. */
+  body: string | string[];
+  /** Safety guard. Defaults to 5 in the executor when omitted. */
+  maxIterations?: number;
+  next?: LoopNext;
+}
+
 export interface ToolLoopStep {
   type: "tool";
   label?: string;
@@ -198,7 +214,7 @@ export interface ToolLoopStep {
   next?: LoopNext;
 }
 
-export type LoopStepConfig = AgentLoopStep | HumanLoopStep | ParallelLoopStep | ToolLoopStep;
+export type LoopStepConfig = AgentLoopStep | HumanLoopStep | ParallelLoopStep | WhileLoopStep | ToolLoopStep;
 
 /** Project-level reusable loop graph. Agents assign these by name/id. */
 export interface ProjectLoopConfig {
@@ -220,11 +236,19 @@ export interface SwitchCase {
   steps: Step[];
 }
 
+export interface WhileBlock {
+  condition?: string;
+  until?: string;
+  maxIterations?: number;
+  steps: Step[];
+}
+
 export type Step =
   | { loop: string; when?: string }
   | { tool: string; input?: unknown; saveAs?: string; when?: string }
   | { parallel: Step[][]; join?: "all" | "any" | number; when?: string }
   | { switch: { cases: SwitchCase[]; default?: { steps: Step[] } }; when?: string }
+  | { while: WhileBlock; when?: string }
   | { human: string; output?: { schema?: unknown }; notify?: string[]; when?: string };
 
 export interface Pipeline {
@@ -251,6 +275,7 @@ export const isParallelStep = (s: Step): s is { parallel: Step[][]; join?: "all"
 export const isSwitchStep = (
   s: Step,
 ): s is { switch: { cases: SwitchCase[]; default?: { steps: Step[] } }; when?: string } => "switch" in s;
+export const isWhileStep = (s: Step): s is { while: WhileBlock; when?: string } => "while" in s;
 export const isHumanStep = (
   s: Step,
 ): s is { human: string; output?: { schema?: unknown }; notify?: string[]; when?: string } => "human" in s;

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -382,6 +382,19 @@ export const projectLoopConfigSchema = z.object({
       next: loopNextSchema.optional(),
     }),
     z.object({
+      type: z.literal("while"),
+      label: z.string().min(1).optional(),
+      description: z.string().min(1).optional(),
+      when: z.string().min(1).optional(),
+      condition: z.string().min(1).optional(),
+      until: z.string().min(1).optional(),
+      body: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]),
+      maxIterations: z.number().int().positive().optional(),
+      next: loopNextSchema.optional(),
+    }).refine((step) => !!step.condition || !!step.until, {
+      message: "while step requires condition or until",
+    }),
+    z.object({
       type: z.literal("tool"),
       label: z.string().min(1).optional(),
       description: z.string().min(1).optional(),
@@ -405,6 +418,10 @@ export const projectLoopConfigSchema = z.object({
   for (const [name, step] of Object.entries(loop.steps)) {
     if (step.type === "parallel") {
       step.branches.forEach((branch, i) => checkTarget(branch, ["steps", name, "branches", i]));
+    }
+    if (step.type === "while") {
+      const body = Array.isArray(step.body) ? step.body : [step.body];
+      body.forEach((entry, i) => checkTarget(entry, ["steps", name, "body", i]));
     }
     const toolChoice = (step as { toolChoice?: unknown }).toolChoice;
     if (toolChoice && typeof toolChoice === "object" && "tool" in toolChoice) {
@@ -440,6 +457,17 @@ export const loopStepSchema: z.ZodType<unknown> = z.lazy(() => z.union([
   z.object({
     parallel: z.array(loopStepSchema).min(1),
     join: z.union([z.literal("all"), z.literal("any"), z.number().int().positive()]).optional(),
+    when: z.string().min(1).optional(),
+  }),
+  z.object({
+    while: z.object({
+      condition: z.string().min(1).optional(),
+      until: z.string().min(1).optional(),
+      maxIterations: z.number().int().positive().optional(),
+      steps: z.array(loopStepSchema).min(1),
+    }).refine((value) => !!value.condition || !!value.until, {
+      message: "while requires condition or until",
+    }),
     when: z.string().min(1).optional(),
   }),
   z.object({
@@ -490,6 +518,11 @@ function collectLoopStepRefs(step: unknown, refs: string[]): void {
       for (const child of branch.steps ?? []) collectLoopStepRefs(child, refs);
     }
     for (const child of switchStep.default?.steps ?? []) collectLoopStepRefs(child, refs);
+    return;
+  }
+  if (node.while && typeof node.while === "object") {
+    const whileStep = node.while as { steps?: unknown[] };
+    for (const child of whileStep.steps ?? []) collectLoopStepRefs(child, refs);
   }
 }
 

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -370,11 +370,11 @@ function validateLoopStep(step: unknown, ctx: ValidationContext, path: (string |
     return;
   }
 
-  const kinds = ["loop", "tool", "parallel", "switch", "human"].filter((kind) => kind in step);
+  const kinds = ["loop", "tool", "parallel", "switch", "while", "human"].filter((kind) => kind in step);
   if (kinds.length !== 1) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "step requires exactly one of loop, tool, parallel, switch, or human",
+      message: "step requires exactly one of loop, tool, parallel, switch, while, or human",
       path,
     });
     return;
@@ -442,6 +442,30 @@ function validateLoopStep(step: unknown, ctx: ValidationContext, path: (string |
     return;
   }
 
+  if ("while" in step) {
+    if (!isPlainObject(step.while)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "while must be an object", path: [...path, "while"] });
+      return;
+    }
+    if (step.while.condition !== undefined) validateNonEmptyString(step.while.condition, ctx, [...path, "while", "condition"], "condition");
+    if (step.while.until !== undefined) validateNonEmptyString(step.while.until, ctx, [...path, "while", "until"], "until");
+    if (step.while.condition === undefined && step.while.until === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "while requires condition or until", path: [...path, "while"] });
+    }
+    if (
+      step.while.maxIterations !== undefined
+      && !(typeof step.while.maxIterations === "number" && Number.isInteger(step.while.maxIterations) && step.while.maxIterations > 0)
+    ) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "maxIterations must be a positive integer", path: [...path, "while", "maxIterations"] });
+    }
+    if (!Array.isArray(step.while.steps) || step.while.steps.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "while.steps must contain at least one step", path: [...path, "while", "steps"] });
+    } else {
+      step.while.steps.forEach((child, index) => validateLoopStep(child, ctx, [...path, "while", "steps", index]));
+    }
+    return;
+  }
+
   validateNonEmptyString(step.human, ctx, [...path, "human"], "human");
   if (step.notify !== undefined && (!Array.isArray(step.notify) || step.notify.some((item) => typeof item !== "string" || item.trim() === ""))) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: "notify must be an array of non-empty strings", path: [...path, "notify"] });
@@ -476,6 +500,11 @@ function collectLoopRefs(step: unknown, refs: string[]): void {
       for (const child of branch.steps ?? []) collectLoopRefs(child, refs);
     }
     for (const child of switchStep.default?.steps ?? []) collectLoopRefs(child, refs);
+    return;
+  }
+  if (node.while && typeof node.while === "object") {
+    const whileStep = node.while as { steps?: unknown[] };
+    for (const child of whileStep.steps ?? []) collectLoopRefs(child, refs);
   }
 }
 

--- a/src/server/schemas.ts
+++ b/src/server/schemas.ts
@@ -295,11 +295,11 @@ function validateLoopStep(step: unknown, ctx: ValidationContext, path: (string |
     return;
   }
 
-  const kinds = ["loop", "tool", "parallel", "switch", "human"].filter((kind) => kind in step);
+  const kinds = ["loop", "tool", "parallel", "switch", "while", "human"].filter((kind) => kind in step);
   if (kinds.length !== 1) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "step requires exactly one of loop, tool, parallel, switch, or human",
+      message: "step requires exactly one of loop, tool, parallel, switch, while, or human",
       path,
     });
     return;
@@ -367,6 +367,30 @@ function validateLoopStep(step: unknown, ctx: ValidationContext, path: (string |
     return;
   }
 
+  if ("while" in step) {
+    if (!isPlainObject(step.while)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "while must be an object", path: [...path, "while"] });
+      return;
+    }
+    if (step.while.condition !== undefined) validateNonEmptyString(step.while.condition, ctx, [...path, "while", "condition"], "condition");
+    if (step.while.until !== undefined) validateNonEmptyString(step.while.until, ctx, [...path, "while", "until"], "until");
+    if (step.while.condition === undefined && step.while.until === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "while requires condition or until", path: [...path, "while"] });
+    }
+    if (
+      step.while.maxIterations !== undefined
+      && !(typeof step.while.maxIterations === "number" && Number.isInteger(step.while.maxIterations) && step.while.maxIterations > 0)
+    ) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "maxIterations must be a positive integer", path: [...path, "while", "maxIterations"] });
+    }
+    if (!Array.isArray(step.while.steps) || step.while.steps.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "while.steps must contain at least one step", path: [...path, "while", "steps"] });
+    } else {
+      step.while.steps.forEach((child, index) => validateLoopStep(child, ctx, [...path, "while", "steps", index]));
+    }
+    return;
+  }
+
   validateNonEmptyString(step.human, ctx, [...path, "human"], "human");
   if (step.notify !== undefined && (!Array.isArray(step.notify) || step.notify.some((item) => typeof item !== "string" || item.trim() === ""))) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: "notify must be an array of non-empty strings", path: [...path, "notify"] });
@@ -401,6 +425,11 @@ function collectLoopRefs(step: unknown, refs: string[]): void {
       for (const child of branch.steps ?? []) collectLoopRefs(child, refs);
     }
     for (const child of switchStep.default?.steps ?? []) collectLoopRefs(child, refs);
+    return;
+  }
+  if (node.while && typeof node.while === "object") {
+    const whileStep = node.while as { steps?: unknown[] };
+    for (const child of whileStep.steps ?? []) collectLoopRefs(child, refs);
   }
 }
 


### PR DESCRIPTION
## Summary
- add explicit project-level `type: "while"` loop steps
- normalize while steps into runtime pipeline blocks
- execute while blocks with condition/until guards and maxIterations safety
- expose while types/helpers through core, server schemas, and client SDK

## Tests
- `pnpm --filter @polpo-ai/core exec vitest run src/loop/pipeline.test.ts src/loop/contract.test.ts`
- `pnpm --filter @polpo-ai/core build`
- `pnpm --filter @polpo-ai/server build`