### PR TITLE
fix: custom providers work for task agents

### DIFF
--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -483,6 +483,7 @@ export class TaskRunner {
       reasoning: this.ctx.config.settings.reasoning,
       whatsappDbPath,
       whatsappProfilePath,
+      providers: this.ctx.config.providers,
     };
 
     try {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -630,6 +630,13 @@ export interface RunnerConfig {
   whatsappDbPath?: string;
   /** WhatsApp Baileys profile path (for whatsapp_send — creates a temporary connection). */
   whatsappProfilePath?: string;
+  /**
+   * Provider overrides from polpo.json (custom baseUrl endpoints: Ollama,
+   * vLLM, proxies). The runner subprocess never reads polpo.json, so the
+   * overrides must travel with the config or custom-provider agents break
+   * inside the runner.
+   */
+  providers?: Record<string, ProviderConfig>;
 }
 
 // === Polpo File Config (.polpo/polpo.json — persistent project configuration) ===

--- a/packages/llm/src/model-resolver.test.ts
+++ b/packages/llm/src/model-resolver.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  validateProviderKeys,
+  validateProviderKeysDetailed,
+  setProviderOverrides,
+} from "./model-resolver.js";
+
+// A provider name that certainly has no env key, no OAuth profile, and no
+// entry in the static PROVIDER_ENV_MAP.
+const CUSTOM = "bench-custom";
+
+afterEach(() => {
+  setProviderOverrides({});
+});
+
+describe("validateProviderKeys — custom provider overrides", () => {
+  it("flags an unknown provider without key as missing", () => {
+    const missing = validateProviderKeys([`${CUSTOM}/some-model`]);
+    expect(missing).toEqual([{ provider: CUSTOM, modelSpec: `${CUSTOM}/some-model` }]);
+  });
+
+  it("accepts a provider with a baseUrl override (no env key required)", () => {
+    setProviderOverrides({ [CUSTOM]: { baseUrl: "http://127.0.0.1:9999/v1" } });
+    const missing = validateProviderKeys([`${CUSTOM}/some-model`]);
+    expect(missing).toEqual([]);
+  });
+
+  it("an override WITHOUT baseUrl does not satisfy the key requirement", () => {
+    setProviderOverrides({ [CUSTOM]: { models: [] } as any });
+    const missing = validateProviderKeys([`${CUSTOM}/some-model`]);
+    expect(missing).toHaveLength(1);
+  });
+});
+
+describe("validateProviderKeysDetailed — custom provider overrides", () => {
+  it("reports hasKey=true when a baseUrl override exists", () => {
+    setProviderOverrides({ [CUSTOM]: { baseUrl: "http://127.0.0.1:9999/v1" } });
+    const results = validateProviderKeysDetailed([`${CUSTOM}/some-model`]);
+    expect(results).toHaveLength(1);
+    expect(results[0].hasKey).toBe(true);
+  });
+
+  it("reports hasKey=false without an override", () => {
+    const results = validateProviderKeysDetailed([`${CUSTOM}/some-model`]);
+    expect(results[0].hasKey).toBe(false);
+  });
+});

--- a/packages/llm/src/model-resolver.ts
+++ b/packages/llm/src/model-resolver.ts
@@ -476,6 +476,10 @@ export function validateProviderKeys(
     if (seen.has(provider)) continue;
     seen.add(provider);
 
+    // Custom providers with a baseUrl override (Ollama, vLLM, proxies)
+    // don't require an env API key — the factory falls back to a dummy key.
+    if (getProviderOverrides()[provider]?.baseUrl) continue;
+
     if (!resolveApiKey(provider) && !hasOAuthProfiles(provider)) {
       missing.push({ provider, modelSpec: spec });
     }
@@ -497,10 +501,13 @@ export function validateProviderKeysDetailed(
     if (seen.has(provider)) continue;
     seen.add(provider);
 
+    const hasBaseUrlOverride = !!getProviderOverrides()[provider]?.baseUrl;
     results.push({
       provider,
       modelSpec: spec,
-      hasKey: !!resolveApiKey(provider),
+      // A baseUrl override satisfies the requirement: custom endpoints
+      // work without an env API key.
+      hasKey: hasBaseUrlOverride || !!resolveApiKey(provider),
       envVar: PROVIDER_ENV_MAP[provider],
     });
   }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -158,6 +158,14 @@ async function createStores(config: RunnerConfig): Promise<RunnerStores> {
 async function main(): Promise<void> {
   const isDbMode = process.argv.includes("--run-id");
   const config = isDbMode ? await readConfigFromDb() : readConfigFromFile();
+
+  // Apply provider overrides from the config (custom baseUrl endpoints).
+  // The runner never reads polpo.json, so without this custom-provider
+  // agents resolve against the static provider map and fail.
+  if (config.providers && Object.keys(config.providers).length > 0) {
+    const { setProviderOverrides } = await import("../llm/pi-client.js");
+    setProviderOverrides(config.providers);
+  }
   const { runStore, logStore, vaultStore: drizzleVaultStore, memoryStore: drizzleMemoryStore } = await createStores(config);
   const actLog = new RunActivityLog(config.polpoDir, config.runId, config.taskId, config.agent.name);
 


### PR DESCRIPTION
Two bugs found by the bench suite kept custom baseUrl providers (Ollama, vLLM, proxies, mocks) from running task agents:

1. **Pre-spawn validation** only consulted the static `PROVIDER_ENV_MAP`, so a provider with a `baseUrl` override failed "Missing API key" even though the factory needs no key for custom endpoints. `validateProviderKeys`/`validateProviderKeysDetailed` now treat a baseUrl override as satisfied.
2. **Provider overrides never reached the runner subprocess** (`RunnerConfig` had no `providers` field and the runner doesn't read polpo.json). Overrides now travel in `RunnerConfig` and the runner applies them via `setProviderOverrides` before spawning the engine.

Unit tests added (packages/llm). The bench suite's preload workaround becomes unnecessary with this fix (kept, harmless no-op).

Stacked on #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)