### PR TITLE
fix: compaction now sees AI SDK v6 tool messages

### DIFF
--- a/bench/results/2026-07-03T04-08-56-874Z-98c34c5-loop-runtime.json
+++ b/bench/results/2026-07-03T04-08-56-874Z-98c34c5-loop-runtime.json
@@ -1,0 +1,580 @@
+{
+  "meta": {
+    "ts": "2026-07-03T04:08:56.874Z",
+    "sha": "98c34c5",
+    "label": "loop-runtime",
+    "node": "v20.20.0",
+    "hostname": "aHp0",
+    "target": "local",
+    "mode": "local"
+  },
+  "scenarios": [
+    {
+      "name": "smoke",
+      "description": "1 assistant turn, no tools — pure spawn + single LLM round-trip",
+      "params": {
+        "turns": 0,
+        "toolsPerTurn": 0,
+        "latencyMs": 50,
+        "finalBytes": 200
+      },
+      "sid": "smr4ewvjiyqxz7y",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10063,
+        "spawn_ms": 4990,
+        "llm_ms": 50,
+        "overhead_ms": 10013,
+        "loop_ms": 0,
+        "loop_overhead_ms": 0,
+        "turns": 1,
+        "llm_requests": 1,
+        "tool_calls": 0,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 8
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 10
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4990
+        },
+        {
+          "status": "done",
+          "tMs": 10063
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 1, mock served 1"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 0, mock emitted 0"
+        }
+      ],
+      "elapsed_ms": 10065
+    },
+    {
+      "name": "tool_loop_50",
+      "description": "50 tool turns x 1 bash — sequential loop throughput",
+      "params": {
+        "turns": 50,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr4ex3b36tpvrp",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 9947,
+        "spawn_ms": 4974,
+        "llm_ms": 2550,
+        "overhead_ms": 7397,
+        "loop_ms": 3048,
+        "loop_overhead_ms": 498,
+        "turns": 51,
+        "llm_requests": 51,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 4
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 5
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4974
+        },
+        {
+          "status": "done",
+          "tMs": 9947
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 51, mock served 51"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        }
+      ],
+      "elapsed_ms": 9949
+    },
+    {
+      "name": "tool_burst",
+      "description": "10 tool turns x 5 bash/turn — parallel tool dispatch within a turn",
+      "params": {
+        "turns": 10,
+        "toolsPerTurn": 5,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr4exazg18s00l",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10044,
+        "spawn_ms": 5080,
+        "llm_ms": 550,
+        "overhead_ms": 9494,
+        "loop_ms": 777,
+        "loop_overhead_ms": 227,
+        "turns": 11,
+        "llm_requests": 11,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 1
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 5080
+        },
+        {
+          "status": "done",
+          "tMs": 10044
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 11, mock served 11"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        }
+      ],
+      "elapsed_ms": 10046
+    },
+    {
+      "name": "big_output",
+      "description": "30 tool turns x 1 bash with 64KB output — context growth / compaction stress",
+      "params": {
+        "turns": 30,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 65536,
+        "finalBytes": 500
+      },
+      "sid": "smr4exiqi6l7x12",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10039,
+        "spawn_ms": 4977,
+        "llm_ms": 1550,
+        "overhead_ms": 8489,
+        "loop_ms": 1902,
+        "loop_overhead_ms": 352,
+        "turns": 31,
+        "llm_requests": 31,
+        "tool_calls": 30,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 1
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4977
+        },
+        {
+          "status": "done",
+          "tMs": 10039
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 31, mock served 31"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 30, mock emitted 30"
+        }
+      ],
+      "elapsed_ms": 10041
+    },
+    {
+      "name": "max_turns_cap",
+      "description": "cap=never on agent with maxTurns=15 — runtime must stop the loop at the ceiling",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "cap": "never"
+      },
+      "sid": "smr4exqhf3yicjr",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 10041,
+        "spawn_ms": 4972,
+        "llm_ms": 750,
+        "overhead_ms": 9291,
+        "loop_ms": 870,
+        "loop_overhead_ms": 120,
+        "turns": 15,
+        "llm_requests": 15,
+        "tool_calls": 15,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 1
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4972
+        },
+        {
+          "status": "done",
+          "tMs": 10041
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done, failed], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 15, mock served 15"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 15, mock emitted 15"
+        }
+      ],
+      "elapsed_ms": 10042
+    },
+    {
+      "name": "outcomes_3",
+      "description": "5 tool turns + 3 register_outcome on the last turn — outcome pipeline",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "outcomes": 3
+      },
+      "sid": "smr4exy8donx5xu",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 9936,
+        "spawn_ms": 4973,
+        "llm_ms": 300,
+        "overhead_ms": 9636,
+        "loop_ms": 338,
+        "loop_overhead_ms": 38,
+        "turns": 6,
+        "llm_requests": 6,
+        "tool_calls": 5,
+        "outcome_calls": 3,
+        "summarize_calls": 0,
+        "post_ms": 2
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 4973
+        },
+        {
+          "status": "done",
+          "tMs": 9936
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 6, mock served 6"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 5, mock emitted 5"
+        },
+        {
+          "name": "outcomes",
+          "pass": true,
+          "detail": "expected 3, task record has 3"
+        }
+      ],
+      "elapsed_ms": 9937
+    },
+    {
+      "name": "timeout_kill",
+      "description": "cap=never + task maxDuration=8s — watchdog must kill and fail the task",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 300,
+        "cap": "never"
+      },
+      "sid": "smr4ey5wep188j4",
+      "pass": true,
+      "terminal": "failed",
+      "metrics": {
+        "wall_ms": 20061,
+        "spawn_ms": 5065,
+        "llm_ms": 9600,
+        "overhead_ms": 10461,
+        "loop_ms": 9642,
+        "loop_overhead_ms": 42,
+        "turns": 32,
+        "llm_requests": 32,
+        "tool_calls": 32,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 2
+      },
+      "timeline": [
+        {
+          "status": "pending",
+          "tMs": 2
+        },
+        {
+          "status": "in_progress",
+          "tMs": 5065
+        },
+        {
+          "status": "failed",
+          "tMs": 20061
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "failed"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [failed], got \"failed\""
+        }
+      ],
+      "elapsed_ms": 20062
+    },
+    {
+      "name": "concurrency_10",
+      "description": "10 concurrent tasks x 5 tool turns — scheduler fan-out + makespan",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "concurrency": 10,
+      "pass": true,
+      "terminal": [
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done"
+      ],
+      "metrics": {
+        "makespan_ms": 10137,
+        "wall_ms_min": 10136,
+        "wall_ms_median": 10136,
+        "wall_ms_max": 10137,
+        "llm_ms_total": 3000,
+        "spawn_ms_min": 5058,
+        "spawn_ms_max": 5059
+      },
+      "checks": [
+        {
+          "name": "all_tasks_pass",
+          "pass": true,
+          "detail": "10/10 tasks green"
+        }
+      ],
+      "tasks": [
+        {
+          "sid": "smr4eyldod3vsju",
+          "wall_ms": 10137,
+          "spawn_ms": 5059,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldovvu43h",
+          "wall_ms": 10137,
+          "spawn_ms": 5059,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldprfx2rl",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldps2poyv",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldp48veof",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldpxkq4gz",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldpf64sf3",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldpwn95zk",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldpnrpmng",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4eyldpo2gwxc",
+          "wall_ms": 10136,
+          "spawn_ms": 5058,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        }
+      ],
+      "elapsed_ms": 10350
+    }
+  ]
+}

