### PR TITLE
test: characterization suite for the task engine

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,209 @@
+# Polpo Task Benchmark Suite
+
+Runtime-agnostic, black-box benchmarks for Polpo's TASK execution path.
+The suite talks **only to public contracts**:
+
+1. the Polpo HTTP task API (`POST /tasks`, `GET /tasks/:id`, …), and
+2. a mock OpenAI-compatible LLM wired in via the standard `providers`
+   baseUrl override in `polpo.json`.
+
+Because nothing here imports runtime internals, the exact same suite runs
+against different runtime versions (old/new branch, local dist, a sandbox, a
+remote deployment) and the JSON results stay comparable over time. Pricing is
+a separate declarative layer (`pricing.json`) — measurements never encode
+costs.
+
+## Quick start
+
+```bash
+pnpm build                                        # dist/ must exist
+node bench/run.mjs --label baseline-main-runtime  # full local run
+node bench/run.mjs --only smoke,tool_loop_50      # subset
+node bench/compare.mjs bench/results/<a>.json bench/results/<b>.json
+```
+
+Local mode creates a throwaway project in a temp dir, starts the mock LLM
+(`:8377`) and a `PolpoServer` from `<repo>/dist` (`:8378`), runs every
+scenario, writes `bench/results/<ISO-ts>-<gitsha7>-<label>.json`, and tears
+everything down. Exit code is non-zero if any scenario fails.
+
+Against a running server (sandbox, other machine, other runtime):
+
+```bash
+node bench/mock-llm.mjs --port 8377 &   # somewhere the server's runtime can reach
+node bench/run.mjs --target http://host:3890 --mock-url http://mock-host:8377 --label candidate
+```
+
+In target mode the target project must already contain the provider override
+(see below) pointing at the mock, and `POLPO_API_KEY` is honored if the target
+requires auth.
+
+## How it works
+
+### The BENCH directive
+
+Every task description embeds a directive that fully scripts the mock model:
+
+```
+[BENCH sid=<id> turns=N toolsPerTurn=K latencyMs=L toolOutputBytes=B finalBytes=F outcomes=O cap=normal|never]
+```
+
+- `turns=N` → N **tool turns** (each with `K` parallel `bash` calls producing
+  `B` bytes of output), then a final text response of `F` bytes on turn N+1.
+- `outcomes=O` → O `register_outcome` calls on the last tool turn.
+- `cap=never` → the model never stops calling tools (tests `maxTurns` /
+  `maxDuration` ceilings).
+- `latencyMs=L` → artificial model think-time per request, so `llm_ms` is
+  known exactly and `overhead_ms = wall_ms − llm_ms` is meaningful.
+
+The mock is stateless per request: the current turn is recovered from the
+conversation history itself (bench tool-call ids encode `sid` + turn, and the
+runtime echoes them back). Per-`sid` stats (requests, turns, artificial
+latency applied, tool calls emitted) are exposed at `GET /bench/stats/<sid>`;
+`POST /bench/reset` clears them.
+
+The mock speaks **both** wire protocols behind a `baseUrl` override:
+
+- `POST <base>/responses` — OpenAI Responses API. This is what the current
+  runtime actually uses: `createOpenAI()(modelId)` from `@ai-sdk/openai` v3
+  defaults to the Responses protocol, *not* Chat Completions.
+- `POST <base>/chat/completions` — OpenAI Chat Completions (streaming SSE and
+  non-streaming), for runtimes using `.chat()` / `openai-compatible`.
+
+Tool-less requests (the engine's context-compaction `generateText` calls) get
+a text "summary" that re-embeds the directive, so scripted sessions survive
+history compaction.
+
+### Metrics
+
+| metric        | meaning                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| `wall_ms`     | `POST /tasks` → terminal status observed (100ms polling)             |
+| `spawn_ms`    | `POST /tasks` → first status past `pending` (orchestrator tick + runner boot) |
+| `llm_ms`      | Σ artificial model latency actually served (from mock stats)          |
+| `overhead_ms` | `wall_ms − llm_ms` — everything that isn't the model: ticks, spawn, tool exec, harness |
+| `loop_ms`     | first → last LLM request seen by the mock — the agent loop itself, free of tick quantization |
+| `loop_overhead_ms` | `loop_ms − llm_ms` — per-loop harness cost (tool exec + engine bookkeeping) |
+| `makespan_ms` | concurrency scenarios: first POST → last task terminal               |
+
+### Scenarios
+
+| name             | what it stresses                                                   |
+| ---------------- | ------------------------------------------------------------------ |
+| `smoke`          | spawn + 1 LLM round-trip, no tools                                 |
+| `tool_loop_50`   | 50 sequential tool turns × 1 bash                                  |
+| `tool_burst`     | 10 turns × 5 bash/turn (parallel tool dispatch within a turn)      |
+| `big_output`     | 30 turns × 64KB tool output (context growth / compaction)          |
+| `max_turns_cap`  | `cap=never` vs agent `maxTurns: 15` — loop ceiling                 |
+| `outcomes_3`     | `register_outcome` pipeline → `task.outcomes`                      |
+| `timeout_kill`   | `cap=never` + `maxDuration: 8s` — watchdog kill → terminal `failed`|
+| `concurrency_10` | 10 concurrent 5-turn tasks — fan-out + makespan                    |
+
+Add a scenario by appending one object to `bench/scenarios.mjs` (directive
+params + declarative invariants — terminal status, turns served by the mock,
+tool calls emitted, outcomes on the task record).
+
+## Baseline results (current runtime, v0.10.x)
+
+All 8 scenarios pass. Headline numbers from the committed baseline run
+(`bench/results/…-baseline-main-runtime.json`, run-to-run variance ~±1%):
+
+| scenario       | wall_ms | spawn_ms | llm_ms | overhead_ms | loop_ms |
+| -------------- | ------- | -------- | ------ | ----------- | ------- |
+| smoke          | 10066   | 4997     | 50     | 10016       | 0       |
+| tool_loop_50   | 10036   | 4968     | 2550   | 7486        | 3058    |
+| tool_burst     | 9939    | 4976     | 550    | 9389        | 784     |
+| big_output     | 10035   | 5070     | 1550   | 8485        | 1926    |
+| max_turns_cap  | 10035   | 4969     | 750    | 9285        | 876     |
+| outcomes_3     | 10031   | 4966     | 300    | 9731        | 339     |
+| timeout_kill   | 19967   | 4971     | 9600   | 10367       | 9636    |
+| concurrency_10 | 10109 (makespan) | 5055 | 3000 | —      | —       |
+
+What the numbers say:
+
+- **Every task pays ~2 orchestrator ticks (~10s wall) of fixed overhead.**
+  The supervisor loop polls at 5s (`POLL_INTERVAL`); spawn happens on the
+  first tick (`spawn_ms ≈ 5s`), result collection on a later tick. A 51-turn
+  tool loop and a 1-turn smoke test both wall at ~10s — the loop itself is
+  fast; tick quantization dominates.
+- `loop_ms` (tick-free) isolates the engine loop: 51 turns with 50ms think
+  time each = 3058ms, i.e. **~10ms harness overhead per turn** (streamText +
+  tool exec + transcript). Bursts of 5 tools/turn: ~23ms/turn.
+- `big_output` crosses the compaction trigger: the prune stage fired
+  (observed: 168K → 48K estimated tokens, 16 tool outputs pruned) with no
+  measurable wall impact, and the LLM-summarize stage was never needed.
+- `timeout_kill` walls ~20s for an 8s `maxDuration`: the kill fires on the
+  tick after the deadline and the failure is collected on a later tick.
+- `concurrency_10`: all 10 tasks spawn on the same tick and run genuinely in
+  parallel — makespan ≈ single-task wall (~10s).
+
+## Runtime findings (empirical, useful for the loop refactor)
+
+Discovered while building this suite against the current dist runtime:
+
+1. **Custom providers can't spawn task agents.** Pre-spawn validation
+   (`validateProviderKeys`) only accepts providers present in the static
+   `PROVIDER_ENV_MAP`; a provider named e.g. `bench` (or `ollama`, `vllm`)
+   fails with "Missing API key" even when `providers.<name>.baseUrl` is set in
+   `polpo.json`. Workaround used here: name the provider `openai` with a
+   `baseUrl` override + dummy `OPENAI_API_KEY`.
+2. **Provider overrides don't reach the task runner subprocess.** The
+   orchestrator applies `providers` from `polpo.json` via
+   `setProviderOverrides()` in-process only; `RunnerConfig` carries no
+   `providers` (and no `gatewayConfig`), and `dist/core/runner.js` never reads
+   `polpo.json`. Chat completions (in-process) honor overrides; task agents do
+   not. The harness bridges this with `NODE_OPTIONS=--import
+   bench/lib/preload-providers.mjs`, which replays the same overrides inside
+   every spawned Node process (a no-op on a runtime that propagates them
+   properly).
+3. **The default provider protocol is the Responses API.** `@ai-sdk/openai` v3
+   `createOpenAI(...)(modelId)` returns a Responses-protocol model. Any
+   OpenAI-compatible endpoint used via `providers.*.baseUrl` must implement
+   `/responses`, not just `/chat/completions`.
+4. **The API rate limiter keys on `x-forwarded-for`** (200 req/60s, in-memory,
+   trusts the client header). Local mode rotates synthetic XFF buckets to
+   poll at 100ms; target mode polls at 300ms and uses one shared `GET /tasks`
+   poll for concurrency scenarios.
+5. **`maxTurns` cap is a silent success.** A loop stopped by `maxTurns`
+   returns exit code 0 and the task lands in `done` (empty result text) — not
+   `failed`. The `max_turns_cap` invariant accepts `done|failed` and asserts
+   the mock served exactly `maxTurns` turns.
+6. **Retries default on.** `settings.maxRetries` (default 2–3) silently
+   re-runs failed tasks; the bench project sets `maxRetries: 0` so failure
+   scenarios (`timeout_kill`) reach a terminal state deterministically.
+7. **Bash output is truncated to the last 30KB** (`MAX_OUTPUT_BYTES`), so a
+   64KB tool output contributes ~30KB to context. Combined with the prune
+   stage of compaction (drop old tool outputs before LLM-summarizing), the
+   LLM-summarize compaction path is effectively unreachable through bash-only
+   loops — prune alone reclaims to target. The mock still handles tool-less
+   summarize requests (and re-embeds the directive) in case another runtime
+   reaches that path.
+8. **`agents.json` on disk is not a bare `AgentConfig[]`** — the file store
+   format is `[{ "agent": {...}, "teamName": "..." }]`.
+
+## Pricing layer
+
+`pricing.json` holds per-provider sandbox rates (official pricing pages, July
+2026) and the reference sandbox size (2 vCPU / 4 GiB). `compare.mjs` projects
+two execution models from any result file:
+
+- **Model A — sandbox-alive-per-task**: the sandbox is billed for the entire
+  task `wall_ms` (today's runner-in-sandbox architecture).
+- **Model B — ProxyTool**: the LLM loop runs in the server; the sandbox is
+  billed only for `overhead_ms` (tool/harness time). LLM think-time costs
+  nothing sandbox-side.
+
+Vercel is modeled per its billing semantics: active-CPU on harness time only
+(LLM wait is I/O), memory on alive time, 60s minimum bill.
+
+## Philosophy
+
+- **Runtime-agnostic**: only public HTTP contracts; no imports from `src/` or
+  `packages/`. If a runtime changes internals but keeps the contracts, the
+  suite runs unchanged and the numbers are comparable.
+- **Deterministic model**: known think-time and scripted turns make overhead
+  computable instead of estimated.
+- **Results are committed**: `bench/results/*.json` is the longitudinal
+  record. Label runs meaningfully (`--label baseline-main-runtime`,
+  `--label task-loop-v2`, …).
+- **Prices are data, not code**: update `pricing.json`, never the harness.

--- a/bench/compare.mjs
+++ b/bench/compare.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * bench/compare.mjs — diff two benchmark result files + project sandbox costs.
+ *
+ * Usage:
+ *   node bench/compare.mjs bench/results/<a>.json bench/results/<b>.json
+ *
+ * Prints:
+ *   1. Per-scenario deltas (wall, overhead, loop) — A → B, absolute and %.
+ *   2. Cost projections from bench/pricing.json under two execution models:
+ *        A) sandbox-alive-per-task — the sandbox is billed for the FULL task
+ *           wall time (today's runner-in-sandbox model).
+ *        B) ProxyTool — the LLM loop lives in the server; the sandbox is only
+ *           billed for the tool/harness part (overhead_ms, i.e. wall − llm).
+ *      Projected at 1k / 10k / 100k tasks per month, per provider.
+ *
+ * Pricing is a declarative layer (bench/pricing.json) — edit rates there.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BENCH_DIR = dirname(fileURLToPath(import.meta.url));
+
+// ─── Load inputs ──────────────────────────────────────────────────────────────
+
+const [fileA, fileB] = process.argv.slice(2);
+if (!fileA || !fileB) {
+  console.error("Usage: node bench/compare.mjs <a.json> <b.json>");
+  process.exit(1);
+}
+
+const load = (p) => JSON.parse(readFileSync(p, "utf-8"));
+const a = load(fileA);
+const b = load(fileB);
+const pricing = load(join(BENCH_DIR, "pricing.json"));
+
+const label = (r) => `${r.meta.label} (${r.meta.sha}, ${r.meta.ts})`;
+console.log(`\nA: ${label(a)}`);
+console.log(`B: ${label(b)}\n`);
+
+// ─── Per-scenario deltas ──────────────────────────────────────────────────────
+
+const byName = (run) => new Map(run.scenarios.map((s) => [s.name, s]));
+const mapA = byName(a);
+const mapB = byName(b);
+const common = [...mapA.keys()].filter((n) => mapB.has(n));
+
+function metric(s, key) {
+  const v = s?.metrics?.[key];
+  return typeof v === "number" ? v : null;
+}
+
+function delta(va, vb) {
+  if (va === null || vb === null) return "-";
+  const d = vb - va;
+  const pct = va !== 0 ? ` (${d >= 0 ? "+" : ""}${((d / va) * 100).toFixed(1)}%)` : "";
+  return `${d >= 0 ? "+" : ""}${Math.round(d)}ms${pct}`;
+}
+
+const fmtMs = (v) => (v === null ? "-" : `${Math.round(v)}`);
+
+const cols = ["scenario", "wall A", "wall B", "Δ wall", "ovh A", "ovh B", "Δ ovh", "loop A", "loop B", "Δ loop", "pass"];
+const rows = [];
+for (const name of common) {
+  const sa = mapA.get(name);
+  const sb = mapB.get(name);
+  const wallA = metric(sa, "wall_ms") ?? metric(sa, "makespan_ms");
+  const wallB = metric(sb, "wall_ms") ?? metric(sb, "makespan_ms");
+  const ovhA = metric(sa, "overhead_ms");
+  const ovhB = metric(sb, "overhead_ms");
+  const loopA = metric(sa, "loop_ms");
+  const loopB = metric(sb, "loop_ms");
+  rows.push([
+    name,
+    fmtMs(wallA),
+    fmtMs(wallB),
+    delta(wallA, wallB),
+    fmtMs(ovhA),
+    fmtMs(ovhB),
+    delta(ovhA, ovhB),
+    fmtMs(loopA),
+    fmtMs(loopB),
+    delta(loopA, loopB),
+    `${sa.pass ? "A✓" : "A✗"}${sb.pass ? "B✓" : "B✗"}`,
+  ]);
+}
+const widths = cols.map((c, i) => Math.max(c.length, ...rows.map((r) => String(r[i]).length)));
+const line = (cells) => "  " + cells.map((c, i) => String(c).padEnd(widths[i])).join("  ");
+console.log(line(cols));
+console.log("  " + widths.map((w) => "-".repeat(w)).join("  "));
+for (const r of rows) console.log(line(r));
+
+const missing = [...mapB.keys()].filter((n) => !mapA.has(n));
+if (missing.length) console.log(`\n  (only in B: ${missing.join(", ")})`);
+
+// ─── Cost projections ─────────────────────────────────────────────────────────
+//
+// Uses run B's numbers (the "candidate" runtime). Mean across the comparable
+// single-task scenarios that passed in B (concurrency/makespan excluded —
+// it measures fan-out, not per-task cost).
+
+const costScenarios = b.scenarios.filter(
+  (s) => !s.concurrency && typeof s.metrics?.wall_ms === "number" && typeof s.metrics?.overhead_ms === "number",
+);
+if (costScenarios.length === 0) {
+  console.log("\nNo cost-comparable scenarios in B — skipping cost projection.");
+  process.exit(0);
+}
+
+const mean = (arr) => arr.reduce((x, y) => x + y, 0) / arr.length;
+const meanWallMs = mean(costScenarios.map((s) => s.metrics.wall_ms));
+const meanOverheadMs = mean(costScenarios.map((s) => s.metrics.overhead_ms));
+
+const { vcpu, ramGib } = pricing.referenceSandbox;
+
+/** $ for one task billed `billedMs` on a full sandbox (cpu+ram always on). */
+function fullSandboxCost(p, billedMs) {
+  const seconds = p.granularity === "second" ? Math.ceil(billedMs / 1000) : billedMs / 1000;
+  const hourly = vcpu * p.vcpuHour + ramGib * p.ramGibHour;
+  return (seconds / 3600) * hourly;
+}
+
+/** $ for one task on Vercel-style billing: active CPU + provisioned memory. */
+function vercelCost(p, activeMs, aliveMs) {
+  const billedAliveMs = Math.max(aliveMs, p.minBillMs ?? 0);
+  const cpuCost = (activeMs / 3600_000) * p.activeCpuHour; // 1 vCPU active during harness work
+  const memCost = (billedAliveMs / 3600_000) * ramGib * p.memGbHour;
+  return cpuCost + memCost;
+}
+
+function perTaskCost(providerName, p, model) {
+  // Model A: sandbox alive for the whole task (billed on wall).
+  // Model B: ProxyTool — sandbox only does tool/harness work (billed on overhead).
+  const billedMs = model === "A" ? meanWallMs : meanOverheadMs;
+  if (providerName === "vercel") {
+    const activeMs = meanOverheadMs; // LLM wait is I/O — never CPU-active
+    return vercelCost(p, activeMs, billedMs);
+  }
+  return fullSandboxCost(p, billedMs);
+}
+
+const volumes = [1_000, 10_000, 100_000];
+console.log(
+  `\nCost projection (run B, mean over ${costScenarios.length} scenarios: wall=${Math.round(meanWallMs)}ms, overhead=${Math.round(meanOverheadMs)}ms, sandbox ${vcpu}vCPU/${ramGib}GiB):`,
+);
+console.log("  Model A = sandbox-alive-per-task (billed on wall) | Model B = ProxyTool (billed on overhead only)\n");
+
+const cCols = ["provider", "model", "$/task", ...volumes.map((v) => `$/mo @${v / 1000}k`)];
+const cRows = [];
+for (const [name, p] of Object.entries(pricing.providers)) {
+  for (const model of ["A", "B"]) {
+    const per = perTaskCost(name, p, model);
+    const monthly = volumes.map((v) => {
+      let m = per * v;
+      if (p.monthlyFloor) m = Math.max(m, p.monthlyFloor);
+      return `$${m.toFixed(m < 100 ? 2 : 0)}`;
+    });
+    cRows.push([name, model, `$${per.toFixed(6)}`, ...monthly]);
+  }
+}
+const cWidths = cCols.map((c, i) => Math.max(c.length, ...cRows.map((r) => String(r[i]).length)));
+const cLine = (cells) => "  " + cells.map((c, i) => String(c).padEnd(cWidths[i])).join("  ");
+console.log(cLine(cCols));
+console.log("  " + cWidths.map((w) => "-".repeat(w)).join("  "));
+for (const r of cRows) console.log(cLine(r));
+if (pricing.providers.e2b?.monthlyFloor) {
+  console.log(`\n  note: e2b monthly totals floored at $${pricing.providers.e2b.monthlyFloor}/mo (plan minimum).`);
+}
+console.log();

--- a/bench/lib/client.mjs
+++ b/bench/lib/client.mjs
@@ -1,0 +1,213 @@
+/**
+ * bench/lib/client.mjs — thin HTTP client for the public Polpo task API.
+ *
+ * Speaks only the public REST contract. The API prefix is probed at runtime
+ * ("/api/v1" on the current OSS server, "/v1" tolerated for other builds) so
+ * the same suite runs unchanged against different runtimes/deployments.
+ */
+
+const TERMINAL_STATUSES = new Set(["done", "failed"]);
+const ACTIVE_PRE_SPAWN = new Set(["pending", "draft", "awaiting_approval"]);
+
+export class PolpoClient {
+  /**
+   * @param {string} baseUrl
+   * @param {{ apiKey?: string, xffRotate?: boolean }} opts
+   *   xffRotate — the OSS server rate-limits 200 req/60s keyed on the
+   *   x-forwarded-for header. When benchmarking a LOCAL server we rotate a
+   *   synthetic XFF bucket every 150 requests so high-frequency polling
+   *   doesn't 429. Disabled in --target mode (a real proxy overwrites XFF);
+   *   there the poll interval + shared list polling keep us under the limit.
+   */
+  constructor(baseUrl, { apiKey, xffRotate = false } = {}) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.prefix = null;
+    this.headers = { "content-type": "application/json" };
+    if (apiKey) this.headers.authorization = `Bearer ${apiKey}`;
+    this.xffRotate = xffRotate;
+    this.requestCount = 0;
+  }
+
+  currentHeaders() {
+    if (!this.xffRotate) return this.headers;
+    const bucket = Math.floor(this.requestCount / 150);
+    return { ...this.headers, "x-forwarded-for": `10.99.${Math.floor(bucket / 250)}.${bucket % 250 + 1}` };
+  }
+
+  /** Find the live API prefix by probing the health endpoint. */
+  async probe({ timeoutMs = 30_000 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    const prefixes = ["/api/v1", "/v1"];
+    let lastErr;
+    while (Date.now() < deadline) {
+      for (const prefix of prefixes) {
+        try {
+          const res = await fetch(`${this.baseUrl}${prefix}/health`, { headers: this.headers });
+          if (res.ok) {
+            this.prefix = prefix;
+            return prefix;
+          }
+          lastErr = new Error(`${prefix}/health → HTTP ${res.status}`);
+        } catch (err) {
+          lastErr = err;
+        }
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    throw new Error(`Polpo API not reachable at ${this.baseUrl}: ${lastErr?.message}`);
+  }
+
+  async request(method, path, body) {
+    this.requestCount++;
+    const res = await fetch(`${this.baseUrl}${this.prefix}${path}`, {
+      method,
+      headers: this.currentHeaders(),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    let json;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      throw new Error(`${method} ${path} → HTTP ${res.status}: ${text.slice(0, 300)}`);
+    }
+    if (!res.ok || json.ok === false) {
+      throw new Error(`${method} ${path} → HTTP ${res.status}: ${JSON.stringify(json).slice(0, 300)}`);
+    }
+    return json.data ?? json;
+  }
+
+  createTask(opts) {
+    return this.request("POST", "/tasks", opts);
+  }
+
+  listTasks() {
+    return this.request("GET", "/tasks");
+  }
+
+  getTask(taskId) {
+    return this.request("GET", `/tasks/${taskId}`);
+  }
+
+  deleteTask(taskId) {
+    return this.request("DELETE", `/tasks/${taskId}`).catch(() => {});
+  }
+
+  killTask(taskId) {
+    return this.request("POST", `/tasks/${taskId}/kill`).catch(() => {});
+  }
+
+  /**
+   * Poll a task to a terminal state.
+   * Returns { task, wallMs, spawnMs, timeline, timedOut }.
+   *   wallMs  — createdAtMs → terminal state observed
+   *   spawnMs — createdAtMs → first observed state past "pending"
+   */
+  async pollTask(taskId, createdAtMs, { timeoutMs = 120_000, intervalMs = 100 } = {}) {
+    const timeline = [];
+    let lastStatus = null;
+    let spawnMs = null;
+    const deadline = createdAtMs + timeoutMs;
+
+    for (;;) {
+      const task = await this.getTask(taskId);
+      const now = Date.now();
+      if (task.status !== lastStatus) {
+        timeline.push({ status: task.status, tMs: now - createdAtMs });
+        lastStatus = task.status;
+      }
+      if (spawnMs === null && !ACTIVE_PRE_SPAWN.has(task.status)) {
+        spawnMs = now - createdAtMs;
+      }
+      if (TERMINAL_STATUSES.has(task.status)) {
+        return { task, wallMs: now - createdAtMs, spawnMs, timeline, timedOut: false };
+      }
+      if (now > deadline) {
+        return { task, wallMs: now - createdAtMs, spawnMs, timeline, timedOut: true };
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+
+  /**
+   * Poll MANY tasks with a single shared GET /tasks loop (one request per
+   * interval regardless of task count — keeps concurrency scenarios inside
+   * the server's rate limit). Same result shape as pollTask, per task.
+   */
+  async pollMany(entries, { timeoutMs = 300_000, intervalMs = 200 } = {}) {
+    const state = new Map(
+      entries.map((e) => [
+        e.taskId,
+        { createdAtMs: e.createdAtMs, timeline: [], lastStatus: null, spawnMs: null, result: null },
+      ]),
+    );
+    const startMs = Math.min(...entries.map((e) => e.createdAtMs));
+    const deadline = startMs + timeoutMs;
+
+    while ([...state.values()].some((s) => s.result === null)) {
+      const now = Date.now();
+      const tasks = await this.listTasks();
+      const byId = new Map(tasks.map((t) => [t.id, t]));
+      for (const [taskId, s] of state) {
+        if (s.result) continue;
+        const task = byId.get(taskId);
+        if (!task) continue;
+        if (task.status !== s.lastStatus) {
+          s.timeline.push({ status: task.status, tMs: now - s.createdAtMs });
+          s.lastStatus = task.status;
+        }
+        if (s.spawnMs === null && !ACTIVE_PRE_SPAWN.has(task.status)) {
+          s.spawnMs = now - s.createdAtMs;
+        }
+        if (TERMINAL_STATUSES.has(task.status)) {
+          s.result = { task, wallMs: now - s.createdAtMs, spawnMs: s.spawnMs, timeline: s.timeline, timedOut: false };
+        }
+      }
+      if (Date.now() > deadline) {
+        for (const [taskId, s] of state) {
+          if (s.result) continue;
+          const task = byId.get(taskId) ?? { id: taskId, status: "unknown" };
+          s.result = { task, wallMs: Date.now() - s.createdAtMs, spawnMs: s.spawnMs, timeline: s.timeline, timedOut: true };
+        }
+        break;
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    return entries.map((e) => state.get(e.taskId).result);
+  }
+}
+
+export class MockClient {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+  }
+
+  async health({ timeoutMs = 10_000 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(`${this.baseUrl}/bench/health`);
+        if (res.ok) return true;
+      } catch {
+        /* not up yet */
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(`mock LLM not reachable at ${this.baseUrl}`);
+  }
+
+  async stats(sid) {
+    const res = await fetch(`${this.baseUrl}/bench/stats/${sid}`);
+    if (!res.ok) return null;
+    return res.json();
+  }
+
+  async reset() {
+    await fetch(`${this.baseUrl}/bench/reset`, { method: "POST" }).catch(() => {});
+  }
+
+  async debug() {
+    const res = await fetch(`${this.baseUrl}/bench/debug`);
+    return res.ok ? res.json() : [];
+  }
+}

--- a/bench/lib/directive.mjs
+++ b/bench/lib/directive.mjs
@@ -1,0 +1,98 @@
+/**
+ * BENCH directive — the contract between the benchmark runner and the mock LLM.
+ *
+ * A directive is embedded in the first user message of a task (i.e. the task
+ * description). The mock LLM parses it and scripts its behavior from it, so
+ * the benchmark never depends on runtime internals — only on the fact that
+ * the task description reaches the model.
+ *
+ * Format:
+ *   [BENCH sid=<id> turns=N toolsPerTurn=K latencyMs=L toolOutputBytes=B finalBytes=F outcomes=O cap=normal|never]
+ *
+ * Semantics:
+ *   sid             session id (alphanumeric, no underscores) — keys mock-side stats
+ *   turns           number of TOOL turns. The mock emits tool calls for turns
+ *                   1..N and a final text response on turn N+1.
+ *                   turns=0 → immediate final response (no tools).
+ *   toolsPerTurn    bash tool calls emitted per tool turn
+ *   latencyMs       artificial model "think time" applied before every response
+ *   toolOutputBytes size of the output each bash command produces
+ *   finalBytes      size of the final assistant text
+ *   outcomes        register_outcome tool calls emitted on the LAST tool turn
+ *   cap             "never" → never emit a final response (always tool calls);
+ *                   used to test maxTurns/timeout ceilings
+ */
+
+const DIRECTIVE_RE = /\[BENCH\s+([^\]]+)\]/;
+
+export const DIRECTIVE_DEFAULTS = {
+  turns: 0,
+  toolsPerTurn: 1,
+  latencyMs: 50,
+  toolOutputBytes: 256,
+  finalBytes: 200,
+  outcomes: 0,
+  cap: "normal",
+};
+
+/** Build a directive string from params. */
+export function buildDirective(sid, params) {
+  const p = { ...DIRECTIVE_DEFAULTS, ...params };
+  return (
+    `[BENCH sid=${sid} turns=${p.turns} toolsPerTurn=${p.toolsPerTurn} ` +
+    `latencyMs=${p.latencyMs} toolOutputBytes=${p.toolOutputBytes} ` +
+    `finalBytes=${p.finalBytes} outcomes=${p.outcomes} cap=${p.cap}]`
+  );
+}
+
+/** Parse the first BENCH directive found in a text blob. Returns null if absent. */
+export function parseDirective(text) {
+  if (typeof text !== "string") return null;
+  const m = DIRECTIVE_RE.exec(text);
+  if (!m) return null;
+  const params = { ...DIRECTIVE_DEFAULTS };
+  let sid = null;
+  for (const pair of m[1].trim().split(/\s+/)) {
+    const eq = pair.indexOf("=");
+    if (eq < 0) continue;
+    const key = pair.slice(0, eq);
+    const value = pair.slice(eq + 1);
+    if (key === "sid") sid = value;
+    else if (key === "cap") params.cap = value === "never" ? "never" : "normal";
+    else if (key in params) params[key] = Number(value);
+  }
+  if (!sid) return null;
+  return { sid, ...params };
+}
+
+/** Generate a session id — lowercase alphanumeric, no underscores (call-id safe). */
+export function genSid() {
+  return (
+    "s" +
+    Date.now().toString(36) +
+    Math.random().toString(36).slice(2, 8)
+  ).toLowerCase();
+}
+
+/**
+ * Tool call ids encode sid + turn so the mock can recover its position
+ * statelessly from the conversation history the runtime echoes back:
+ *   call_<sid>_t<turn>_<index>
+ */
+export function buildCallId(sid, turn, index) {
+  return `call_${sid}_t${turn}_${index}`;
+}
+
+const CALL_ID_RE = /call_([a-z0-9]+)_t(\d+)_(\d+)/g;
+
+/** Extract {sid, maxTurn} from any text containing bench call ids. */
+export function scanCallIds(text) {
+  let sid = null;
+  let maxTurn = 0;
+  for (const m of text.matchAll(CALL_ID_RE)) {
+    sid = m[1];
+    const turn = Number(m[2]);
+    if (turn > maxTurn) maxTurn = turn;
+  }
+  return sid ? { sid, maxTurn } : null;
+}

--- a/bench/lib/preload-providers.mjs
+++ b/bench/lib/preload-providers.mjs
@@ -1,0 +1,37 @@
+/**
+ * bench/lib/preload-providers.mjs — provider-override glue for task runner subprocesses.
+ *
+ * WHY THIS EXISTS (verified on the current runtime, v0.10.x dist build):
+ * `providers` overrides from `.polpo/polpo.json` are applied via
+ * `setProviderOverrides()` **in the orchestrator process only**. The task
+ * runner is a detached Node subprocess (dist/core/runner.js) that never reads
+ * polpo.json and never receives the overrides (RunnerConfig has no
+ * `providers` field, SpawnContext has no `gatewayConfig`). Without this glue,
+ * an agent with model "bench/mock-1" fails inside the runner with
+ * "No LLM gateway configured and no API key found for provider bench".
+ *
+ * The benchmark harness injects this file into every spawned Node process via
+ * `NODE_OPTIONS="--import <this file>"`, replaying the same overrides that
+ * polpo.json declares (passed as JSON in POLPO_BENCH_PROVIDERS). On a runtime
+ * that propagates providers correctly this is a harmless no-op re-set of the
+ * same values — the benchmark itself stays black-box.
+ *
+ * POLPO_BENCH_LLM_DIST must point at the runtime's llm entry (the module
+ * instance the engine actually imports), e.g. <repo>/dist/llm/pi-client.js.
+ */
+
+const providersJson = process.env.POLPO_BENCH_PROVIDERS;
+const llmModulePath = process.env.POLPO_BENCH_LLM_DIST;
+
+if (providersJson && llmModulePath) {
+  try {
+    const { pathToFileURL } = await import("node:url");
+    const mod = await import(pathToFileURL(llmModulePath).href);
+    if (typeof mod.setProviderOverrides === "function") {
+      mod.setProviderOverrides(JSON.parse(providersJson));
+    }
+  } catch {
+    // Best-effort: if the module moved (different runtime), stay silent —
+    // the run will fail loudly on its own and the README explains this knob.
+  }
+}

--- a/bench/mock-llm.mjs
+++ b/bench/mock-llm.mjs
@@ -1,0 +1,569 @@
+#!/usr/bin/env node
+/**
+ * bench/mock-llm.mjs — OpenAI-compatible mock LLM server for Polpo benchmarks.
+ *
+ * Speaks BOTH wire protocols the AI SDK can use against a custom baseUrl:
+ *   - POST <base>/responses         (OpenAI Responses API — used by @ai-sdk/openai v3,
+ *                                    which is what Polpo's provider override resolves to)
+ *   - POST <base>/chat/completions  (OpenAI Chat Completions — for runtimes that use
+ *                                    .chat() / openai-compatible providers)
+ * Both support stream:true (SSE) and stream:false (JSON).
+ *
+ * Behavior is 100% scripted by a [BENCH ...] directive embedded in the first
+ * user message (see lib/directive.mjs). The server is stateless per request:
+ * the current turn is derived from the conversation history itself (bench
+ * call ids encode sid+turn). A small in-memory registry keeps per-sid stats
+ * and the directive params so sessions survive history compaction.
+ *
+ * Introspection:
+ *   GET  /bench/stats/<sid>  → per-session stats (requests, turns, llmBusyMs, ...)
+ *   GET  /bench/stats        → all sessions
+ *   GET  /bench/debug        → ring buffer of recent request summaries
+ *   POST /bench/reset        → clear registry + stats
+ *   GET  /bench/health       → { ok: true }
+ *
+ * Zero npm dependencies — Node stdlib only.
+ */
+
+import { createServer } from "node:http";
+import {
+  DIRECTIVE_DEFAULTS,
+  parseDirective,
+  buildCallId,
+  scanCallIds,
+} from "./lib/directive.mjs";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ─── Session registry ────────────────────────────────────────────────────────
+
+function newStats() {
+  return {
+    requests: 0,
+    streamRequests: 0,
+    jsonRequests: 0,
+    byEndpoint: { responses: 0, chat: 0 },
+    turnsServed: 0, // highest tool-loop turn answered
+    finals: 0, // final (stop) responses served
+    summarizeCalls: 0, // tool-less requests (context compaction etc.)
+    toolCallsEmitted: 0,
+    outcomeCallsEmitted: 0,
+    llmBusyMs: 0, // sum of artificial latency applied
+    firstRequestAt: null,
+    lastRequestAt: null,
+  };
+}
+
+export function createMockLlm({ port = 8377, host = "127.0.0.1", quiet = true } = {}) {
+  /** sid → { params, stats } */
+  const sessions = new Map();
+  /** ring buffer of request summaries for debugging */
+  const debugLog = [];
+  const pushDebug = (entry) => {
+    debugLog.push(entry);
+    if (debugLog.length > 50) debugLog.shift();
+  };
+
+  const getSession = (sid, params) => {
+    let s = sessions.get(sid);
+    if (!s) {
+      s = { params: params ?? { ...DIRECTIVE_DEFAULTS }, stats: newStats() };
+      sessions.set(sid, s);
+    } else if (params) {
+      s.params = params; // refresh — directive re-seen
+    }
+    return s;
+  };
+
+  // ── Request text extraction (both protocols) ──────────────────────────────
+
+  /** Collect all human-readable text from a request body (to find the directive). */
+  function extractText(body) {
+    const chunks = [];
+    if (typeof body.instructions === "string") chunks.push(body.instructions);
+    if (typeof body.system === "string") chunks.push(body.system);
+    const items = Array.isArray(body.input)
+      ? body.input
+      : Array.isArray(body.messages)
+        ? body.messages
+        : [];
+    if (typeof body.input === "string") chunks.push(body.input);
+    for (const item of items) {
+      if (typeof item?.content === "string") chunks.push(item.content);
+      else if (Array.isArray(item?.content)) {
+        for (const part of item.content) {
+          if (typeof part?.text === "string") chunks.push(part.text);
+          if (typeof part?.input_text === "string") chunks.push(part.input_text);
+        }
+      }
+      if (typeof item?.text === "string") chunks.push(item.text);
+    }
+    return chunks.join("\n");
+  }
+
+  /** Does the request carry tools? (tool-less ⇒ summarize/utility call) */
+  function hasTools(body) {
+    return Array.isArray(body.tools) && body.tools.length > 0;
+  }
+
+  /**
+   * Current turn = max turn already answered (from bench call ids echoed in
+   * history) + 1. Call ids live in call_id / tool_call_id fields, so we scan
+   * the RAW request JSON, not just the text parts. Works identically for both
+   * protocols and survives compaction as long as the previous turn's calls
+   * are still in context. Falls back to counting assistant messages (chat).
+   */
+  function computeTurn(body, rawJson) {
+    const scanned = scanCallIds(rawJson);
+    let turn = scanned ? scanned.maxTurn + 1 : 1;
+    if (Array.isArray(body.messages)) {
+      const assistantCount = body.messages.filter((m) => m?.role === "assistant").length;
+      turn = Math.max(turn, assistantCount + 1);
+    }
+    return turn;
+  }
+
+  // ── Behavior: decide what this response contains ──────────────────────────
+
+  /**
+   * Returns { kind: "tools", calls: [{id, name, args}] } or
+   *         { kind: "text", text }
+   */
+  function decide(sid, params, turn) {
+    const toolTurns = params.cap === "never" ? Infinity : params.turns;
+    if (turn <= toolTurns) {
+      const calls = [];
+      for (let i = 0; i < params.toolsPerTurn; i++) {
+        calls.push({
+          id: buildCallId(sid, turn, i),
+          name: "bash",
+          args: JSON.stringify({
+            command: `head -c ${params.toolOutputBytes} /dev/zero | tr '\\0' 'x'`,
+            timeout: 30000,
+          }),
+        });
+      }
+      // Outcomes are emitted on the LAST tool turn
+      if (params.outcomes > 0 && turn === params.turns) {
+        for (let i = 0; i < params.outcomes; i++) {
+          calls.push({
+            id: buildCallId(sid, turn, params.toolsPerTurn + i),
+            name: "register_outcome",
+            args: JSON.stringify({
+              type: "text",
+              label: `bench-${i + 1}`,
+              text: `benchmark outcome ${i + 1} for session ${sid}`,
+            }),
+          });
+        }
+      }
+      return { kind: "tools", calls };
+    }
+    const pad = "Benchmark task complete. All scripted turns executed. ";
+    let text = pad.repeat(Math.ceil(params.finalBytes / pad.length)).slice(0, params.finalBytes);
+    if (text.length === 0) text = "Done.";
+    return { kind: "text", text };
+  }
+
+  /** Summarize/compaction response: echo the directive so it survives compaction. */
+  function summarizeText(directiveText) {
+    return (
+      "Summary of prior work: the agent executed a scripted benchmark tool loop. " +
+      "Continue following the benchmark directive exactly as before. " +
+      (directiveText ?? "")
+    );
+  }
+
+  const USAGE = { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 };
+
+  // ── Responses API encoding ─────────────────────────────────────────────────
+
+  function respondResponsesJson(res, decision, model) {
+    const created = Math.floor(Date.now() / 1000);
+    const id = `resp_${Math.random().toString(36).slice(2, 10)}`;
+    const output = [];
+    if (decision.kind === "tools") {
+      for (const call of decision.calls) {
+        output.push({
+          type: "function_call",
+          id: `fc_${call.id}`,
+          call_id: call.id,
+          name: call.name,
+          arguments: call.args,
+        });
+      }
+    } else {
+      output.push({
+        type: "message",
+        role: "assistant",
+        id: `msg_${id}`,
+        content: [{ type: "output_text", text: decision.text, annotations: [] }],
+      });
+    }
+    const payload = {
+      id,
+      object: "response",
+      created_at: created,
+      model,
+      output,
+      usage: { input_tokens: USAGE.prompt_tokens, output_tokens: USAGE.completion_tokens },
+      incomplete_details: null,
+    };
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(payload));
+  }
+
+  function respondResponsesStream(res, decision, model) {
+    const created = Math.floor(Date.now() / 1000);
+    const id = `resp_${Math.random().toString(36).slice(2, 10)}`;
+    res.writeHead(200, {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    const send = (obj) => {
+      res.write(`event: ${obj.type}\n`);
+      res.write(`data: ${JSON.stringify(obj)}\n\n`);
+    };
+
+    send({ type: "response.created", response: { id, created_at: created, model } });
+
+    if (decision.kind === "tools") {
+      decision.calls.forEach((call, idx) => {
+        const itemId = `fc_${call.id}`;
+        send({
+          type: "response.output_item.added",
+          output_index: idx,
+          item: { type: "function_call", id: itemId, call_id: call.id, name: call.name, arguments: "" },
+        });
+        // Split arguments to exercise the streaming delta path
+        const mid = Math.max(1, Math.floor(call.args.length / 2));
+        send({
+          type: "response.function_call_arguments.delta",
+          item_id: itemId,
+          output_index: idx,
+          delta: call.args.slice(0, mid),
+        });
+        send({
+          type: "response.function_call_arguments.delta",
+          item_id: itemId,
+          output_index: idx,
+          delta: call.args.slice(mid),
+        });
+        send({
+          type: "response.output_item.done",
+          output_index: idx,
+          item: {
+            type: "function_call",
+            id: itemId,
+            call_id: call.id,
+            name: call.name,
+            arguments: call.args,
+            status: "completed",
+          },
+        });
+      });
+    } else {
+      const msgId = `msg_${id}`;
+      send({ type: "response.output_item.added", output_index: 0, item: { type: "message", id: msgId } });
+      // Chunk the text in ~1KB deltas
+      for (let i = 0; i < decision.text.length; i += 1024) {
+        send({
+          type: "response.output_text.delta",
+          item_id: msgId,
+          delta: decision.text.slice(i, i + 1024),
+        });
+      }
+      send({ type: "response.output_item.done", output_index: 0, item: { type: "message", id: msgId } });
+    }
+
+    send({
+      type: "response.completed",
+      response: {
+        usage: { input_tokens: USAGE.prompt_tokens, output_tokens: USAGE.completion_tokens },
+      },
+    });
+    res.end();
+  }
+
+  // ── Chat Completions encoding ──────────────────────────────────────────────
+
+  function respondChatJson(res, decision, model) {
+    const created = Math.floor(Date.now() / 1000);
+    const id = `chatcmpl-${Math.random().toString(36).slice(2, 10)}`;
+    const message = { role: "assistant", content: decision.kind === "text" ? decision.text : null };
+    if (decision.kind === "tools") {
+      message.tool_calls = decision.calls.map((call) => ({
+        id: call.id,
+        type: "function",
+        function: { name: call.name, arguments: call.args },
+      }));
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        id,
+        object: "chat.completion",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            message,
+            finish_reason: decision.kind === "tools" ? "tool_calls" : "stop",
+          },
+        ],
+        usage: USAGE,
+      }),
+    );
+  }
+
+  function respondChatStream(res, decision, model, includeUsage) {
+    const created = Math.floor(Date.now() / 1000);
+    const id = `chatcmpl-${Math.random().toString(36).slice(2, 10)}`;
+    res.writeHead(200, {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    const send = (choices, extra = {}) => {
+      res.write(
+        `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model, choices, ...extra })}\n\n`,
+      );
+    };
+
+    send([{ index: 0, delta: { role: "assistant" }, finish_reason: null }]);
+
+    if (decision.kind === "tools") {
+      decision.calls.forEach((call, idx) => {
+        // First chunk of a tool call carries id + name; arguments stream after.
+        send([
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: idx, id: call.id, type: "function", function: { name: call.name, arguments: "" } },
+              ],
+            },
+            finish_reason: null,
+          },
+        ]);
+        const mid = Math.max(1, Math.floor(call.args.length / 2));
+        for (const piece of [call.args.slice(0, mid), call.args.slice(mid)]) {
+          send([
+            {
+              index: 0,
+              delta: { tool_calls: [{ index: idx, function: { arguments: piece } }] },
+              finish_reason: null,
+            },
+          ]);
+        }
+      });
+      send([{ index: 0, delta: {}, finish_reason: "tool_calls" }]);
+    } else {
+      for (let i = 0; i < decision.text.length; i += 1024) {
+        send([{ index: 0, delta: { content: decision.text.slice(i, i + 1024) }, finish_reason: null }]);
+      }
+      send([{ index: 0, delta: {}, finish_reason: "stop" }]);
+    }
+
+    if (includeUsage) send([], { usage: USAGE });
+    res.write("data: [DONE]\n\n");
+    res.end();
+  }
+
+  // ── Main completion handler (shared by both endpoints) ────────────────────
+
+  async function handleCompletion(body, endpoint, res, rawJson) {
+    const rawText = extractText(body);
+    let directive = parseDirective(rawText);
+
+    // Directive missing (e.g. compacted away) → recover sid from call ids.
+    let sid = directive?.sid ?? scanCallIds(rawJson)?.sid ?? null;
+    if (!directive && sid && sessions.has(sid)) {
+      directive = { sid, ...sessions.get(sid).params };
+    }
+
+    if (!directive) {
+      // Unknown session — answer benignly so the runtime doesn't crash.
+      pushDebug({ at: new Date().toISOString(), endpoint, note: "no-directive", stream: !!body.stream });
+      const decision = { kind: "text", text: "bench-mock: no BENCH directive found in context." };
+      return encode(body, endpoint, res, decision);
+    }
+
+    sid = directive.sid;
+    const { sid: _sid, ...params } = directive;
+    const session = getSession(sid, params);
+    const stats = session.stats;
+    const now = new Date().toISOString();
+    stats.requests++;
+    stats.firstRequestAt ??= now;
+    stats.lastRequestAt = now;
+    stats.byEndpoint[endpoint]++;
+    if (body.stream) stats.streamRequests++;
+    else stats.jsonRequests++;
+
+    // Artificial model latency (the "LLM think time" this benchmark subtracts out)
+    if (params.latencyMs > 0) {
+      await sleep(params.latencyMs);
+      stats.llmBusyMs += params.latencyMs;
+    }
+
+    let decision;
+    if (!hasTools(body)) {
+      // Tool-less request ⇒ summarize/utility call (e.g. context compaction).
+      // Echo the directive so it survives history replacement.
+      stats.summarizeCalls++;
+      decision = { kind: "text", text: summarizeText(rawText.match(/\[BENCH[^\]]+\]/)?.[0]) };
+    } else {
+      const turn = computeTurn(body, rawJson);
+      decision = decide(sid, params, turn);
+      if (decision.kind === "tools") {
+        stats.turnsServed = Math.max(stats.turnsServed, turn);
+        for (const call of decision.calls) {
+          if (call.name === "register_outcome") stats.outcomeCallsEmitted++;
+          else stats.toolCallsEmitted++;
+        }
+      } else {
+        stats.turnsServed = Math.max(stats.turnsServed, turn);
+        stats.finals++;
+      }
+      pushDebug({
+        at: now,
+        endpoint,
+        sid,
+        turn,
+        stream: !!body.stream,
+        kind: decision.kind,
+        calls: decision.kind === "tools" ? decision.calls.length : 0,
+      });
+    }
+
+    encode(body, endpoint, res, decision);
+  }
+
+  function encode(body, endpoint, res, decision) {
+    const model = body.model ?? "mock-1";
+    if (endpoint === "responses") {
+      if (body.stream) respondResponsesStream(res, decision, model);
+      else respondResponsesJson(res, decision, model);
+    } else {
+      if (body.stream) respondChatStream(res, decision, model, !!body.stream_options?.include_usage);
+      else respondChatJson(res, decision, model);
+    }
+  }
+
+  // ── HTTP server ────────────────────────────────────────────────────────────
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
+    const path = url.pathname;
+
+    // Introspection endpoints
+    if (req.method === "GET" && path.startsWith("/bench/stats/")) {
+      const sid = path.slice("/bench/stats/".length);
+      const s = sessions.get(sid);
+      res.writeHead(s ? 200 : 404, { "content-type": "application/json" });
+      res.end(JSON.stringify(s ? { sid, params: s.params, stats: s.stats } : { error: "unknown sid" }));
+      return;
+    }
+    if (req.method === "GET" && path === "/bench/stats") {
+      const all = {};
+      for (const [sid, s] of sessions) all[sid] = { params: s.params, stats: s.stats };
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(all));
+      return;
+    }
+    if (req.method === "GET" && path === "/bench/debug") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(debugLog));
+      return;
+    }
+    if (req.method === "POST" && path === "/bench/reset") {
+      sessions.clear();
+      debugLog.length = 0;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    if (req.method === "GET" && path === "/bench/health") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    // LLM endpoints — match by path suffix so any baseUrl prefix works
+    const endpoint = path.endsWith("/chat/completions")
+      ? "chat"
+      : path.endsWith("/responses")
+        ? "responses"
+        : null;
+    if (req.method === "POST" && endpoint) {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        let body;
+        try {
+          body = JSON.parse(raw || "{}");
+        } catch {
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: { message: "invalid JSON" } }));
+          return;
+        }
+        handleCompletion(body, endpoint, res, raw).catch((err) => {
+          if (!quiet) console.error("[mock-llm] handler error:", err);
+          if (!res.headersSent) {
+            res.writeHead(500, { "content-type": "application/json" });
+            res.end(JSON.stringify({ error: { message: String(err?.message ?? err) } }));
+          } else {
+            res.end();
+          }
+        });
+      });
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: { message: `mock-llm: no route for ${req.method} ${path}` } }));
+  });
+
+  return {
+    server,
+    sessions,
+    start: () =>
+      new Promise((resolveStart, rejectStart) => {
+        server.once("error", rejectStart);
+        server.listen(port, host, () => {
+          server.off("error", rejectStart);
+          if (!quiet) console.log(`[mock-llm] listening on http://${host}:${port}`);
+          resolveStart({ url: `http://${host}:${port}` });
+        });
+      }),
+    stop: () =>
+      new Promise((resolveStop) => {
+        server.closeAllConnections?.();
+        server.close(() => resolveStop());
+      }),
+  };
+}
+
+// ── Standalone CLI: node bench/mock-llm.mjs [--port 8377] [--host 127.0.0.1] ──
+
+import { pathToFileURL } from "node:url";
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const args = process.argv.slice(2);
+  const getArg = (name, fallback) => {
+    const i = args.indexOf(`--${name}`);
+    return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+  };
+  const port = Number(getArg("port", 8377));
+  const host = getArg("host", "127.0.0.1");
+  const mock = createMockLlm({ port, host, quiet: false });
+  mock.start().catch((err) => {
+    console.error("[mock-llm] failed to start:", err.message);
+    process.exit(1);
+  });
+  process.on("SIGINT", () => mock.stop().then(() => process.exit(0)));
+  process.on("SIGTERM", () => mock.stop().then(() => process.exit(0)));
+}

