### PR TITLE
feat: event-driven orchestrator tick

### DIFF
--- a/bench/results/2026-07-03T04-34-04-085Z-14529b2-reactive-tick.json
+++ b/bench/results/2026-07-03T04-34-04-085Z-14529b2-reactive-tick.json
@@ -1,0 +1,552 @@
+{
+  "meta": {
+    "ts": "2026-07-03T04:34:04.085Z",
+    "sha": "14529b2",
+    "label": "reactive-tick",
+    "node": "v20.20.0",
+    "hostname": "aHp0",
+    "target": "local",
+    "mode": "local"
+  },
+  "scenarios": [
+    {
+      "name": "smoke",
+      "description": "1 assistant turn, no tools — pure spawn + single LLM round-trip",
+      "params": {
+        "turns": 0,
+        "toolsPerTurn": 0,
+        "latencyMs": 50,
+        "finalBytes": 200
+      },
+      "sid": "smr4funi0e3ch0q",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 536,
+        "spawn_ms": 20,
+        "llm_ms": 50,
+        "overhead_ms": 486,
+        "loop_ms": 0,
+        "loop_overhead_ms": 0,
+        "turns": 1,
+        "llm_requests": 1,
+        "tool_calls": 0,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 17
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 20
+        },
+        {
+          "status": "done",
+          "tMs": 536
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 1, mock served 1"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 0, mock emitted 0"
+        }
+      ],
+      "elapsed_ms": 539
+    },
+    {
+      "name": "tool_loop_50",
+      "description": "50 tool turns x 1 bash — sequential loop throughput",
+      "params": {
+        "turns": 50,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr4funwz6gstw5",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 3574,
+        "spawn_ms": 13,
+        "llm_ms": 2550,
+        "overhead_ms": 1024,
+        "loop_ms": 3116,
+        "loop_overhead_ms": 566,
+        "turns": 51,
+        "llm_requests": 51,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 8
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 13
+        },
+        {
+          "status": "done",
+          "tMs": 3574
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 51, mock served 51"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        }
+      ],
+      "elapsed_ms": 3577
+    },
+    {
+      "name": "tool_burst",
+      "description": "10 tool turns x 5 bash/turn — parallel tool dispatch within a turn",
+      "params": {
+        "turns": 10,
+        "toolsPerTurn": 5,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr4fuqocgrpf65",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 1226,
+        "spawn_ms": 8,
+        "llm_ms": 550,
+        "overhead_ms": 676,
+        "loop_ms": 835,
+        "loop_overhead_ms": 285,
+        "turns": 11,
+        "llm_requests": 11,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 7
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 8
+        },
+        {
+          "status": "done",
+          "tMs": 1226
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 11, mock served 11"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        }
+      ],
+      "elapsed_ms": 1227
+    },
+    {
+      "name": "big_output",
+      "description": "30 tool turns x 1 bash with 64KB output — context growth / compaction stress",
+      "params": {
+        "turns": 30,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 65536,
+        "finalBytes": 500
+      },
+      "sid": "smr4furmfmxoivi",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 2342,
+        "spawn_ms": 7,
+        "llm_ms": 1550,
+        "overhead_ms": 792,
+        "loop_ms": 1920,
+        "loop_overhead_ms": 370,
+        "turns": 31,
+        "llm_requests": 31,
+        "tool_calls": 30,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 6
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 7
+        },
+        {
+          "status": "done",
+          "tMs": 2342
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 31, mock served 31"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 30, mock emitted 30"
+        }
+      ],
+      "elapsed_ms": 2343
+    },
+    {
+      "name": "max_turns_cap",
+      "description": "cap=never on agent with maxTurns=15 — runtime must stop the loop at the ceiling",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "cap": "never"
+      },
+      "sid": "smr4futfivga8v9",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 1328,
+        "spawn_ms": 10,
+        "llm_ms": 750,
+        "overhead_ms": 578,
+        "loop_ms": 896,
+        "loop_overhead_ms": 146,
+        "turns": 15,
+        "llm_requests": 15,
+        "tool_calls": 15,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 9
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 10
+        },
+        {
+          "status": "done",
+          "tMs": 1328
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done, failed], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 15, mock served 15"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 15, mock emitted 15"
+        }
+      ],
+      "elapsed_ms": 1329
+    },
+    {
+      "name": "outcomes_3",
+      "description": "5 tool turns + 3 register_outcome on the last turn — outcome pipeline",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "outcomes": 3
+      },
+      "sid": "smr4fuugf43zbqc",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 716,
+        "spawn_ms": 8,
+        "llm_ms": 300,
+        "overhead_ms": 416,
+        "loop_ms": 350,
+        "loop_overhead_ms": 50,
+        "turns": 6,
+        "llm_requests": 6,
+        "tool_calls": 5,
+        "outcome_calls": 3,
+        "summarize_calls": 0,
+        "post_ms": 7
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 8
+        },
+        {
+          "status": "done",
+          "tMs": 716
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 6, mock served 6"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 5, mock emitted 5"
+        },
+        {
+          "name": "outcomes",
+          "pass": true,
+          "detail": "expected 3, task record has 3"
+        }
+      ],
+      "elapsed_ms": 717
+    },
+    {
+      "name": "timeout_kill",
+      "description": "cap=never + task maxDuration=8s — watchdog must kill and fail the task",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 300,
+        "cap": "never"
+      },
+      "sid": "smr4fuv0c4kwah1",
+      "pass": true,
+      "terminal": "failed",
+      "metrics": {
+        "wall_ms": 10065,
+        "spawn_ms": 6,
+        "llm_ms": 9300,
+        "overhead_ms": 765,
+        "loop_ms": 9666,
+        "loop_overhead_ms": 366,
+        "turns": 31,
+        "llm_requests": 32,
+        "tool_calls": 31,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 6
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 6
+        },
+        {
+          "status": "failed",
+          "tMs": 10065
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "failed"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [failed], got \"failed\""
+        }
+      ],
+      "elapsed_ms": 10067
+    },
+    {
+      "name": "concurrency_10",
+      "description": "10 concurrent tasks x 5 tool turns — scheduler fan-out + makespan",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "concurrency": 10,
+      "pass": true,
+      "terminal": [
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done"
+      ],
+      "metrics": {
+        "makespan_ms": 1808,
+        "wall_ms_min": 1606,
+        "wall_ms_median": 1808,
+        "wall_ms_max": 1808,
+        "llm_ms_total": 3000,
+        "spawn_ms_min": 151,
+        "spawn_ms_max": 152
+      },
+      "checks": [
+        {
+          "name": "all_tasks_pass",
+          "pass": true,
+          "detail": "10/10 tasks green"
+        }
+      ],
+      "tasks": [
+        {
+          "sid": "smr4fv2rz9fqrl0",
+          "wall_ms": 1607,
+          "spawn_ms": 152,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2rzn1ps8p",
+          "wall_ms": 1607,
+          "spawn_ms": 152,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2rzpkwusg",
+          "wall_ms": 1606,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2s0yng97l",
+          "wall_ms": 1808,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2s0e7dab9",
+          "wall_ms": 1808,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2s08px2ed",
+          "wall_ms": 1808,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2s0yefq71",
+          "wall_ms": 1606,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2s0gjn8tk",
+          "wall_ms": 1808,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2s0zew2fu",
+          "wall_ms": 1808,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        },
+        {
+          "sid": "smr4fv2s09y8ged",
+          "wall_ms": 1808,
+          "spawn_ms": 151,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6
+        }
+      ],
+      "elapsed_ms": 2022
+    }
+  ]
+}