--- a/packages/core/src/__tests__/context-compactor.test.ts
+++ b/packages/core/src/__tests__/context-compactor.test.ts
@@ -399,3 +399,117 @@ describe("constants", () => {
     expect(TARGET_AFTER).toBe(0.50);
   });
 });
+
+// ── AI SDK v6 message shapes ────────────────────────────────────────────
+//
+// The runtime (loop-engine tasks, completions) speaks AI SDK v6
+// ModelMessages: assistant tool calls are `{type:"tool-call", toolCallId,
+// toolName, input}` parts, tool results are `role:"tool"` messages with
+// `{type:"tool-result", toolCallId, toolName, output:{type,value}}` parts.
+// Estimation and pruning must see them, or compaction never fires on
+// tool-heavy tasks (the historical bug pinned in engine-behavior.test.ts).
+
+function v6ToolMsg(id: string, toolName: string, value: string) {
+  return {
+    role: "tool",
+    content: [{
+      type: "tool-result",
+      toolCallId: id,
+      toolName,
+      output: { type: "text" as const, value },
+    }],
+  };
+}
+
+describe("AI SDK v6 shapes — estimation", () => {
+  it("counts assistant tool-call input tokens", () => {
+    const tokens = estimateMessagesTokens([
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "c1", toolName: "bash", input: { command: "x".repeat(4000) } }],
+      },
+    ]);
+    expect(tokens).toBeGreaterThan(900);
+  });
+
+  it("counts tool-result output tokens", () => {
+    const tokens = estimateMessagesTokens([v6ToolMsg("c1", "bash", "y".repeat(8000))]);
+    expect(tokens).toBeGreaterThan(1900);
+  });
+
+  it("counts non-text tool-result outputs by stringification", () => {
+    const tokens = estimateMessagesTokens([
+      {
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId: "c1", toolName: "bash", output: { type: "json", value: { rows: "z".repeat(2000) } } }],
+      },
+    ]);
+    expect(tokens).toBeGreaterThan(400);
+  });
+});
+
+describe("AI SDK v6 shapes — pruning", () => {
+  const config: CompactionConfig = {
+    contextWindow: 200_000,
+    maxOutputTokens: 4_000,
+    pruneProtect: 500,
+    pruneMinimum: 500,
+  };
+
+  it("prunes old v6 tool results and preserves the message envelope", () => {
+    const messages = [
+      v6ToolMsg("c1", "oldTool", "x".repeat(8000)),    // ~2000 tokens, prunable
+      // ~600 tokens: fills the 500-token protect window on its own, so the
+      // older entry above falls outside it (the walk protects entries until
+      // the cumulative total reaches pruneProtect).
+      v6ToolMsg("c2", "recentTool", "y".repeat(2400)),
+    ];
+    const result = pruneToolOutputs(messages, config);
+
+    const pruned = result[0].content[0];
+    expect(result[0].role).toBe("tool");
+    expect(pruned.type).toBe("tool-result");
+    expect(pruned.toolCallId).toBe("c1"); // envelope intact for the provider
+    expect(pruned.output.type).toBe("text");
+    expect(pruned.output.value).toContain("[Output pruned");
+    expect(pruned.output.value).toContain("Tool: oldTool");
+
+    // Recent output protected
+    expect(result[1].content[0].output.value).toBe("y".repeat(2400));
+    // Original untouched
+    expect(messages[0].content[0].output.value).toBe("x".repeat(8000));
+  });
+
+  it("compactIfNeeded resolves tool-heavy v6 history with the prune phase", async () => {
+    const summarize = vi.fn(async () => "SUMMARY");
+    const events: Array<{ phase: string; toolOutputsPruned: number }> = [];
+
+    const result = await compactIfNeeded({
+      systemPrompt: "",
+      messages: [
+        { role: "user", content: "run the pipeline" },
+        v6ToolMsg("c1", "bash", "a".repeat(8000)), // ~2000 tokens
+        v6ToolMsg("c2", "bash", "b".repeat(8000)), // ~2000 tokens
+        v6ToolMsg("c3", "bash", "c".repeat(4000)), // ~1000 tokens, protected
+      ],
+      tools: [],
+      config: {
+        contextWindow: 4000,
+        maxOutputTokens: 500,
+        pruneProtect: 500,
+        pruneMinimum: 500,
+      },
+      summarize,
+      mode: "task",
+      onCompaction: (e) => events.push({ phase: e.phase, toolOutputsPruned: e.toolOutputsPruned ?? 0 }),
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
+    // Prune alone reclaims enough — no LLM summarization needed
+    expect(summarize).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0].phase).toBe("prune");
+    expect(events[0].toolOutputsPruned).toBe(2);
+  });
+});

