### PR TITLE
feat: task runtime on the core LoopRunner

### DIFF
--- a/src/__tests__/engine-behavior.test.ts
+++ b/src/__tests__/engine-behavior.test.ts
@@ -47,7 +47,16 @@ vi.mock("../llm/pi-client.js", async (importOriginal) => {
 });
 
 import { spawnEngine } from "../adapters/engine.js";
+import { spawnLoopEngine } from "../adapters/loop-engine.js";
 import type { AgentConfig, Task } from "../core/types.js";
+
+// Both engines must satisfy the same observable contract: the legacy
+// manual loop and its loop-runtime replacement. This IS the parity gate
+// for the migration.
+const ENGINES = [
+  ["spawnEngine (legacy)", spawnEngine],
+  ["spawnLoopEngine (loop runtime)", spawnLoopEngine],
+] as const;
 
 // ── Helpers ─────────────────────────────────────────────
 
@@ -83,25 +92,6 @@ let cwd: string;
 let polpoDir: string;
 let outputDir: string;
 
-/** Spawn the engine and collect every transcript entry until done. */
-async function runEngine(
-  agent: AgentConfig,
-  responses: MockResponse[] | MockLanguageModelV3,
-  modelOverrides: Partial<ResolvedModel> = {},
-  taskOverrides: Partial<Task> = {},
-) {
-  const model = Array.isArray(responses) ? mockTurnSequenceModel(responses) : responses;
-  setMockModel(model, modelOverrides);
-  const transcript: TranscriptEntry[] = [];
-  // outputDir is required for register_outcome to exist: the tool is
-  // task-only by design — createSystemTools injects it only when the
-  // caller provides an output directory (chat completions never do).
-  const handle = spawnEngine(agent, makeTask(taskOverrides), cwd, { polpoDir, outputDir });
-  handle.onTranscript = (entry) => transcript.push(entry as TranscriptEntry);
-  const result = await handle.done;
-  return { handle, result, transcript };
-}
-
 beforeAll(async () => {
   tmpRoot = await mkdtemp(join(tmpdir(), "polpo-engine-char-"));
   cwd = join(tmpRoot, "work");
@@ -118,7 +108,25 @@ afterAll(async () => {
 
 // ── Tests ───────────────────────────────────────────────
 
-describe("spawnEngine — characterization", () => {
+describe.each(ENGINES)("%s — characterization", (_label, spawn) => {
+  /** Spawn the engine and collect every transcript entry until done. */
+  async function runEngine(
+    agent: AgentConfig,
+    responses: MockResponse[] | MockLanguageModelV3,
+    modelOverrides: Partial<ResolvedModel> = {},
+    taskOverrides: Partial<Task> = {},
+  ) {
+    const model = Array.isArray(responses) ? mockTurnSequenceModel(responses) : responses;
+    setMockModel(model, modelOverrides);
+    const transcript: TranscriptEntry[] = [];
+    // outputDir is required for register_outcome to exist: the tool is
+    // task-only by design — createSystemTools injects it only when the
+    // caller provides an output directory (chat completions never do).
+    const handle = spawn(agent, makeTask(taskOverrides), cwd, { polpoDir, outputDir });
+    handle.onTranscript = (entry) => transcript.push(entry as TranscriptEntry);
+    const result = await handle.done;
+    return { handle, result, transcript };
+  }
   test("text-only run: TaskResult shape, transcript, handle lifecycle", async () => {
     const { handle, result, transcript } = await runEngine(makeAgent(), [
       { type: "text", text: "All done here." },
@@ -244,7 +252,7 @@ describe("spawnEngine — characterization", () => {
 
   test("kill(): run terminates, no model turns are consumed after abort", async () => {
     setMockModel(mockTextModel("should not matter"));
-    const handle = spawnEngine(makeAgent(), makeTask(), cwd, { polpoDir });
+    const handle = spawn(makeAgent(), makeTask(), cwd, { polpoDir });
     handle.kill();
     const result = await handle.done;
 

--- a/src/adapters/engine.ts
+++ b/src/adapters/engine.ts
@@ -271,7 +271,7 @@ export function buildSystemPrompt(agent: AgentConfig, cwd: string, polpoDir?: st
 /**
  * Build the user prompt from task data.
  */
-function buildPrompt(task: Task): string {
+export function buildPrompt(task: Task): string {
   const parts = [`Task: ${task.title}`, ``, task.description];
   if (task.expectations.length > 0) {
     parts.push(``, `Acceptance criteria:`);
@@ -374,17 +374,28 @@ function convertToolsToToolSet(
   return toolSet;
 }
 
-/**
- * Spawn an agent using Polpo's built-in engine (AI SDK streamText loop).
- *
- * This is the default execution path — used when no adapter is specified
- * on an agent config.
- */
-export function spawnEngine(agentConfig: AgentConfig, task: Task, cwd: string, ctx?: SpawnContext): AgentHandle {
-  const activity = createActivity();
-  const start = Date.now();
-  let alive = true;
+// ─── Shared spawn preparation ──────────────────────────
+//
+// Used by both the legacy manual-loop engine (spawnEngine) and the
+// loop-runtime engine (spawnLoopEngine in loop-engine.ts) so that model
+// resolution, sandbox paths, system prompt, and tool building stay
+// byte-identical during the migration.
 
+export interface SpawnPrep {
+  model: ReturnType<typeof resolveModel>;
+  polpoDir: string;
+  fs: FileSystem;
+  shell: Shell;
+  outputDir?: string;
+  effectiveAllowedPaths?: string[];
+  systemPrompt: string;
+  providerOptions?: Record<string, Record<string, any>>;
+  hasExtendedTools: boolean;
+  browserProfileDir: string;
+  maxTurns: number;
+}
+
+export function prepareSpawn(agentConfig: AgentConfig, cwd: string, ctx?: SpawnContext): SpawnPrep {
   // Enforce model allowlist (throws if model not allowed)
   if (agentConfig.model) {
     enforceModelAllowlist(agentConfig.model);
@@ -393,9 +404,6 @@ export function spawnEngine(agentConfig: AgentConfig, task: Task, cwd: string, c
   // Resolve model
   const model = resolveModel(agentConfig.model, { gateway: ctx?.gatewayConfig as any });
 
-  // Create all tools scoped to working directory with path sandboxing
-  // Core tools (always available): read, write, edit, bash, glob, grep, ls, http_fetch, http_download, register_outcome, vault_get, vault_list
-  // Extended tools are auto-loaded when their names appear in allowedTools (e.g. "browser_*", "email_*", "image_*", "video_*", "audio_*", "excel_*", "pdf_*", "docx_*", "search_*")
   // polpoDir must always be provided via SpawnContext.
   // Fallback to join(cwd, ".polpo") is WRONG when settings.workDir points to a
   // subdirectory — cwd would be e.g. /project/packages/app while .polpo/ lives
@@ -451,16 +459,84 @@ export function spawnEngine(agentConfig: AgentConfig, task: Task, cwd: string, c
     effectiveAllowedPaths = undefined;
   }
 
-  // Vault resolution is async — will be resolved in handle.done before tools are used.
-  // Start with core coding tools WITHOUT vault; vault tools are added in the async phase.
-  const codingTools = createSystemTools(cwd, agentConfig.allowedTools, effectiveAllowedPaths, outputDir, undefined, fs, shell);
-
-
   // Resolve reasoning level: agent config > global settings (via SpawnContext) > "off"
   const thinkingLevel = agentConfig.reasoning ?? ctx?.reasoning ?? "off";
 
   // Build the system prompt once for reuse in both the agent loop and context compaction
   const systemPrompt = buildSystemPrompt(agentConfig, cwd, ctx?.polpoDir, outputDir, effectiveAllowedPaths);
+
+  // Track turns for maxTurns enforcement
+  const maxTurns = agentConfig.maxTurns ?? 150;
+
+  // Provider options for reasoning/thinking
+  // Cast needed: mapReasoningToProviderOptions returns Record<string, Record<string, unknown>>
+  // but AI SDK expects Record<string, JSONObject> (JSONValue values). The values are always
+  // JSON-serializable (numbers, strings, objects), so this cast is safe.
+  const providerOptions = mapReasoningToProviderOptions(model.provider, thinkingLevel, model.maxTokens) as
+    Record<string, Record<string, any>> | undefined;
+
+  return {
+    model, polpoDir, fs, shell, outputDir, effectiveAllowedPaths,
+    systemPrompt, providerOptions, hasExtendedTools, browserProfileDir, maxTurns,
+  };
+}
+
+/**
+ * Resolve the agent vault and build the full PolpoTool set (core tools plus
+ * extended categories when requested via allowedTools). Async because vault
+ * resolution hits the store.
+ */
+export async function buildAgentTools(
+  agentConfig: AgentConfig,
+  cwd: string,
+  prep: SpawnPrep,
+  ctx?: SpawnContext,
+): Promise<PolpoTool[]> {
+  const vaultEntries = await ctx?.vaultStore?.getAllForAgent(agentConfig.name);
+  const vault = resolveAgentVault(vaultEntries);
+
+  let allPolpoTools = createSystemTools(cwd, agentConfig.allowedTools, prep.effectiveAllowedPaths, prep.outputDir, vault, prep.fs, prep.shell);
+
+  if (prep.hasExtendedTools) {
+    allPolpoTools = await createAllTools({
+      cwd,
+      allowedTools: agentConfig.allowedTools,
+      allowedPaths: prep.effectiveAllowedPaths,
+      browserSession: agentConfig.name,
+      browserProfileDir: prep.browserProfileDir,
+      vault,
+      emailAllowedDomains: agentConfig.emailAllowedDomains ?? ctx?.emailAllowedDomains,
+      outputDir: prep.outputDir,
+      fs: prep.fs,
+      shell: prep.shell,
+      memoryStore: ctx?.memoryStore,
+      agentName: agentConfig.name,
+      // Per-modality models from agent config. When undefined, the
+      // tool layer applies its own DEFAULT_*_MODEL.
+      imageModel:      agentConfig.image_model,
+      videoModel:      agentConfig.video_model,
+      visionModel:     agentConfig.vision_model,
+      transcribeModel: agentConfig.transcribe_model,
+      ttsModel:        agentConfig.tts_model,
+    });
+  }
+
+  return allPolpoTools;
+}
+
+/**
+ * Spawn an agent using Polpo's built-in engine (AI SDK streamText loop).
+ *
+ * This is the default execution path — used when no adapter is specified
+ * on an agent config.
+ */
+export function spawnEngine(agentConfig: AgentConfig, task: Task, cwd: string, ctx?: SpawnContext): AgentHandle {
+  const activity = createActivity();
+  const start = Date.now();
+  let alive = true;
+
+  const prep = prepareSpawn(agentConfig, cwd, ctx);
+  const { model, systemPrompt, providerOptions, hasExtendedTools, maxTurns } = prep;
 
   // AbortController for the agent — used to cancel the loop
   const abortController = new AbortController();
@@ -479,49 +555,11 @@ export function spawnEngine(agentConfig: AgentConfig, task: Task, cwd: string, c
     },
   };
 
-  // Track turns for maxTurns enforcement
-  const maxTurns = agentConfig.maxTurns ?? 150;
-
-  // Provider options for reasoning/thinking
-  // Cast needed: mapReasoningToProviderOptions returns Record<string, Record<string, unknown>>
-  // but AI SDK expects Record<string, JSONObject> (JSONValue values). The values are always
-  // JSON-serializable (numbers, strings, objects), so this cast is safe.
-  const providerOptions = mapReasoningToProviderOptions(model.provider, thinkingLevel, model.maxTokens) as
-    Record<string, Record<string, any>> | undefined;
-
   // Run the agent and capture result
   handle.done = (async (): Promise<TaskResult> => {
     try {
-      // Resolve vault credentials (async) — then rebuild tools with vault included
-      const vaultEntries = await ctx?.vaultStore?.getAllForAgent(agentConfig.name);
-      const vault = resolveAgentVault(vaultEntries);
-
-      // Rebuild tools with vault resolved
-      let allPolpoTools = createSystemTools(cwd, agentConfig.allowedTools, effectiveAllowedPaths, outputDir, vault, fs, shell);
-
-      if (hasExtendedTools) {
-        allPolpoTools = await createAllTools({
-          cwd,
-          allowedTools: agentConfig.allowedTools,
-          allowedPaths: effectiveAllowedPaths,
-          browserSession: agentConfig.name,
-          browserProfileDir,
-          vault,
-          emailAllowedDomains: agentConfig.emailAllowedDomains ?? ctx?.emailAllowedDomains,
-          outputDir,
-          fs,
-          shell,
-          memoryStore: ctx?.memoryStore,
-          agentName: agentConfig.name,
-          // Per-modality models from agent config. When undefined, the
-          // tool layer applies its own DEFAULT_*_MODEL.
-          imageModel:      agentConfig.image_model,
-          videoModel:      agentConfig.video_model,
-          visionModel:     agentConfig.vision_model,
-          transcribeModel: agentConfig.transcribe_model,
-          ttsModel:        agentConfig.tts_model,
-        });
-      }
+      // Resolve vault credentials (async) and build the full tool set
+      const allPolpoTools = await buildAgentTools(agentConfig, cwd, prep, ctx);
 
       // Convert PolpoTool[] to AI SDK ToolSet with activity tracking
       const toolSet = convertToolsToToolSet(
@@ -778,7 +816,7 @@ function guessMime(filePath: string): string | undefined {
  * Create a TaskOutcome from a `register_outcome` tool call.
  * Returns undefined for any other tool — outcome registration is explicit only.
  */
-function collectOutcome(toolName: string, details: Record<string, unknown>): TaskOutcome | undefined {
+export function collectOutcome(toolName: string, details: Record<string, unknown>): TaskOutcome | undefined {
   if (toolName !== "register_outcome" || !details.outcomeType || !details.outcomeLabel) {
     return undefined;
   }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,1 +1,2 @@
 export { spawnEngine } from "./engine.js";
+export { spawnLoopEngine } from "./loop-engine.js";

--- a/src/adapters/loop-engine.ts
+++ b/src/adapters/loop-engine.ts
@@ -1,0 +1,362 @@
+/**
+ * Loop-engine — the task runtime driven by the core loop system.
+ *
+ * Same external contract as spawnEngine (AgentHandle in, TaskResult out),
+ * but the agentic loop is @polpo-ai/core's LoopRunner instead of a manual
+ * for-loop: the model callback does one streamText step (with compaction),
+ * and tool execution is dispatched by the LoopRunner through its
+ * tool:before/tool:after hook points — which is what makes per-tool
+ * gating, tracing, and (later) pipelines available to tasks.
+ *
+ * Setup semantics (model resolution, sandbox paths, system prompt, tool
+ * building) are shared with the legacy engine via prepareSpawn/
+ * buildAgentTools so the two stay byte-identical during the migration.
+ *
+ * Known deliberate differences from the legacy engine:
+ * - In a turn with MULTIPLE tool calls, transcript order is
+ *   use,use,...,result,result (the model step completes before execution)
+ *   instead of use,result interleaved. Single-call turns are identical.
+ */
+
+import type { AgentConfig, Task, TaskResult } from "../core/types.js";
+import type { AgentHandle, SpawnContext } from "../core/adapter.js";
+import {
+  streamText,
+  generateText,
+  jsonSchema,
+  tool as aiTool,
+  type ModelMessage,
+  type ToolSet,
+} from "ai";
+import { cleanupAgentBrowserSession } from "@polpo-ai/tools";
+import {
+  LoopRunner,
+  compactIfNeeded,
+  type SummarizeFn,
+  type CompactionEvent,
+  type LoopModelResult,
+  type PolpoTool,
+  type ToolResult,
+} from "@polpo-ai/core";
+import type { LoopToolCall } from "@polpo-ai/core";
+import {
+  createActivity,
+  prepareSpawn,
+  buildAgentTools,
+  buildPrompt,
+  collectOutcome,
+} from "./engine.js";
+
+/** Convert PolpoTool[] to a declaration-only AI SDK ToolSet (no execute —
+ *  execution is owned by the LoopRunner, not the model stream). */
+function toToolDeclarations(polpoTools: PolpoTool[]): ToolSet {
+  const toolSet: ToolSet = {};
+  for (const pt of polpoTools) {
+    toolSet[pt.name] = aiTool({
+      description: pt.description,
+      inputSchema: jsonSchema(pt.parameters as any),
+    });
+  }
+  return toolSet;
+}
+
+/**
+ * Spawn an agent on the loop runtime.
+ *
+ * Drop-in replacement for spawnEngine: same signature, same AgentHandle
+ * contract, same activity/transcript/outcome semantics.
+ */
+export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: string, ctx?: SpawnContext): AgentHandle {
+  const activity = createActivity();
+  const start = Date.now();
+  let alive = true;
+
+  const prep = prepareSpawn(agentConfig, cwd, ctx);
+  const { model, systemPrompt, providerOptions, hasExtendedTools, maxTurns } = prep;
+
+  const abortController = new AbortController();
+
+  const handle: AgentHandle = {
+    agentName: agentConfig.name,
+    taskId: task.id,
+    startedAt: new Date().toISOString(),
+    pid: 0, // No OS process — runs in-process
+    activity,
+    done: null as any, // set below
+    isAlive: () => alive,
+    kill: () => {
+      abortController.abort();
+      alive = false;
+    },
+  };
+
+  handle.done = (async (): Promise<TaskResult> => {
+    try {
+      const allPolpoTools = await buildAgentTools(agentConfig, cwd, prep, ctx);
+      const toolByName = new Map(allPolpoTools.map((t) => [t.name, t]));
+      const toolSet = toToolDeclarations(allPolpoTools);
+      const toolDescriptions = allPolpoTools.map((t) => ({ description: t.description ?? "" }));
+
+      // Conversation state owned by the host, exactly like the legacy loop.
+      let messages: ModelMessage[] = [{ role: "user", content: buildPrompt(task) }];
+      let lastStepText = "";
+
+      const summarize: SummarizeFn = async (msgs, compactionPrompt) => {
+        const response = await generateText({
+          model: model.aiModel,
+          system: compactionPrompt,
+          messages: msgs as ModelMessage[],
+          maxOutputTokens: model.maxTokens,
+          abortSignal: abortController.signal,
+          providerOptions,
+        });
+        return response.text;
+      };
+
+      // ── LoopRunner model callback: one streamText step per turn ──
+      const modelStep = async (): Promise<LoopModelResult> => {
+        // Abort between turns mirrors the legacy `if (aborted) break`:
+        // report no tool calls so the runner stops cleanly (exit 0).
+        if (abortController.signal.aborted) {
+          return { text: "", toolCalls: [] };
+        }
+
+        // Context compaction — same call, same config, same quirks as the
+        // legacy engine (see engine-behavior characterization tests).
+        const compactionResult = await compactIfNeeded({
+          systemPrompt,
+          messages,
+          tools: toolDescriptions,
+          config: {
+            contextWindow: model.contextWindow ?? 200_000,
+            maxOutputTokens: model.maxTokens ?? 8192,
+          },
+          summarize,
+          mode: "task",
+          onCompaction: (event: CompactionEvent) => {
+            handle.onTranscript?.({
+              type: "compaction",
+              phase: event.phase,
+              tokensBefore: event.tokensBefore,
+              tokensAfter: event.tokensAfter,
+              tokensReclaimed: event.tokensReclaimed,
+              messagesBefore: event.messagesBefore,
+              messagesAfter: event.messagesAfter,
+              toolOutputsPruned: event.toolOutputsPruned,
+              summary: event.summary,
+            });
+          },
+        });
+        if (compactionResult.compacted) {
+          messages = compactionResult.messages as ModelMessage[];
+        }
+
+        let stepUsage: unknown;
+        const stream = streamText({
+          model: model.aiModel,
+          system: systemPrompt,
+          messages,
+          tools: toolSet,
+          maxOutputTokens: model.maxTokens,
+          abortSignal: abortController.signal,
+          providerOptions,
+          onStepFinish: async ({ usage }) => {
+            if (usage) {
+              activity.totalTokens += (usage.totalTokens ?? 0);
+              stepUsage = usage;
+            }
+            activity.lastUpdate = new Date().toISOString();
+          },
+        });
+
+        let stepText = "";
+        const toolCalls: LoopToolCall[] = [];
+        for await (const part of stream.fullStream) {
+          switch (part.type) {
+            case "text-delta": {
+              stepText += part.text;
+              break;
+            }
+            case "tool-call": {
+              activity.toolCalls++;
+              activity.lastTool = part.toolName;
+              activity.lastUpdate = new Date().toISOString();
+              handle.onTranscript?.({
+                type: "tool_use",
+                tool: part.toolName,
+                toolId: part.toolCallId,
+                input: part.input,
+              });
+              toolCalls.push({
+                id: part.toolCallId,
+                name: part.toolName,
+                args: (part.input ?? {}) as Record<string, unknown>,
+              });
+              break;
+            }
+            case "error": {
+              handle.onTranscript?.({
+                type: "error",
+                message: part.error instanceof Error ? part.error.message : String(part.error),
+              });
+              break;
+            }
+          }
+        }
+
+        if (stepText) {
+          activity.summary = stepText.slice(0, 200);
+          handle.onTranscript?.({ type: "assistant", text: stepText });
+        }
+        lastStepText = stepText;
+
+        // On stream errors, `stream.text` throws the AI SDK "No output
+        // generated" error — awaiting it here preserves the legacy error
+        // path (exitCode 1 + that message in stderr).
+        if (toolCalls.length === 0) {
+          lastStepText = await stream.text;
+        }
+
+        // Append the assistant message (with its tool-call parts) to history.
+        const responseMessages = (await stream.response).messages;
+        messages.push(...responseMessages);
+
+        return { text: stepText, toolCalls, usage: stepUsage };
+      };
+
+      // ── LoopRunner tool executor: dispatch + activity + history ──
+      const executeTool = async (toolCall: LoopToolCall): Promise<string> => {
+        const pt = toolByName.get(toolCall.name);
+        let result: ToolResult;
+        let isError = false;
+
+        if (!pt) {
+          isError = true;
+          result = {
+            content: [{ type: "text", text: `Unknown tool: ${toolCall.name}` }],
+            details: {},
+          };
+        } else {
+          try {
+            result = await pt.execute(toolCall.id, toolCall.args, abortController.signal);
+          } catch (err) {
+            isError = true;
+            result = {
+              content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }],
+              details: {},
+            };
+          }
+        }
+
+        activity.lastUpdate = new Date().toISOString();
+
+        // Track file operations from tool details
+        const details = result.details;
+        if (details?.path) {
+          const filePath = details.path as string;
+          activity.lastFile = filePath;
+          if (toolCall.name === "write" && !activity.filesCreated.includes(filePath)) {
+            activity.filesCreated.push(filePath);
+          }
+          if (toolCall.name === "edit" && !activity.filesEdited.includes(filePath)) {
+            activity.filesEdited.push(filePath);
+          }
+        }
+
+        // Collect outcomes from explicit register_outcome calls
+        if (!isError && details) {
+          const outcome = collectOutcome(toolCall.name, details);
+          if (outcome) {
+            if (!handle.outcomes) handle.outcomes = [];
+            handle.outcomes.push(outcome);
+          }
+        }
+
+        // Harvest billable per-tool inference cost (managed image/video via
+        // the gateway). Rides back in `details.usage`; the cloud data plane
+        // reads activity.toolUsage after the run → Autumn + usage_logs.
+        if (!isError && details?.usage && typeof details.usage === "object") {
+          const u = details.usage as Record<string, unknown>;
+          if (u.generationId || typeof u.marketCostUsd === "number") {
+            (activity.toolUsage ??= []).push({
+              toolName: toolCall.name,
+              generationId: u.generationId as string | undefined,
+              marketCostUsd: u.marketCostUsd as number | undefined,
+              actualCostUsd: u.actualCostUsd as number | undefined,
+              resolvedModel: u.resolvedModel as string | undefined,
+              finalProvider: u.finalProvider as string | undefined,
+              credentialType: u.credentialType as string | undefined,
+            });
+          }
+        }
+
+        // Emit tool result transcript
+        const resultText = result.content
+          .map((c: any) => c.text ?? "")
+          .join("");
+        handle.onTranscript?.({
+          type: "tool_result",
+          toolId: toolCall.id,
+          tool: toolCall.name,
+          content: resultText.slice(0, 2000),
+          isError,
+        });
+
+        // Text returned to the LLM — same rendering as the legacy engine.
+        const llmText = result.content
+          .map((c) => c.type === "text" ? c.text : `[image: ${c.mimeType}]`)
+          .join("\n");
+
+        // Append the tool result to conversation history so the next model
+        // step sees it (the model stream no longer auto-executes tools).
+        messages.push({
+          role: "tool",
+          content: [{
+            type: "tool-result",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            output: isError
+              ? { type: "error-text" as const, value: llmText }
+              : { type: "text" as const, value: llmText },
+          }],
+        });
+
+        return llmText;
+      };
+
+      const runner = new LoopRunner();
+      await runner.run({
+        agent: agentConfig,
+        loop: { name: "default", maxTurns },
+        maxTurns,
+        model: modelStep,
+        executeTool,
+      });
+
+      alive = false;
+      return {
+        exitCode: 0,
+        stdout: lastStepText,
+        stderr: "",
+        duration: Date.now() - start,
+      };
+    } catch (err) {
+      alive = false;
+      const msg = err instanceof Error ? err.message : String(err);
+      handle.onTranscript?.({ type: "error", message: msg });
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: msg,
+        duration: Date.now() - start,
+      };
+    } finally {
+      // Close agent-browser session (profile data auto-persisted by --profile)
+      if (hasExtendedTools) {
+        await cleanupAgentBrowserSession(agentConfig.name).catch(() => {});
+      }
+    }
+  })();
+
+  return handle;
+}

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -16,6 +16,7 @@ import { readFileSync, unlinkSync, appendFileSync, mkdirSync, existsSync } from 
 import { join } from "node:path";
 import { FileRunStore } from "../stores/file-run-store.js";
 import { spawnEngine } from "../adapters/engine.js";
+import { spawnLoopEngine } from "../adapters/loop-engine.js";
 import type { RunStore, RunRecord } from "./run-store.js";
 import type { LogStore } from "./log-store.js";
 import type { RunnerConfig, TaskResult } from "./types.js";
@@ -217,7 +218,11 @@ async function main(): Promise<void> {
       fs: new NodeFileSystem(),
       shell: new NodeShell(),
     };
-    handle = spawnEngine(config.agent, config.task, config.cwd, spawnCtx);
+    // Task loop runs on the core loop runtime (LoopRunner). The legacy
+    // manual loop stays available behind POLPO_ENGINE=legacy as a rollback
+    // hatch until it is removed at the end of the migration.
+    const spawn = process.env.POLPO_ENGINE === "legacy" ? spawnEngine : spawnLoopEngine;
+    handle = spawn(config.agent, config.task, config.cwd, spawnCtx);
     // Propagate the LogStore sessionId onto the agent's activity blob so
     // the poll loop's updateActivity() persists it on every tick. Without
     // this the run record has activity.sessionId = undefined forever, and

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { FileTaskStore, FileRunStore, JsonTaskStore } from "./stores/index.js";
 
 // Engine
 export { spawnEngine } from "./adapters/engine.js";
+export { spawnLoopEngine } from "./adapters/loop-engine.js";
 
 // Assessment
 export { assessTask, runCheck, runMetric } from "./assessment/assessor.js";


### PR DESCRIPTION
Adds spawnLoopEngine (src/adapters/loop-engine.ts): a drop-in replacement for spawnEngine that drives the agentic task loop through @polpo-ai/core's LoopRunner instead of a hand-rolled for-loop, and switches src/core/runner.ts to it (POLPO_ENGINE=legacy rollback hatch until the stack completes).

- Tool execution goes through the runner's tool:before/tool:after hook points → unlocks per-tool gating, tracing, and pipelines for tasks
- engine.ts: extracted prepareSpawn/buildAgentTools (shared setup, byte-identical semantics)
- The characterization suite runs against BOTH engines (describe.each): 16/16 green = behavioral parity for transcript sequence, activity, outcomes, maxTurns, abort, error path, compaction

Known benign difference: multi-tool turns emit use,use,result,result instead of interleaved pairs.

Stacked on #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)