--- a/bench/pricing.json
+++ b/bench/pricing.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "Declarative sandbox pricing layer — separate from measurements on purpose. Rates from official pricing pages, July 2026. Reference assumption: one 2 vCPU / 4 GiB sandbox per task. Update the numbers here without touching any benchmark code.",
+  "referenceSandbox": { "vcpu": 2, "ramGib": 4 },
+  "providers": {
+    "daytona": {
+      "vcpuHour": 0.0504,
+      "ramGibHour": 0.0162,
+      "granularity": "second"
+    },
+    "e2b": {
+      "vcpuHour": 0.0504,
+      "ramGibHour": 0.0162,
+      "granularity": "second",
+      "monthlyFloor": 150,
+      "note": "same per-unit rates as Daytona; Pro plan floor $150/mo"
+    },
+    "vercel": {
+      "activeCpuHour": 0.128,
+      "memGbHour": 0.0212,
+      "minBillMs": 60000,
+      "note": "active CPU only — I/O wait (LLM think time) is not billed; 60s minimum bill per sandbox"
+    }
+  }
+}

--- a/bench/results/2026-07-03T04-03-36-636Z-970e3d7-baseline-main-runtime.json
+++ b/bench/results/2026-07-03T04-03-36-636Z-970e3d7-baseline-main-runtime.json
@@ -1,0 +1,580 @@
+{
+  "meta": {
+    "ts": "2026-07-03T04:03:36.636Z",
+    "sha": "970e3d7",
+    "label": "baseline-main-runtime",
+    "node": "v20.20.0",
+    "hostname": "aHp0",
+    "target": "local",
+    "mode": "local"
+  },
+  "scenarios": [
+    {
+      "name": "smoke",
+      "description": "1 assistant turn, no tools — pure spawn + single LLM round-trip",
+      "params": {
+        "turns": 0,
+        "toolsPerTurn": 0,
+        "latencyMs": 50,
+        "finalBytes": 200
+      },
+      "sid": "smr4eq0hahtf4b6",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10066,
+        "spawn_ms": 4997,
+        "llm_ms": 50,
+        "overhead_ms": 10016,
+        "loop_ms": 0,
+        "loop_overhead_ms": 0,
+        "turns": 1,
+        "llm_requests": 1,
+        "tool_calls": 0,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 8
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 10
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4997
+        },
+        {
+          "status": "done",
+          "tMs": 10066
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 1, mock served 1"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 0, mock emitted 0"
+        }
+      ],
+      "elapsed_ms": 10069
+    },
+    {
+      "name": "tool_loop_50",
+      "description": "50 tool turns x 1 bash — sequential loop throughput",
+      "params": {
+        "turns": 50,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr4eq88z059dn6",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10036,
+        "spawn_ms": 4968,
+        "llm_ms": 2550,
+        "overhead_ms": 7486,
+        "loop_ms": 3058,
+        "loop_overhead_ms": 508,
+        "turns": 51,
+        "llm_requests": 51,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 3
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 4
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4968
+        },
+        {
+          "status": "done",
+          "tMs": 10036
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 51, mock served 51"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        }
+      ],
+      "elapsed_ms": 10039
+    },
+    {
+      "name": "tool_burst",
+      "description": "10 tool turns x 5 bash/turn — parallel tool dispatch within a turn",
+      "params": {
+        "turns": 10,
+        "toolsPerTurn": 5,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr4eqfzunrcstd",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 9939,
+        "spawn_ms": 4976,
+        "llm_ms": 550,
+        "overhead_ms": 9389,
+        "loop_ms": 784,
+        "loop_overhead_ms": 234,
+        "turns": 11,
+        "llm_requests": 11,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 1
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4976
+        },
+        {
+          "status": "done",
+          "tMs": 9939
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 11, mock served 11"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        }
+      ],
+      "elapsed_ms": 9941
+    },
+    {
+      "name": "big_output",
+      "description": "30 tool turns x 1 bash with 64KB output — context growth / compaction stress",
+      "params": {
+        "turns": 30,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 65536,
+        "finalBytes": 500
+      },
+      "sid": "smr4eqnnzopxcku",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10035,
+        "spawn_ms": 5070,
+        "llm_ms": 1550,
+        "overhead_ms": 8485,
+        "loop_ms": 1926,
+        "loop_overhead_ms": 376,
+        "turns": 31,
+        "llm_requests": 31,
+        "tool_calls": 30,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 1
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 5070
+        },
+        {
+          "status": "done",
+          "tMs": 10035
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 31, mock served 31"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 30, mock emitted 30"
+        }
+      ],
+      "elapsed_ms": 10039
+    },
+    {
+      "name": "max_turns_cap",
+      "description": "cap=never on agent with maxTurns=15 — runtime must stop the loop at the ceiling",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "cap": "never"
+      },
+      "sid": "smr4eqveudu0u91",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10035,
+        "spawn_ms": 4969,
+        "llm_ms": 750,
+        "overhead_ms": 9285,
+        "loop_ms": 876,
+        "loop_overhead_ms": 126,
+        "turns": 15,
+        "llm_requests": 15,
+        "tool_calls": 15,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 2
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 3
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4969
+        },
+        {
+          "status": "done",
+          "tMs": 10035
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done, failed], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 15, mock served 15"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 15, mock emitted 15"
+        }
+      ],
+      "elapsed_ms": 10037
+    },
+    {
+      "name": "outcomes_3",
+      "description": "5 tool turns + 3 register_outcome on the last turn — outcome pipeline",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "outcomes": 3
+      },
+      "sid": "smr4er35nt3mkso",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10031,
+        "spawn_ms": 4966,
+        "llm_ms": 300,
+        "overhead_ms": 9731,
+        "loop_ms": 339,
+        "loop_overhead_ms": 39,
+        "turns": 6,
+        "llm_requests": 6,
+        "tool_calls": 5,
+        "outcome_calls": 3,
+        "summarize_calls": 0,
+        "post_ms": 1
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4966
+        },
+        {
+          "status": "done",
+          "tMs": 10031
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 6, mock served 6"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 5, mock emitted 5"
+        },
+        {
+          "name": "outcomes",
+          "pass": true,
+          "detail": "expected 3, task record has 3"
+        }
+      ],
+      "elapsed_ms": 10033
+    },
+    {
+      "name": "timeout_kill",
+      "description": "cap=never + task maxDuration=8s — watchdog must kill and fail the task",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 300,
+        "cap": "never"
+      },
+      "sid": "smr4erawco00m0t",
+      "pass": true,
+      "terminal": "failed",
+      "metrics": {
+        "wall_ms": 19967,
+        "spawn_ms": 4971,
+        "llm_ms": 9600,
+        "overhead_ms": 10367,
+        "loop_ms": 9636,
+        "loop_overhead_ms": 36,
+        "turns": 32,
+        "llm_requests": 32,
+        "tool_calls": 32,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 2
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4971
+        },
+        {
+          "status": "failed",
+          "tMs": 19967
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "failed"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [failed], got \"failed\""
+        }
+      ],
+      "elapsed_ms": 19968
+    },
+    {
+      "name": "concurrency_10",
+      "description": "10 concurrent tasks x 5 tool turns — scheduler fan-out + makespan",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "concurrency": 10,
+      "pass": true,
+      "terminal": [
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done"
+      ],
+      "metrics": {
+        "makespan_ms": 10109,
+        "wall_ms_min": 10107,
+        "wall_ms_median": 10108,
+        "wall_ms_max": 10109,
+        "llm_ms_total": 3000,
+        "spawn_ms_min": 5053,
+        "spawn_ms_max": 5055
+      },
+      "checks": [
+        {
+          "name": "all_tasks_pass",
+          "pass": true,
+          "detail": "10/10 tasks green"
+        }
+      ],
+      "tasks": [
+        {
+          "sid": "smr4erqb0qoa39q",
+          "wall_ms": 10109,
+          "spawn_ms": 5055,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb1hsnzzy",
+          "wall_ms": 10108,
+          "spawn_ms": 5054,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb1w5kv3i",
+          "wall_ms": 10108,
+          "spawn_ms": 5054,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb10a8doc",
+          "wall_ms": 10108,
+          "spawn_ms": 5054,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb15fv4un",
+          "wall_ms": 10108,
+          "spawn_ms": 5054,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb1t8ja3s",
+          "wall_ms": 10108,
+          "spawn_ms": 5054,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb1ukzbru",
+          "wall_ms": 10108,
+          "spawn_ms": 5054,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb1iiqtil",
+          "wall_ms": 10108,
+          "spawn_ms": 5054,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb2flcxsn",
+          "wall_ms": 10107,
+          "spawn_ms": 5053,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4erqb2oxtu95",
+          "wall_ms": 10107,
+          "spawn_ms": 5053,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        }
+      ],
+      "elapsed_ms": 10320
+    }
+  ]
+}

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+/**
+ * bench/run.mjs — runtime-agnostic Polpo task benchmark runner.
+ *
+ * Usage:
+ *   node bench/run.mjs [--label <label>] [--only <names,csv>]
+ *                      [--mock-port 8377] [--port 8378]
+ *                      [--target <url>] [--mock-url <url>]
+ *                      [--keep]
+ *
+ * Local mode (default, no --target):
+ *   1. creates a throwaway Polpo project (polpo.json + agents.json) in a temp dir
+ *   2. starts the mock LLM (bench/mock-llm.mjs) on --mock-port
+ *   3. starts a PolpoServer from <repo>/dist on --port pointing at the temp project
+ *   4. runs every scenario through the public task API, checking invariants
+ *   5. writes bench/results/<ISO-ts>-<gitsha7>-<label>.json and tears everything down
+ *
+ * Target mode (--target http://host:port):
+ *   Uses an already-running Polpo server whose project is configured with the
+ *   bench provider override pointing at a reachable mock (--mock-url, default
+ *   http://127.0.0.1:8377). This is how the same suite runs against a sandbox
+ *   or a different runtime branch.
+ *
+ * Only talks to public contracts: the task REST API + the mock's /bench/stats.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { tmpdir, hostname } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+import { createMockLlm } from "./mock-llm.mjs";
+import { scenarios as allScenarios, selectScenarios } from "./scenarios.mjs";
+import { buildDirective, genSid } from "./lib/directive.mjs";
+import { PolpoClient, MockClient } from "./lib/client.mjs";
+
+const BENCH_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(BENCH_DIR, "..");
+
+// ─── Args ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { label: "run", mockPort: 8377, port: 8378, target: null, mockUrl: null, only: null, keep: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--label") args.label = argv[++i];
+    else if (a === "--mock-port") args.mockPort = Number(argv[++i]);
+    else if (a === "--port") args.port = Number(argv[++i]);
+    else if (a === "--target") args.target = argv[++i];
+    else if (a === "--mock-url") args.mockUrl = argv[++i];
+    else if (a === "--only") args.only = argv[++i];
+    else if (a === "--keep") args.keep = true;
+    else if (a === "--help" || a === "-h") {
+      console.log("Usage: node bench/run.mjs [--label <label>] [--target <url>] [--mock-port 8377] [--port 8378] [--only <names,csv>] [--keep]");
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+// ─── Local environment setup ──────────────────────────────────────────────────
+
+function writeProject(dir, mockPort) {
+  const polpoDir = join(dir, ".polpo");
+  mkdirSync(polpoDir, { recursive: true });
+  writeFileSync(
+    join(polpoDir, "polpo.json"),
+    JSON.stringify(
+      {
+        project: "polpo-bench",
+        settings: {
+          storage: "file",
+          maxRetries: 0, // failures must be terminal — no silent retries mid-benchmark
+          workDir: ".",
+          logLevel: "quiet",
+        },
+        // NOTE: the provider is named "openai" (with a baseUrl override) instead
+        // of a dedicated "bench" provider because the runtime's pre-spawn
+        // validation (validateProviderKeys) only accepts providers present in
+        // the static PROVIDER_ENV_MAP — unknown custom providers can never
+        // spawn task agents. See bench/README.md, "Runtime findings".
+        providers: {
+          openai: { baseUrl: `http://127.0.0.1:${mockPort}/v1` },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  // FileAgentStore format: [{ agent: AgentConfig, teamName }]
+  writeFileSync(
+    join(polpoDir, "agents.json"),
+    JSON.stringify(
+      [
+        {
+          agent: { name: "bench-agent", role: "developer", model: "openai/mock-1", maxTurns: 250 },
+          teamName: "bench",
+        },
+        {
+          agent: { name: "bench-capped", role: "developer", model: "openai/mock-1", maxTurns: 15 },
+          teamName: "bench",
+        },
+      ],
+      null,
+      2,
+    ),
+  );
+}
+
+/**
+ * Provider-override glue for runner subprocesses — see lib/preload-providers.mjs.
+ * Harmless no-op on runtimes that propagate polpo.json providers themselves.
+ */
+function injectRunnerEnv(mockPort) {
+  const preload = pathToFileURL(join(BENCH_DIR, "lib", "preload-providers.mjs")).href;
+  // Dummy key: satisfies the runtime's env-var key validation AND shields the
+  // benchmark from ever hitting the real OpenAI API by accident.
+  process.env.OPENAI_API_KEY = "bench-mock-key";
+  process.env.POLPO_BENCH_PROVIDERS = JSON.stringify({
+    openai: { baseUrl: `http://127.0.0.1:${mockPort}/v1` },
+  });
+  process.env.POLPO_BENCH_LLM_DIST = join(REPO_ROOT, "dist", "llm", "pi-client.js");
+  const existing = process.env.NODE_OPTIONS ? `${process.env.NODE_OPTIONS} ` : "";
+  process.env.NODE_OPTIONS = `${existing}--import ${preload}`;
+}
+
+// ─── Scenario execution ───────────────────────────────────────────────────────
+
+function checkInvariants(scenario, outcome) {
+  const inv = scenario.invariants ?? {};
+  const checks = [];
+  const push = (name, pass, detail) => checks.push({ name, pass, detail });
+
+  if (outcome.timedOut) {
+    push("terminal_reached", false, `no terminal state within ${scenario.timeoutMs}ms (last: ${outcome.task?.status})`);
+    return checks;
+  }
+  push("terminal_reached", true, outcome.task.status);
+
+  if (inv.terminal) {
+    push(
+      "terminal_status",
+      inv.terminal.includes(outcome.task.status),
+      `expected one of [${inv.terminal.join(", ")}], got "${outcome.task.status}"`,
+    );
+  }
+  const stats = outcome.mockStats?.stats;
+  if (inv.turnsServed !== undefined && stats) {
+    const t = stats.turnsServed;
+    const pass =
+      typeof inv.turnsServed === "number"
+        ? t === inv.turnsServed
+        : t >= (inv.turnsServed.min ?? 0) && t <= (inv.turnsServed.max ?? Infinity);
+    push("turns_served", pass, `expected ${JSON.stringify(inv.turnsServed)}, mock served ${t}`);
+  }
+  if (inv.toolCalls !== undefined && stats) {
+    push("tool_calls", stats.toolCallsEmitted === inv.toolCalls, `expected ${inv.toolCalls}, mock emitted ${stats.toolCallsEmitted}`);
+  }
+  if (inv.outcomes !== undefined) {
+    const n = Array.isArray(outcome.task.outcomes) ? outcome.task.outcomes.length : 0;
+    push("outcomes", n === inv.outcomes, `expected ${inv.outcomes}, task record has ${n}`);
+  }
+  if (inv.maxWallMs !== undefined) {
+    push("max_wall", outcome.wallMs <= inv.maxWallMs, `wall ${outcome.wallMs}ms vs max ${inv.maxWallMs}ms`);
+  }
+  return checks;
+}
+
+async function runSingleTask(polpo, mock, scenario, sid, pollIntervalMs) {
+  const created = await createScenarioTask(polpo, scenario, sid);
+  const polled = await polpo.pollTask(created.taskId, created.createdAtMs, {
+    timeoutMs: scenario.timeoutMs,
+    intervalMs: pollIntervalMs,
+  });
+  if (polled.timedOut) await polpo.killTask(created.taskId);
+  const mockStats = await mock.stats(sid);
+  return { ...created, mockStats, ...polled };
+}
+
+async function createScenarioTask(polpo, scenario, sid, taskIndex = 0) {
+  const directive = buildDirective(sid, scenario.directive);
+  const description =
+    `${directive}\n\n` +
+    `Benchmark task — the model behavior is fully scripted by the directive above. ` +
+    `Execute the requested tool calls and finish.`;
+  const createdAtMs = Date.now();
+  const task = await polpo.createTask({
+    title: `bench:${scenario.name}${scenario.concurrency ? `#${taskIndex}` : ""}`,
+    description,
+    assignTo: scenario.agent,
+    expectations: [],
+    ...(scenario.taskOpts ?? {}),
+  });
+  return { sid, taskId: task.id, createdAtMs, postMs: Date.now() - createdAtMs };
+}
+
+async function runScenario(polpo, mock, scenario, pollIntervalMs) {
+  const startedAt = Date.now();
+
+  if (scenario.concurrency && scenario.concurrency > 1) {
+    // Fire all creations together, then poll them all with ONE shared
+    // GET /tasks loop (rate-limit friendly, identical precision).
+    const created = await Promise.all(
+      Array.from({ length: scenario.concurrency }, (_, i) => createScenarioTask(polpo, scenario, genSid(), i)),
+    );
+    const polled = await polpo.pollMany(created, { timeoutMs: scenario.timeoutMs, intervalMs: pollIntervalMs * 2 });
+    const runs = [];
+    for (let i = 0; i < created.length; i++) {
+      const c = created[i];
+      const p = polled[i];
+      if (p.timedOut) await polpo.killTask(c.taskId);
+      const mockStats = await mock.stats(c.sid);
+      runs.push({ ...c, ...p, mockStats });
+    }
+    const makespanMs = Math.max(...runs.map((r) => r.wallMs));
+    const walls = runs.map((r) => r.wallMs).sort((a, b) => a - b);
+    const llmMs = runs.reduce((sum, r) => sum + (r.mockStats?.stats?.llmBusyMs ?? 0), 0);
+    const perTaskChecks = runs.map((r) => checkInvariants(scenario, r));
+    const failing = perTaskChecks.flat().filter((c) => !c.pass);
+    const checks = [
+      { name: "all_tasks_pass", pass: failing.length === 0, detail: failing.length ? `${failing.length} failing sub-checks` : `${runs.length}/${runs.length} tasks green` },
+    ];
+    for (const r of runs) await polpo.deleteTask(r.taskId);
+    return {
+      name: scenario.name,
+      description: scenario.description,
+      params: scenario.directive,
+      concurrency: scenario.concurrency,
+      pass: failing.length === 0,
+      terminal: runs.map((r) => r.task?.status),
+      metrics: {
+        makespan_ms: makespanMs,
+        wall_ms_min: walls[0],
+        wall_ms_median: walls[Math.floor(walls.length / 2)],
+        wall_ms_max: walls[walls.length - 1],
+        llm_ms_total: llmMs,
+        spawn_ms_min: Math.min(...runs.map((r) => r.spawnMs ?? Infinity)),
+        spawn_ms_max: Math.max(...runs.map((r) => r.spawnMs ?? 0)),
+      },
+      checks,
+      tasks: runs.map((r) => ({
+        sid: r.sid,
+        wall_ms: r.wallMs,
+        spawn_ms: r.spawnMs,
+        terminal: r.task?.status,
+        llm_ms: r.mockStats?.stats?.llmBusyMs ?? null,
+        turns: r.mockStats?.stats?.turnsServed ?? null,
+      })),
+      elapsed_ms: Date.now() - startedAt,
+    };
+  }
+
+  const run = await runSingleTask(polpo, mock, scenario, genSid(), pollIntervalMs);
+  const checks = checkInvariants(scenario, run);
+  const stats = run.mockStats?.stats;
+  const llmMs = stats?.llmBusyMs ?? null;
+  // Engine-loop duration seen from the model's side (first→last LLM request).
+  // Unlike wall_ms this is NOT quantized by the orchestrator tick, so it is
+  // the most precise cross-runtime comparison of the agent loop itself.
+  const loopMs =
+    stats?.firstRequestAt && stats?.lastRequestAt
+      ? new Date(stats.lastRequestAt).getTime() - new Date(stats.firstRequestAt).getTime()
+      : null;
+  await polpo.deleteTask(run.taskId);
+
+  return {
+    name: scenario.name,
+    description: scenario.description,
+    params: scenario.directive,
+    sid: run.sid,
+    pass: checks.every((c) => c.pass),
+    terminal: run.task?.status ?? null,
+    metrics: {
+      wall_ms: run.wallMs,
+      spawn_ms: run.spawnMs,
+      llm_ms: llmMs,
+      overhead_ms: llmMs !== null ? run.wallMs - llmMs : null,
+      loop_ms: loopMs,
+      loop_overhead_ms: loopMs !== null && llmMs !== null ? Math.max(0, loopMs - llmMs) : null,
+      turns: stats?.turnsServed ?? null,
+      llm_requests: stats?.requests ?? null,
+      tool_calls: stats?.toolCallsEmitted ?? null,
+      outcome_calls: stats?.outcomeCallsEmitted ?? null,
+      summarize_calls: stats?.summarizeCalls ?? null,
+      post_ms: run.postMs,
+    },
+    timeline: run.timeline,
+    checks,
+    elapsed_ms: Date.now() - startedAt,
+  };
+}
+
+// ─── Reporting ────────────────────────────────────────────────────────────────
+
+function gitSha() {
+  try {
+    return execSync("git rev-parse --short HEAD", { cwd: REPO_ROOT, encoding: "utf-8" }).trim();
+  } catch {
+    return "nosha";
+  }
+}
+
+function fmt(v) {
+  return v === null || v === undefined ? "-" : typeof v === "number" ? String(Math.round(v)) : String(v);
+}
+
+function printTable(results) {
+  const cols = ["scenario", "pass", "terminal", "wall_ms", "spawn_ms", "llm_ms", "overhead_ms", "loop_ms", "turns", "tool_calls"];
+  const rows = results.map((r) => [
+    r.name,
+    r.pass ? "PASS" : "FAIL",
+    Array.isArray(r.terminal) ? r.terminal.join(",").slice(0, 20) : fmt(r.terminal),
+    fmt(r.metrics.wall_ms ?? r.metrics.makespan_ms),
+    fmt(r.metrics.spawn_ms ?? r.metrics.spawn_ms_max),
+    fmt(r.metrics.llm_ms ?? r.metrics.llm_ms_total),
+    fmt(r.metrics.overhead_ms),
+    fmt(r.metrics.loop_ms),
+    fmt(r.metrics.turns),
+    fmt(r.metrics.tool_calls),
+  ]);
+  const widths = cols.map((c, i) => Math.max(c.length, ...rows.map((row) => row[i].length)));
+  const line = (cells) => "  " + cells.map((c, i) => c.padEnd(widths[i])).join("  ");
+  console.log("\n" + line(cols));
+  console.log("  " + widths.map((w) => "-".repeat(w)).join("  "));
+  for (const row of rows) console.log(line(row));
+  console.log();
+  for (const r of results) {
+    for (const c of r.checks.filter((c) => !c.pass)) {
+      console.log(`  ! ${r.name} :: ${c.name}: ${c.detail}`);
+    }
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const selected = selectScenarios(args.only);
+
+  let mockHandle = null;
+  let polpoServer = null;
+  let projectDir = null;
+
+  const mockUrl = args.mockUrl ?? `http://127.0.0.1:${args.mockPort}`;
+  const targetUrl = args.target ?? `http://127.0.0.1:${args.port}`;
+
+  const cleanup = async () => {
+    try {
+      await polpoServer?.stop();
+    } catch { /* already down */ }
+    try {
+      await mockHandle?.stop();
+    } catch { /* already down */ }
+    if (projectDir && !args.keep) {
+      try {
+        rmSync(projectDir, { recursive: true, force: true });
+      } catch { /* best effort */ }
+    }
+  };
+
+  try {
+    if (!args.target) {
+      // ── Local mode: temp project + in-repo dist server ──
+      const serverEntry = join(REPO_ROOT, "dist", "server", "index.js");
+      if (!existsSync(serverEntry)) {
+        throw new Error(`dist not built: ${serverEntry} missing. Run pnpm build first.`);
+      }
+      projectDir = mkdtempSync(join(tmpdir(), "polpo-bench-"));
+      writeProject(projectDir, args.mockPort);
+      injectRunnerEnv(args.mockPort);
+
+      mockHandle = createMockLlm({ port: args.mockPort, quiet: true });
+      await mockHandle.start();
+
+      console.log(`[bench] project: ${projectDir}`);
+      console.log(`[bench] mock:    ${mockUrl}`);
+      console.log(`[bench] server:  ${targetUrl} (dist @ ${gitSha()})`);
+
+      const { PolpoServer } = await import(pathToFileURL(serverEntry).href);
+      polpoServer = new PolpoServer({ port: args.port, host: "127.0.0.1", workDir: projectDir });
+      await polpoServer.start();
+    } else {
+      console.log(`[bench] target:  ${targetUrl}`);
+      console.log(`[bench] mock:    ${mockUrl} (assumed already running & wired into the target project)`);
+    }
+
+    const mock = new MockClient(mockUrl);
+    await mock.health();
+
+    // Local mode: rotate synthetic x-forwarded-for buckets so 100ms polling
+    // doesn't trip the server's 200req/60s per-IP limiter. Target mode: a real
+    // proxy owns XFF, so poll gently instead.
+    const isLocal = !args.target;
+    const pollIntervalMs = isLocal ? 100 : 300;
+    const polpo = new PolpoClient(targetUrl, { apiKey: process.env.POLPO_API_KEY, xffRotate: isLocal });
+    const prefix = await polpo.probe();
+    console.log(`[bench] api:     ${targetUrl}${prefix}`);
+
+    const results = [];
+    for (const scenario of selected) {
+      process.stdout.write(`[bench] ${scenario.name} ... `);
+      try {
+        const result = await runScenario(polpo, mock, scenario, pollIntervalMs);
+        results.push(result);
+        console.log(`${result.pass ? "PASS" : "FAIL"} (${Math.round(result.elapsed_ms / 1000)}s)`);
+      } catch (err) {
+        console.log(`ERROR: ${err.message}`);
+        results.push({
+          name: scenario.name,
+          description: scenario.description,
+          params: scenario.directive,
+          pass: false,
+          terminal: null,
+          metrics: {},
+          checks: [{ name: "execution", pass: false, detail: err.message }],
+          elapsed_ms: 0,
+        });
+      }
+    }
+
+    // ── Persist results ──
+    const meta = {
+      ts: new Date().toISOString(),
+      sha: gitSha(),
+      label: args.label,
+      node: process.version,
+      hostname: hostname(),
+      target: args.target ?? "local",
+      mode: args.target ? "target" : "local",
+    };
+    const resultsDir = join(BENCH_DIR, "results");
+    mkdirSync(resultsDir, { recursive: true });
+    const fileName = `${meta.ts.replace(/[:.]/g, "-")}-${meta.sha}-${meta.label}.json`;
+    const outPath = join(resultsDir, fileName);
+    writeFileSync(outPath, JSON.stringify({ meta, scenarios: results }, null, 2));
+
+    printTable(results);
+    console.log(`[bench] results: ${outPath}`);
+    const failed = results.filter((r) => !r.pass);
+    console.log(`[bench] ${results.length - failed.length}/${results.length} scenarios green${failed.length ? ` — failing: ${failed.map((f) => f.name).join(", ")}` : ""}`);
+
+    await cleanup();
+    process.exit(failed.length > 0 ? 1 : 0);
+  } catch (err) {
+    console.error(`[bench] fatal: ${err.stack ?? err.message}`);
+    await cleanup();
+    process.exit(1);
+  }
+}
+
+main();

--- a/bench/scenarios.mjs
+++ b/bench/scenarios.mjs
@@ -1,0 +1,107 @@
+/**
+ * bench/scenarios.mjs — declarative benchmark scenarios.
+ *
+ * Each scenario describes:
+ *   - directive params for the mock LLM (see lib/directive.mjs — `turns` is
+ *     the number of TOOL turns; the final text response happens on turn N+1)
+ *   - which agent runs it ("bench-agent" maxTurns=250, "bench-capped" maxTurns=15)
+ *   - task options (maxDuration, ...)
+ *   - invariants checked against the terminal task record + mock stats
+ *
+ * Invariant fields (all optional):
+ *   terminal      array of acceptable terminal task statuses
+ *   turnsServed   exact number, or { min, max }
+ *   toolCalls     exact number of bash tool calls the mock must have emitted
+ *   outcomes      exact number of outcomes expected on the task record
+ *   maxWallMs     upper bound on wall time (sanity ceiling, generous)
+ *
+ * latencyMs defaults to 50 everywhere so llm_ms is known and
+ * overhead_ms = wall_ms − llm_ms is meaningful.
+ */
+
+export const DEFAULT_LATENCY_MS = 50;
+
+export const scenarios = [
+  {
+    name: "smoke",
+    description: "1 assistant turn, no tools — pure spawn + single LLM round-trip",
+    agent: "bench-agent",
+    directive: { turns: 0, toolsPerTurn: 0, latencyMs: DEFAULT_LATENCY_MS, finalBytes: 200 },
+    timeoutMs: 90_000,
+    invariants: { terminal: ["done"], turnsServed: 1, toolCalls: 0 },
+  },
+  {
+    name: "tool_loop_50",
+    description: "50 tool turns x 1 bash — sequential loop throughput",
+    agent: "bench-agent",
+    directive: { turns: 50, toolsPerTurn: 1, latencyMs: DEFAULT_LATENCY_MS, toolOutputBytes: 256 },
+    timeoutMs: 240_000,
+    invariants: { terminal: ["done"], turnsServed: 51, toolCalls: 50 },
+  },
+  {
+    name: "tool_burst",
+    description: "10 tool turns x 5 bash/turn — parallel tool dispatch within a turn",
+    agent: "bench-agent",
+    directive: { turns: 10, toolsPerTurn: 5, latencyMs: DEFAULT_LATENCY_MS, toolOutputBytes: 256 },
+    timeoutMs: 180_000,
+    invariants: { terminal: ["done"], turnsServed: 11, toolCalls: 50 },
+  },
+  {
+    name: "big_output",
+    description: "30 tool turns x 1 bash with 64KB output — context growth / compaction stress",
+    agent: "bench-agent",
+    // Note: the runtime's bash tool truncates output to the last 30KB, so each
+    // turn contributes ~30KB to context. 30 turns ≈ 900KB ≈ 225K estimated
+    // tokens — enough to cross the compaction trigger (85% of a 200K window).
+    directive: { turns: 30, toolsPerTurn: 1, latencyMs: DEFAULT_LATENCY_MS, toolOutputBytes: 65_536, finalBytes: 500 },
+    timeoutMs: 300_000,
+    invariants: { terminal: ["done"], turnsServed: 31, toolCalls: 30 },
+  },
+  {
+    name: "max_turns_cap",
+    description: "cap=never on agent with maxTurns=15 — runtime must stop the loop at the ceiling",
+    agent: "bench-capped", // maxTurns: 15
+    directive: { turns: 9999, toolsPerTurn: 1, latencyMs: DEFAULT_LATENCY_MS, cap: "never" },
+    timeoutMs: 120_000,
+    // The engine performs exactly maxTurns streamText calls, all answered with
+    // tool calls, then exits the loop. Terminal status is runtime-defined:
+    // current runtime treats a capped loop as a normal exit (done).
+    invariants: { terminal: ["done", "failed"], turnsServed: 15, toolCalls: 15 },
+  },
+  {
+    name: "outcomes_3",
+    description: "5 tool turns + 3 register_outcome on the last turn — outcome pipeline",
+    agent: "bench-agent",
+    directive: { turns: 5, toolsPerTurn: 1, latencyMs: DEFAULT_LATENCY_MS, outcomes: 3 },
+    timeoutMs: 120_000,
+    invariants: { terminal: ["done"], turnsServed: 6, toolCalls: 5, outcomes: 3 },
+  },
+  {
+    name: "timeout_kill",
+    description: "cap=never + task maxDuration=8s — watchdog must kill and fail the task",
+    agent: "bench-agent",
+    directive: { turns: 9999, toolsPerTurn: 1, latencyMs: 300, cap: "never" },
+    taskOpts: { maxDuration: 8_000 },
+    timeoutMs: 120_000,
+    invariants: { terminal: ["failed"] },
+  },
+  {
+    name: "concurrency_10",
+    description: "10 concurrent tasks x 5 tool turns — scheduler fan-out + makespan",
+    agent: "bench-agent",
+    concurrency: 10,
+    directive: { turns: 5, toolsPerTurn: 1, latencyMs: DEFAULT_LATENCY_MS, toolOutputBytes: 256 },
+    timeoutMs: 300_000,
+    invariants: { terminal: ["done"], turnsServed: 6, toolCalls: 5 },
+  },
+];
+
+export function selectScenarios(only) {
+  if (!only) return scenarios;
+  const names = only.split(",").map((s) => s.trim()).filter(Boolean);
+  const unknown = names.filter((n) => !scenarios.some((s) => s.name === n));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown scenario(s): ${unknown.join(", ")}. Available: ${scenarios.map((s) => s.name).join(", ")}`);
+  }
+  return scenarios.filter((s) => names.includes(s.name));
+}

--- a/src/__tests__/engine-behavior.test.ts
+++ b/src/__tests__/engine-behavior.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Characterization tests for the task execution engine (spawnEngine).
+ *
+ * These pin the OBSERVABLE contract of the task path before the migration to
+ * the core loop runtime (LoopRunner/PipelineExecutor): transcript event
+ * sequence, activity tracking, outcome registration, maxTurns, abort, and
+ * TaskResult shape. The loop-engine replacement must keep every assertion
+ * here green (parity), so this file is intentionally engine-agnostic in what
+ * it asserts — it describes behavior, not implementation.
+ *
+ * Mock strategy: same as completions.test.ts — vi.mock the pi-client module
+ * so resolveModel returns a MockLanguageModelV3 wrapped in a ResolvedModel.
+ * Everything else (tool layer, filesystem, prompt building) runs for real
+ * against a temp directory.
+ *
+ * Known non-injectable seams of the current engine (documented, not tested):
+ * - activity.toolUsage harvesting (needs image/video tools with gateway
+ *   metadata — the engine builds its own tools, so a fake tool cannot be
+ *   injected). Covered from Phase 1 where the tool set is injectable.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { mkdtemp, mkdir, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedModel } from "../llm/pi-client.js";
+import {
+  type MockLanguageModelV3,
+  mockTextModel,
+  mockTurnSequenceModel,
+  mockResolvedModel,
+  type MockResponse,
+} from "./helpers/mock-llm.js";
+
+// ── Mock pi-client BEFORE any imports that pull it in ──
+
+let activeResolvedModel: ResolvedModel = mockResolvedModel(mockTextModel("default"));
+
+vi.mock("../llm/pi-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../llm/pi-client.js")>();
+  return {
+    ...actual,
+    resolveModel: () => activeResolvedModel,
+    enforceModelAllowlist: () => {},
+    mapReasoningToProviderOptions: () => undefined,
+  };
+});
+
+import { spawnEngine } from "../adapters/engine.js";
+import type { AgentConfig, Task } from "../core/types.js";
+
+// ── Helpers ─────────────────────────────────────────────
+
+function setMockModel(model: MockLanguageModelV3, overrides: Partial<ResolvedModel> = {}) {
+  activeResolvedModel = { ...mockResolvedModel(model), ...overrides };
+}
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { name: "char-agent", role: "developer", ...overrides };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-char-1",
+    title: "Characterization task",
+    description: "Do the scripted thing.",
+    state: "in_progress",
+    expectations: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    assignedTo: "char-agent",
+    ...overrides,
+  } as Task;
+}
+
+interface TranscriptEntry {
+  type: string;
+  [key: string]: unknown;
+}
+
+let tmpRoot: string;
+let cwd: string;
+let polpoDir: string;
+let outputDir: string;
+
+/** Spawn the engine and collect every transcript entry until done. */
+async function runEngine(
+  agent: AgentConfig,
+  responses: MockResponse[] | MockLanguageModelV3,
+  modelOverrides: Partial<ResolvedModel> = {},
+  taskOverrides: Partial<Task> = {},
+) {
+  const model = Array.isArray(responses) ? mockTurnSequenceModel(responses) : responses;
+  setMockModel(model, modelOverrides);
+  const transcript: TranscriptEntry[] = [];
+  // outputDir is required for register_outcome to exist: the tool is
+  // task-only by design — createSystemTools injects it only when the
+  // caller provides an output directory (chat completions never do).
+  const handle = spawnEngine(agent, makeTask(taskOverrides), cwd, { polpoDir, outputDir });
+  handle.onTranscript = (entry) => transcript.push(entry as TranscriptEntry);
+  const result = await handle.done;
+  return { handle, result, transcript };
+}
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "polpo-engine-char-"));
+  cwd = join(tmpRoot, "work");
+  polpoDir = join(tmpRoot, ".polpo");
+  outputDir = join(tmpRoot, "output");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(polpoDir, { recursive: true });
+  await mkdir(outputDir, { recursive: true });
+});
+
+afterAll(async () => {
+  if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true });
+});
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("spawnEngine — characterization", () => {
+  test("text-only run: TaskResult shape, transcript, handle lifecycle", async () => {
+    const { handle, result, transcript } = await runEngine(makeAgent(), [
+      { type: "text", text: "All done here." },
+    ]);
+
+    // TaskResult contract
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("All done here.");
+    expect(result.stderr).toBe("");
+    expect(result.duration).toBeGreaterThanOrEqual(0);
+
+    // Handle lifecycle
+    expect(handle.isAlive()).toBe(false);
+    expect(handle.agentName).toBe("char-agent");
+    expect(handle.taskId).toBe("task-char-1");
+    expect(handle.pid).toBe(0); // in-process: no OS pid
+
+    // Transcript: exactly one assistant entry with the final text
+    const assistant = transcript.filter((t) => t.type === "assistant");
+    expect(assistant).toHaveLength(1);
+    expect(assistant[0].text).toBe("All done here.");
+
+    // Activity summary mirrors last assistant text (truncated to 200)
+    expect(handle.activity.summary).toBe("All done here.");
+    expect(handle.activity.totalTokens).toBeGreaterThan(0);
+  });
+
+  test("tool loop: transcript order, activity tracking, real file effects", async () => {
+    const { handle, result, transcript } = await runEngine(makeAgent(), [
+      { type: "tool-call", toolName: "write", args: { path: "out.txt", content: "hello" } },
+      { type: "tool-call", toolName: "bash", args: { command: "echo ciao" } },
+      { type: "text", text: "done" },
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("done");
+
+    // The write tool really wrote the file in cwd
+    const written = await readFile(join(cwd, "out.txt"), "utf-8");
+    expect(written).toBe("hello");
+
+    // Transcript order: per turn, tool_use precedes its tool_result;
+    // final assistant text comes last.
+    const types = transcript.map((t) => `${t.type}${t.tool ? `:${t.tool}` : ""}`);
+    expect(types).toEqual([
+      "tool_use:write",
+      "tool_result:write",
+      "tool_use:bash",
+      "tool_result:bash",
+      "assistant",
+    ]);
+
+    // tool_use carries input, tool_result carries content and isError=false
+    const bashUse = transcript.find((t) => t.type === "tool_use" && t.tool === "bash");
+    expect(bashUse?.input).toEqual({ command: "echo ciao" });
+    const bashResult = transcript.find((t) => t.type === "tool_result" && t.tool === "bash");
+    expect(bashResult?.isError).toBe(false);
+    expect(String(bashResult?.content)).toContain("ciao");
+
+    // Activity tracking
+    expect(handle.activity.toolCalls).toBe(2);
+    expect(handle.activity.lastTool).toBe("bash");
+    expect(handle.activity.filesCreated).toHaveLength(1);
+    expect(handle.activity.filesCreated[0].endsWith("out.txt")).toBe(true);
+    expect(handle.activity.filesEdited).toHaveLength(0);
+    expect(handle.activity.totalTokens).toBeGreaterThan(0);
+  });
+
+  test("register_outcome: outcomes are collected on the handle with full shape", async () => {
+    const { handle, result } = await runEngine(makeAgent(), [
+      {
+        type: "tool-call",
+        toolName: "register_outcome",
+        args: { type: "text", label: "Summary", text: "Revenue up 23%" },
+      },
+      { type: "text", text: "registered" },
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(handle.outcomes).toBeDefined();
+    expect(handle.outcomes).toHaveLength(1);
+    const outcome = handle.outcomes![0];
+    expect(outcome.type).toBe("text");
+    expect(outcome.label).toBe("Summary");
+    expect(outcome.text).toBe("Revenue up 23%");
+    expect(outcome.producedBy).toBe("register_outcome");
+    expect(typeof outcome.id).toBe("string");
+    expect(outcome.id.length).toBeGreaterThan(0);
+    expect(typeof outcome.producedAt).toBe("string");
+  });
+
+  test("maxTurns: a model that never stops is capped, run still succeeds", async () => {
+    // A fresh tool-call response per turn (a static mockToolCallModel reuses
+    // one consumed stream) — the model would loop forever without the cap.
+    const alwaysToolCall: MockResponse[] = Array.from({ length: 6 }, () => ({
+      type: "tool-call" as const,
+      toolName: "bash",
+      args: { command: "true" },
+    }));
+    const { handle, result } = await runEngine(makeAgent({ maxTurns: 3 }), alwaysToolCall);
+
+    expect(result.exitCode).toBe(0);
+    // One tool call per turn, capped at maxTurns
+    expect(handle.activity.toolCalls).toBe(3);
+    expect(handle.isAlive()).toBe(false);
+  });
+
+  test("failing tool command: isError stays false (bash reports, not throws), loop continues", async () => {
+    const { handle, result, transcript } = await runEngine(makeAgent(), [
+      { type: "tool-call", toolName: "bash", args: { command: "exit 3" } },
+      { type: "text", text: "recovered" },
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("recovered");
+    expect(handle.activity.toolCalls).toBe(1);
+    const bashResult = transcript.find((t) => t.type === "tool_result" && t.tool === "bash");
+    expect(bashResult).toBeDefined();
+    // Characterization: non-zero exit codes are reported as content, not
+    // thrown — the engine's isError flag is reserved for tool exceptions.
+    expect(bashResult?.isError).toBe(false);
+  });
+
+  test("kill(): run terminates, no model turns are consumed after abort", async () => {
+    setMockModel(mockTextModel("should not matter"));
+    const handle = spawnEngine(makeAgent(), makeTask(), cwd, { polpoDir });
+    handle.kill();
+    const result = await handle.done;
+
+    expect(handle.isAlive()).toBe(false);
+    // Aborted before the first turn: clean exit, no output, no tool calls.
+    expect(handle.activity.toolCalls).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("model error: exitCode 1, stderr message, error transcript entry", async () => {
+    const boom = new (await import("ai/test")).MockLanguageModelV3({
+      doStream: async () => {
+        throw new Error("provider exploded");
+      },
+    });
+    const { handle, result, transcript } = await runEngine(makeAgent(), boom);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    // Characterization: the stream error surfaces as an "error" part in
+    // fullStream (with the real message), while awaiting stream.text then
+    // throws the generic AI SDK error — which is what lands in stderr.
+    expect(result.stderr).toContain("No output generated");
+    expect(handle.isAlive()).toBe(false);
+    const errors = transcript.filter((t) => t.type === "error");
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some((e) => String(e.message).includes("provider exploded"))).toBe(true);
+  });
+
+  test("compaction: fires once multi-turn history exists over the window", async () => {
+    // Characterization of the CURRENT trigger, with two known quirks pinned
+    // on purpose (they are findings, not features — the loop-engine must
+    // change them deliberately, not silently):
+    // 1. A single over-threshold user message never emits an event
+    //    (splitIndex <= 0 short-circuit in compactIfNeeded).
+    // 2. estimateMessageTokens only counts "text" and legacy "toolCall"
+    //    blocks — AI SDK v6 "tool-call"/"tool-result" parts are NOT counted,
+    //    so tool outputs never contribute to the estimate and compaction on
+    //    tool-heavy tasks effectively never triggers. The only reliably
+    //    counted mass is the system prompt + string user messages.
+    // Therefore: an over-threshold task DESCRIPTION + one tool turn makes
+    // the summarize phase observable at turn 1.
+    const { result, transcript } = await runEngine(
+      makeAgent(),
+      [
+        { type: "tool-call", toolName: "bash", args: { command: "true" } },
+        { type: "text", text: "compacted and finished" },
+      ],
+      { contextWindow: 3000, maxTokens: 256 },
+      { description: "analyze this dataset. ".repeat(600) },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("compacted and finished");
+    const compactions = transcript.filter((t) => t.type === "compaction");
+    expect(compactions.length).toBeGreaterThanOrEqual(1);
+    expect(compactions[0].phase).toBe("summarize");
+    expect(compactions[0].tokensBefore).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Pins the observable contract of the task execution path before the migration to the core loop runtime: transcript event sequence, activity tracking, register_outcome collection, maxTurns cap, abort, error path, compaction trigger, TaskResult shape.

Findings documented in the tests:
- register_outcome only exists when outputDir is provided (task-only by design)
- stream errors surface as transcript entries; stderr gets the generic AI SDK "No output generated" message
- estimateMessageTokens does not count AI SDK v6 tool-call/tool-result parts → compaction on tool-heavy tasks effectively never triggers (fixed later in this stack)
- a single over-threshold message compacts silently (no event)

First PR of the task→loop-runtime stack. The runtime-agnostic benchmark suite (bench/) lands here too once finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)