--- a/packages/core/src/context-compactor.ts
+++ b/packages/core/src/context-compactor.ts
@@ -135,6 +135,19 @@ export function estimateMessagesTokens(messages: any[]): number {
   return total;
 }
 
+/** Render an AI SDK v6 tool-result `output` to text for token estimation
+ *  and pruning ({type:"text"|"error-text", value} | {type:"json", value} | …). */
+function toolResultOutputText(output: any): string {
+  if (output == null) return "";
+  if (typeof output === "string") return output;
+  if (typeof output.value === "string") return output.value;
+  try {
+    return JSON.stringify(output.value ?? output) ?? "";
+  } catch {
+    return "";
+  }
+}
+
 function estimateMessageTokens(msg: any): number {
   if (!msg) return 0;
 
@@ -149,7 +162,7 @@ function estimateMessageTokens(msg: any): number {
       if (block.type === "text" && typeof block.text === "string") {
         tokens += estimateTokens(block.text);
       } else if (block.type === "toolCall") {
-        // Tool call: name + stringified arguments
+        // Legacy (pi-ai) tool call: name + stringified arguments
         if (block.name) tokens += estimateTokens(block.name);
         if (block.arguments !== undefined) {
           const args =
@@ -158,6 +171,19 @@ function estimateMessageTokens(msg: any): number {
               : JSON.stringify(block.arguments);
           tokens += estimateTokens(args);
         }
+      } else if (block.type === "tool-call") {
+        // AI SDK v6 assistant tool-call part: toolName + input
+        if (block.toolName) tokens += estimateTokens(block.toolName);
+        if (block.input !== undefined) {
+          const input =
+            typeof block.input === "string"
+              ? block.input
+              : JSON.stringify(block.input) ?? "";
+          tokens += estimateTokens(input);
+        }
+      } else if (block.type === "tool-result") {
+        // AI SDK v6 tool-result part (role:"tool" messages)
+        tokens += estimateTokens(toolResultOutputText(block.output));
       }
     }
   }
@@ -195,6 +221,9 @@ export function pruneToolOutputs(
     blockIndex?: number; // for array content within toolResult messages
     tokens: number;
     toolName: string;
+    /** Message shape: legacy pi-ai "toolResult" text blocks vs AI SDK v6
+     *  role:"tool" tool-result parts. Determines how pruning is applied. */
+    shape: "legacy" | "v6";
   }
 
   const entries: ToolResultEntry[] = [];
@@ -213,6 +242,24 @@ export function pruneToolOutputs(
             blockIndex: j,
             tokens,
             toolName,
+            shape: "legacy",
+          });
+        }
+      }
+    } else if (msg.role === "tool" && Array.isArray(msg.content)) {
+      // AI SDK v6 tool message: prune the output value inside the
+      // tool-result part while keeping the envelope (toolCallId/toolName)
+      // intact so the conversation stays valid for providers.
+      for (let j = msg.content.length - 1; j >= 0; j--) {
+        const block = msg.content[j];
+        if (block.type === "tool-result") {
+          const tokens = estimateTokens(toolResultOutputText(block.output));
+          entries.push({
+            messageIndex: i,
+            blockIndex: j,
+            tokens,
+            toolName: block.toolName || "unknown",
+            shape: "v6",
           });
         }
       }
@@ -245,11 +292,15 @@ export function pruneToolOutputs(
   // Apply pruning
   for (const entry of prunableEntries) {
     const msg = result[entry.messageIndex];
-    if (entry.blockIndex !== undefined && Array.isArray(msg.content)) {
+    if (entry.blockIndex === undefined || !Array.isArray(msg.content)) continue;
+    const placeholder = `[Output pruned — was ${entry.tokens} tokens. Tool: ${entry.toolName}]`;
+    if (entry.shape === "v6") {
       msg.content[entry.blockIndex] = {
-        type: "text",
-        text: `[Output pruned — was ${entry.tokens} tokens. Tool: ${entry.toolName}]`,
+        ...msg.content[entry.blockIndex],
+        output: { type: "text", value: placeholder },
       };
+    } else {
+      msg.content[entry.blockIndex] = { type: "text", text: placeholder };
     }
   }
 
@@ -390,6 +441,16 @@ function countPrunedOutputs(messages: any[]): number {
     if (msg.role === "toolResult" && Array.isArray(msg.content)) {
       for (const block of msg.content) {
         if (block.type === "text" && typeof block.text === "string" && block.text.startsWith("[Output pruned")) {
+          count++;
+        }
+      }
+    } else if (msg.role === "tool" && Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (
+          block.type === "tool-result" &&
+          typeof block.output?.value === "string" &&
+          block.output.value.startsWith("[Output pruned")
+        ) {
           count++;
         }
       }

--- a/src/__tests__/engine-behavior.test.ts
+++ b/src/__tests__/engine-behavior.test.ts
@@ -284,18 +284,13 @@ describe.each(ENGINES)("%s — characterization", (_label, spawn) => {
   });
 
   test("compaction: fires once multi-turn history exists over the window", async () => {
-    // Characterization of the CURRENT trigger, with two known quirks pinned
-    // on purpose (they are findings, not features — the loop-engine must
-    // change them deliberately, not silently):
-    // 1. A single over-threshold user message never emits an event
-    //    (splitIndex <= 0 short-circuit in compactIfNeeded).
-    // 2. estimateMessageTokens only counts "text" and legacy "toolCall"
-    //    blocks — AI SDK v6 "tool-call"/"tool-result" parts are NOT counted,
-    //    so tool outputs never contribute to the estimate and compaction on
-    //    tool-heavy tasks effectively never triggers. The only reliably
-    //    counted mass is the system prompt + string user messages.
-    // Therefore: an over-threshold task DESCRIPTION + one tool turn makes
-    // the summarize phase observable at turn 1.
+    // Characterization of the trigger, with one known quirk pinned on
+    // purpose: a single over-threshold user message never emits an event
+    // (splitIndex <= 0 short-circuit in compactIfNeeded). Estimation of
+    // AI SDK v6 tool-call/tool-result parts was historically broken (tool
+    // outputs were never counted) — fixed in context-compactor and covered
+    // by its own tests; here an over-threshold task DESCRIPTION + one tool
+    // turn makes the summarize phase observable at turn 1.
     const { result, transcript } = await runEngine(
       makeAgent(),
       [


### PR DESCRIPTION
estimateMessageTokens, pruneToolOutputs, and countPrunedOutputs only recognized the legacy pi-ai shapes (toolCall blocks, role:"toolResult" messages). Since the AI SDK migration the runtime speaks v6 ModelMessages, so tool outputs were invisible to token estimation and Phase-1 pruning was a no-op: compaction on tool-heavy tasks effectively never fired and long tasks could blow the context window.

- estimation counts v6 tool-call input and tool-result output (any output shape)
- pruning replaces the output value inside the tool-result part, keeping the toolCallId/toolName envelope intact so providers still accept the history
- pruned-output accounting covers both shapes
- legacy shapes remain supported; all pre-existing tests untouched and green

Stacked on #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)