--- a/packages/core/src/__tests__/tick-waiter.test.ts
+++ b/packages/core/src/__tests__/tick-waiter.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TickWaiter } from "../tick-waiter.js";
+
+describe("TickWaiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves after the interval when never woken", async () => {
+    const waiter = new TickWaiter();
+    let resolved = false;
+    const p = waiter.wait(5000).then(() => { resolved = true; });
+
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves immediately on wake() during the wait", async () => {
+    const waiter = new TickWaiter();
+    let resolved = false;
+    const p = waiter.wait(5000).then(() => { resolved = true; });
+
+    await vi.advanceTimersByTimeAsync(100);
+    waiter.wake();
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it("a wake before the wait (in-flight tick) consumes the next wait", async () => {
+    const waiter = new TickWaiter();
+    waiter.wake(); // arrives while no wait is active
+
+    let resolved = false;
+    const p = waiter.wait(5000).then(() => { resolved = true; });
+    await p; // resolves without advancing timers
+    expect(resolved).toBe(true);
+
+    // The pending wake is consumed: the following wait behaves normally
+    let second = false;
+    waiter.wait(5000).then(() => { second = true; });
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(second).toBe(false);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(second).toBe(true);
+  });
+
+  it("multiple wakes coalesce into one", async () => {
+    const waiter = new TickWaiter();
+    waiter.wake();
+    waiter.wake();
+    waiter.wake();
+
+    await waiter.wait(5000); // immediate (pending wake)
+
+    // Only ONE pending wake was stored — next wait runs the full interval
+    let second = false;
+    waiter.wait(5000).then(() => { second = true; });
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(second).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(second).toBe(true);
+  });
+
+  it("wake after a completed wait arms the next one (no lost signals)", async () => {
+    const waiter = new TickWaiter();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const first = waiter.wait(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await first;
+
+    waiter.wake(); // between waits
+    let resolved = false;
+    waiter.wait(5000).then(() => { resolved = true; });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+});

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -34,6 +34,10 @@ export interface PolpoEventMap {
   "orchestrator:deadlock": { taskIds: string[] };
   "orchestrator:shutdown": Record<string, never>;
 
+  // Runner process lifecycle (local spawners only — sandbox spawners
+  // don't track process exit and rely on poll-based collection)
+  "run:exited": { taskId: string; runId: string; pid: number };
+
   // Retry & Fix
   "task:retry": { taskId: string; attempt: number; maxRetries: number };
   "task:retry:blocked": { taskId: string; reason: string };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,7 @@ export { TaskRunner } from "./task-runner.js";
 
 // ── OrchestratorEngine ──────────────────────────────────────────────────
 export { OrchestratorEngine } from "./orchestrator-engine.js";
+export { TickWaiter } from "./tick-waiter.js";
 export type {
   OrchestratorEngineDeps,
   TaskRunnerPort,

--- a/packages/core/src/orchestrator-engine.ts
+++ b/packages/core/src/orchestrator-engine.ts
@@ -12,6 +12,7 @@
  */
 
 import type { OrchestratorContext } from "./orchestrator-context.js";
+import { TickWaiter } from "./tick-waiter.js";
 import type { TaskManager } from "./task-manager.js";
 import type { AgentManager } from "./agent-manager.js";
 import type { ApprovalManager } from "./approval-manager.js";
@@ -180,11 +181,21 @@ export interface OrchestratorEngineDeps {
 
 // ── Utility ──────────────────────────────────────────────────────────────
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+const POLL_INTERVAL = 5000; // 5s safety net — event wakes are the primary trigger
 
-const POLL_INTERVAL = 5000; // 5s safety net (push notification is primary)
+/**
+ * Events that wake the supervisor loop immediately instead of waiting out
+ * the poll interval: new/changed work (task lifecycle), answered questions,
+ * resolved approvals, and runner process exits.
+ */
+const WAKE_EVENTS = [
+  "task:created",
+  "task:updated",
+  "task:transition",
+  "task:answered",
+  "approval:resolved",
+  "run:exited",
+] as const;
 
 // ── OrchestratorEngine ──────────────────────────────────────────────────
 
@@ -209,6 +220,7 @@ export class OrchestratorEngine {
   private escalationMgr?: EscalationManager;
   private deadlockResolver?: DeadlockResolverPort;
   private stopped = false;
+  private readonly waiter = new TickWaiter();
 
   constructor(deps: OrchestratorEngineDeps) {
     this.ctx = deps.ctx;
@@ -253,19 +265,37 @@ export class OrchestratorEngine {
     this.stopped = false;
     onBeforeLoop?.();
 
-    // Supervisor loop
-    while (!this.stopped) {
-      try {
-        const allDone = await this.tick();
-        if (allDone && !interactive) break;
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        this.ctx.emitter.emit("log", { level: "error", message: `[supervisor] Error in tick: ${message}` });
-      }
-      await sleep(POLL_INTERVAL);
+    // Event-driven wakes: react to new work immediately; the poll interval
+    // below is only the safety net. A wake landing while a tick is in
+    // flight is remembered by the waiter and consumes the next wait.
+    const onWake = (): void => this.waiter.wake();
+    for (const event of WAKE_EVENTS) {
+      this.ctx.emitter.on(event, onWake);
     }
 
-    onAfterLoop?.();
+    try {
+      // Supervisor loop
+      while (!this.stopped) {
+        try {
+          const allDone = await this.tick();
+          if (allDone && !interactive) break;
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.ctx.emitter.emit("log", { level: "error", message: `[supervisor] Error in tick: ${message}` });
+        }
+        await this.waiter.wait(POLL_INTERVAL);
+      }
+    } finally {
+      for (const event of WAKE_EVENTS) {
+        this.ctx.emitter.off(event, onWake);
+      }
+      onAfterLoop?.();
+    }
+  }
+
+  /** Wake the supervisor loop immediately (event-driven tick). */
+  wake(): void {
+    this.waiter.wake();
   }
 
   /**
@@ -480,7 +510,11 @@ export class OrchestratorEngine {
 
   // ── Stop control ────────────────────────────────────────────────────
 
-  stop(): void { this.stopped = true; }
+  stop(): void {
+    this.stopped = true;
+    // Interrupt the current wait so shutdown is immediate
+    this.waiter.wake();
+  }
   isStopped(): boolean { return this.stopped; }
 
   // ── Task Management (delegates to TaskManager) ──────────────────────

--- a/packages/core/src/spawner.ts
+++ b/packages/core/src/spawner.ts
@@ -17,6 +17,13 @@ export interface SpawnResult {
   pid: number;
   /** Where the config was persisted ("file:///path" or "db://runId"). */
   configPath: string;
+  /**
+   * Register a callback fired when the runner process exits (optional —
+   * spawners that don't track process lifecycle, e.g. sandbox-based ones,
+   * simply omit it and callers fall back to poll-based collection).
+   * If the process already exited, the callback fires immediately.
+   */
+  onExit?(cb: () => void): void;
 }
 
 /**

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -506,6 +506,13 @@ export class TaskRunner {
       };
       await this.ctx.runStore.upsertRun(runRecord);
 
+      // Wake the supervisor as soon as the runner process exits so results
+      // are collected immediately (poll interval remains the safety net for
+      // spawners that don't track process lifecycle).
+      spawnResult.onExit?.(() => {
+        this.ctx.emitter.emit("run:exited", { taskId: task.id, runId, pid: spawnResult.pid });
+      });
+
       this.ctx.emitter.emit("agent:spawned", {
         taskId: task.id,
         agentName: agent.name,

--- a/packages/core/src/tick-waiter.ts
+++ b/packages/core/src/tick-waiter.ts
@@ -1,0 +1,40 @@
+/**
+ * TickWaiter — interruptible delay for the supervisor loop.
+ *
+ * The orchestrator ticks on a fixed safety-net interval, but external
+ * signals (task created, runner exited, approval resolved) can wake the
+ * loop immediately so new work is picked up without waiting out the
+ * interval. A wake that arrives while a tick is in flight (no wait
+ * active) is remembered and consumes the NEXT wait, so no signal is
+ * ever lost.
+ */
+export class TickWaiter {
+  private pendingWake = false;
+  private resolveWait: (() => void) | undefined;
+
+  /** Wake the current wait immediately, or arm the next one. */
+  wake(): void {
+    if (this.resolveWait) {
+      this.resolveWait();
+    } else {
+      this.pendingWake = true;
+    }
+  }
+
+  /** Wait up to `ms`, resolving early on wake(). */
+  wait(ms: number): Promise<void> {
+    if (this.pendingWake) {
+      this.pendingWake = false;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const finish = (): void => {
+        clearTimeout(timer);
+        this.resolveWait = undefined;
+        resolve();
+      };
+      const timer = setTimeout(finish, ms);
+      this.resolveWait = finish;
+    });
+  }
+}

--- a/src/__tests__/integration/lifecycle.test.ts
+++ b/src/__tests__/integration/lifecycle.test.ts
@@ -9,7 +9,12 @@ vi.mock("node:child_process", async (importOriginal) => {
   return {
     ...original,
     spawn: (_cmd: string, _args: string[], _opts: any) => {
-      const child = { pid: Math.floor(Math.random() * 90000) + 10000, unref: () => {} };
+      const child = {
+        pid: Math.floor(Math.random() * 90000) + 10000,
+        unref: () => {},
+        // NodeSpawner registers an exit listener for event-driven collection
+        on: (_event: string, _cb: () => void) => child,
+      };
       return child;
     },
   };

--- a/src/adapters/node-spawner.ts
+++ b/src/adapters/node-spawner.ts
@@ -61,11 +61,25 @@ export class NodeSpawner implements Spawner {
       stdio: "ignore",
       cwd: this.cwd,
     });
+
+    // Track process exit so the orchestrator can collect results
+    // immediately instead of waiting out the poll interval. The listener
+    // works on detached+unref'd children as long as this process lives.
+    let exited = false;
+    const exitCallbacks: Array<() => void> = [];
+    child.on("exit", () => {
+      exited = true;
+      for (const cb of exitCallbacks.splice(0)) cb();
+    });
     child.unref();
 
     return {
       pid: child.pid ?? 0,
       configPath,
+      onExit: (cb: () => void) => {
+        if (exited) cb();
+        else exitCallbacks.push(cb);
+      },
     };
   }
 


### PR DESCRIPTION
The supervisor loop slept a fixed 5s between ticks, so every task paid ~2 poll intervals of dead time (spawn pickup + result collection): a 1-turn task walled ~10s regardless of actual work. The "push notification is primary" design note in the engine was never implemented.

- **TickWaiter** (core): interruptible wait — `wake()` resolves the current wait immediately; a wake landing mid-tick is remembered and consumes the next wait (no lost signals). Unit-tested with fake timers.
- The engine subscribes to work signals (`task:created/updated/transition/answered`, `approval:resolved`, `run:exited`) and wakes; the 5s interval remains as the safety-net heartbeat.
- New `run:exited` event: NodeSpawner tracks child exit (`SpawnResult.onExit`, optional in the port — sandbox spawners keep poll-based collection, cloud unaffected).
- `stop()` wakes the loop so shutdown is immediate.

Bench (same suite, same invariants, 8/8 green — result committed):

| scenario | before | after |
|---|---|---|
| smoke | 10066ms | **536ms** |
| outcomes_3 | 10031ms | **716ms** |
| tool_loop_50 | 9947ms | **3574ms** (work-bound) |
| concurrency_10 makespan | 10137ms | **1808ms** |
| spawn_ms | ~5000 | **~10** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)