### PR TITLE
refactor: canonical MissionStore contract

### DIFF
--- a/packages/core/src/__tests__/mission-store.test.ts
+++ b/packages/core/src/__tests__/mission-store.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  taskStoreMissionAdapter,
+  resolveMissionStore,
+  resolveMissionForTask,
+  type MissionStore,
+} from "../mission-store.js";
+import type { TaskStore } from "../task-store.js";
+import type { Mission } from "../types.js";
+
+const mission = (id: string, name: string): Mission =>
+  ({ id, name, data: "", status: "active", createdAt: "", updatedAt: "" }) as Mission;
+
+function storeWithMissions(): TaskStore {
+  const byId = new Map([["m1", mission("m1", "Launch")]]);
+  return {
+    getMission: async (id: string) => byId.get(id),
+    getMissionByName: async (name: string) => [...byId.values()].find((m) => m.name === name),
+    getAllMissions: async () => [...byId.values()],
+  } as unknown as TaskStore;
+}
+
+function storeWithoutMissions(): TaskStore {
+  return {} as TaskStore;
+}
+
+describe("taskStoreMissionAdapter", () => {
+  it("delegates reads and degrades gracefully on missing read methods", async () => {
+    const withMissions = taskStoreMissionAdapter(storeWithMissions());
+    expect((await withMissions.getMission("m1"))?.name).toBe("Launch");
+    expect((await withMissions.getMissionByName("Launch"))?.id).toBe("m1");
+    expect(await withMissions.getAllMissions()).toHaveLength(1);
+
+    const without = taskStoreMissionAdapter(storeWithoutMissions());
+    expect(await without.getMission("m1")).toBeUndefined();
+    expect(await without.getAllMissions()).toEqual([]);
+  });
+
+  it("throws descriptive errors for writes on stores without mission support", async () => {
+    const adapter = taskStoreMissionAdapter(storeWithoutMissions());
+    await expect(adapter.saveMission({} as never)).rejects.toThrow("Store does not support missions");
+    await expect(adapter.updateMission("m1", {})).rejects.toThrow("Store does not support missions");
+    await expect(adapter.deleteMission("m1")).rejects.toThrow("Store does not support missions");
+  });
+
+  it("nextMissionName falls back to a generated name", async () => {
+    const adapter = taskStoreMissionAdapter(storeWithoutMissions());
+    expect(await adapter.nextMissionName()).toMatch(/^mission-\d+$/);
+  });
+});
+
+describe("resolveMissionStore", () => {
+  it("prefers the explicit missionStore port", async () => {
+    const explicit = { getMission: async () => mission("mx", "Explicit") } as unknown as MissionStore;
+    const resolved = resolveMissionStore({ missionStore: explicit, registry: storeWithMissions() });
+    expect((await resolved.getMission("whatever"))?.name).toBe("Explicit");
+  });
+
+  it("falls back to the task-store adapter", async () => {
+    const resolved = resolveMissionStore({ registry: storeWithMissions() });
+    expect((await resolved.getMission("m1"))?.name).toBe("Launch");
+  });
+});
+
+describe("resolveMissionForTask — legacy fallback in one place", () => {
+  const missions = taskStoreMissionAdapter(storeWithMissions());
+
+  it("prefers the missionId FK", async () => {
+    const m = await resolveMissionForTask(missions, { missionId: "m1", group: "ignored" });
+    expect(m?.id).toBe("m1");
+  });
+
+  it("falls back to group-name lookup for legacy tasks", async () => {
+    const m = await resolveMissionForTask(missions, { group: "Launch" });
+    expect(m?.id).toBe("m1");
+  });
+
+  it("returns undefined for tasks outside any mission", async () => {
+    expect(await resolveMissionForTask(missions, {})).toBeUndefined();
+  });
+});

--- a/packages/core/src/assessment-orchestrator.ts
+++ b/packages/core/src/assessment-orchestrator.ts
@@ -8,6 +8,7 @@
  */
 
 import type { OrchestratorContext } from "./orchestrator-context.js";
+import { resolveMissionStore, resolveMissionForTask } from "./mission-store.js";
 import type { Task, TaskResult, AssessmentResult, TaskExpectation, ReviewContext, ModelConfig } from "./types.js";
 import { setAssessment } from "./types.js";
 import { buildFixPrompt, buildRetryPrompt, buildSideEffectFixPrompt, buildSideEffectRetryPrompt, buildJudgePrompt, type JudgeVerdict, type JudgeCorrection } from "./assessment-prompts.js";
@@ -802,9 +803,7 @@ export class AssessmentOrchestrator {
 
     // Don't retry tasks from cancelled missions — resolve via missionId (direct FK) first
     if (current.group) {
-      const mission = current.missionId
-        ? await this.ctx.registry.getMission?.(current.missionId)
-        : await this.ctx.registry.getMissionByName?.(current.group);
+      const mission = await resolveMissionForTask(resolveMissionStore(this.ctx), current);
       if (mission && mission.status === "cancelled") {
         this.ctx.emitter.emit("log", { level: "debug", message: `[${taskId}] Skipping retry — mission cancelled` });
         await this.ctx.registry.transition(taskId, "failed");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,10 @@ export { TaskRunner } from "./task-runner.js";
 export { OrchestratorEngine } from "./orchestrator-engine.js";
 export { TickWaiter } from "./tick-waiter.js";
 
+// ── Mission store (canonical mission persistence contract) ──────────────
+export { taskStoreMissionAdapter, resolveMissionStore, resolveMissionForTask } from "./mission-store.js";
+export type { MissionStore } from "./mission-store.js";
+
 // ── Vault resolver (shared by shell, tools, and the cloud data plane) ────
 export {
   resolveEnvVar,

--- a/packages/core/src/mission-executor.ts
+++ b/packages/core/src/mission-executor.ts
@@ -5,6 +5,7 @@ import type { Mission, MissionStatus, MissionReport, Task, TaskExpectation, Expe
 import type { QualityController } from "./quality-controller.js";
 import { sanitizeExpectations, parseMissionDocument, type MissionDocumentParsed } from "./schemas.js";
 import type { CheckpointStore, CheckpointState } from "./checkpoint-store.js";
+import { resolveMissionStore, type MissionStore } from "./mission-store.js";
 import type { DelayStore, DelayState } from "./delay-store.js";
 // ── In-memory fallback stores (no Node.js deps) ─────────────────────────
 
@@ -52,6 +53,7 @@ export class MissionExecutor {
   /** Quality gates parsed from mission documents, keyed by mission group name */
   private gatesByGroup = new Map<string, MissionQualityGate[]>();
   /** Persistent checkpoint store — survives server restarts */
+  private missions: MissionStore;
   private cpStore: CheckpointStore;
   /** In-memory mirror of persisted checkpoint state (synced on every mutation) */
   private cpState!: CheckpointState;
@@ -70,6 +72,7 @@ export class MissionExecutor {
     private taskMgr: TaskManager,
     private agentMgr: AgentManager,
   ) {
+    this.missions = resolveMissionStore(ctx);
     this.cpStore = ctx.checkpointStore ?? new InMemoryCheckpointStore();
     this.delayStore = ctx.delayStore ?? new InMemoryDelayStore();
 
@@ -164,10 +167,10 @@ export class MissionExecutor {
         // Pause the mission — use task.missionId when available
         const taskMissionId = tasks.find(t => t.group === group && t.missionId)?.missionId;
         const mission = taskMissionId
-          ? await this.ctx.registry.getMission?.(taskMissionId)
-          : await this.ctx.registry.getMissionByName?.(group);
+          ? await this.missions.getMission(taskMissionId)
+          : await this.missions.getMissionByName(group);
         if (mission && mission.status === "active") {
-          await this.ctx.registry.updateMission?.(mission.id, { status: "paused" });
+          await this.missions.updateMission(mission.id, { status: "paused" });
         }
 
         // Register notification rules for this checkpoint's channels
@@ -209,7 +212,7 @@ export class MissionExecutor {
     const groupTasks = (await this.ctx.registry.getAllTasks()).filter(t => t.group === group);
     const mission = await this.resolveMissionForGroup(groupTasks, group);
     if (mission && mission.status === "paused") {
-      await this.ctx.registry.updateMission?.(mission.id, { status: "active" });
+      await this.missions.updateMission(mission.id, { status: "active" });
     }
 
     this.ctx.emitter.emit("checkpoint:resumed", {
@@ -370,9 +373,8 @@ export class MissionExecutor {
     /** Opaque end-user identifier (OpenAI-compat). */
     user?: string;
   }): Promise<Mission> {
-    if (!this.ctx.registry.saveMission) throw new Error("Store does not support missions");
-    const name = opts.name ?? (await this.ctx.registry.nextMissionName?.()) ?? `mission-${Date.now()}`;
-    const mission = await this.ctx.registry.saveMission({
+    const name = opts.name ?? await this.missions.nextMissionName();
+    const mission = await this.missions.saveMission({
       name,
       data: opts.data,
       prompt: opts.prompt,
@@ -388,24 +390,22 @@ export class MissionExecutor {
   }
 
   async getMission(missionId: string): Promise<Mission | undefined> {
-    return this.ctx.registry.getMission?.(missionId);
+    return this.missions.getMission(missionId);
   }
 
   async getMissionByName(name: string): Promise<Mission | undefined> {
-    return this.ctx.registry.getMissionByName?.(name);
+    return this.missions.getMissionByName(name);
   }
 
   async getAllMissions(): Promise<Mission[]> {
-    return (await this.ctx.registry.getAllMissions?.()) ?? [];
+    return await this.missions.getAllMissions();
   }
 
   async updateMission(missionId: string, updates: Partial<Omit<Mission, "id">>): Promise<Mission> {
-    if (!this.ctx.registry.updateMission) throw new Error("Store does not support missions");
-    return this.ctx.registry.updateMission(missionId, updates);
+    return this.missions.updateMission(missionId, updates);
   }
 
   async deleteMission(missionId: string): Promise<boolean> {
-    if (!this.ctx.registry.deleteMission) throw new Error("Store does not support missions");
     const mission = await this.getMission(missionId);
     if (!mission) return false;
 
@@ -456,7 +456,7 @@ export class MissionExecutor {
     }
 
     // ── Delete the mission record ────────────────────────
-    const result = await this.ctx.registry.deleteMission(missionId);
+    const result = await this.missions.deleteMission(missionId);
     if (result) {
       this.ctx.emitter.emit("mission:deleted", { missionId, deletedTasks });
     }
@@ -524,7 +524,7 @@ export class MissionExecutor {
   }
 
   async executeMission(missionId: string): Promise<{ tasks: Task[]; group: string }> {
-    const mission = await this.ctx.registry.getMission?.(missionId);
+    const mission = await this.missions.getMission(missionId);
     if (!mission) throw new Error("Mission not found");
     const executableStates = ["draft", "scheduled", "recurring", "failed", "cancelled"];
     if (!executableStates.includes(mission.status)) {
@@ -535,7 +535,7 @@ export class MissionExecutor {
 
     // Increment execution count (tracks how many times this mission has run — useful for recurring)
     const runNumber = (mission.executionCount ?? 0) + 1;
-    await this.ctx.registry.updateMission?.(missionId, { executionCount: runNumber });
+    await this.missions.updateMission(missionId, { executionCount: runNumber });
 
     // Validate mission document through Zod schema — throws with clear error on invalid shape
     const raw = JSON.parse(mission.data);
@@ -648,10 +648,10 @@ export class MissionExecutor {
 
     // Persist mission-level notifications from document onto the Mission record
     if (doc.notifications) {
-      await this.ctx.registry.updateMission?.(missionId, { status: "active", notifications: doc.notifications });
+      await this.missions.updateMission(missionId, { status: "active", notifications: doc.notifications });
     } else {
       // Mark mission as active
-      await this.ctx.registry.updateMission?.(missionId, { status: "active" });
+      await this.missions.updateMission(missionId, { status: "active" });
     }
     this.ctx.emitter.emit("mission:executed", { missionId, group, taskCount: tasks.length });
 
@@ -666,9 +666,9 @@ export class MissionExecutor {
   private async resolveMissionForGroup(groupTasks: Task[], group: string): Promise<Mission | undefined> {
     // Prefer the direct ID reference from any task in the group
     const mid = groupTasks.find(t => t.missionId)?.missionId;
-    if (mid) return this.ctx.registry.getMission?.(mid);
+    if (mid) return this.missions.getMission(mid);
     // Fallback: strip run-number suffix (e.g. "Mission #3" → "Mission") for legacy compat
-    return this.ctx.registry.getMissionByName?.(group.replace(/ #\d+$/, ""));
+    return this.missions.getMissionByName(group.replace(/ #\d+$/, ""));
   }
 
   /** Check if any mission groups have all tasks terminal, and clean up their volatile agents */
@@ -731,7 +731,7 @@ export class MissionExecutor {
           // Normal missions or successful one-shot scheduled missions
           finalStatus = allDone ? "completed" : "failed";
         }
-        await this.ctx.registry.updateMission?.(mission.id, { status: finalStatus });
+        await this.missions.updateMission(mission.id, { status: finalStatus });
         const report = await this.buildMissionReport(mission.id, group, groupTasks, allDone);
         this.ctx.emitter.emit("mission:completed", { missionId: mission.id, group, allPassed: allDone, report });
 

--- a/packages/core/src/mission-store.ts
+++ b/packages/core/src/mission-store.ts
@@ -1,0 +1,75 @@
+/**
+ * MissionStore — canonical persistence contract for missions.
+ *
+ * Historically missions were bolted onto TaskStore as OPTIONAL methods,
+ * which forced every consumer into defensive `store.getMission?.()` calls
+ * and left "does this deployment support missions?" implicit. This module
+ * makes the contract explicit:
+ *
+ * - `MissionStore` is the non-optional interface.
+ * - `taskStoreMissionAdapter` adapts the legacy TaskStore mission block to
+ *   it (missing write methods throw descriptive errors on use).
+ * - `resolveMissionStore(ctx)` picks the explicit port when a runtime
+ *   provides one, otherwise falls back to the task-store adapter.
+ * - `resolveMissionForTask` is the ONE home of the missionId/group legacy
+ *   fallback (tasks created before the missionId FK existed resolve their
+ *   mission by group name).
+ */
+
+import type { Mission } from "./types.js";
+import type { TaskStore } from "./task-store.js";
+
+export interface MissionStore {
+  saveMission(mission: Omit<Mission, "id" | "createdAt" | "updatedAt">): Promise<Mission>;
+  getMission(missionId: string): Promise<Mission | undefined>;
+  getMissionByName(name: string): Promise<Mission | undefined>;
+  getAllMissions(): Promise<Mission[]>;
+  updateMission(missionId: string, updates: Partial<Omit<Mission, "id">>): Promise<Mission>;
+  deleteMission(missionId: string): Promise<boolean>;
+  nextMissionName(): Promise<string>;
+}
+
+/**
+ * Adapt a TaskStore's legacy (optional) mission methods to the canonical
+ * MissionStore contract. Reads degrade gracefully (undefined / empty);
+ * writes on a store without mission support throw a descriptive error.
+ */
+export function taskStoreMissionAdapter(store: TaskStore): MissionStore {
+  const unsupported = (): never => {
+    throw new Error("Store does not support missions");
+  };
+  return {
+    saveMission: async (mission) => store.saveMission ? store.saveMission(mission) : unsupported(),
+    getMission: async (missionId) => store.getMission?.(missionId),
+    getMissionByName: async (name) => store.getMissionByName?.(name),
+    getAllMissions: async () => (await store.getAllMissions?.()) ?? [],
+    updateMission: async (missionId, updates) =>
+      store.updateMission ? store.updateMission(missionId, updates) : unsupported(),
+    deleteMission: async (missionId) => store.deleteMission ? store.deleteMission(missionId) : unsupported(),
+    nextMissionName: async () => (await store.nextMissionName?.()) ?? `mission-${Date.now()}`,
+  };
+}
+
+/**
+ * Resolve the mission store for an orchestrator context: the explicit
+ * `missionStore` port when the runtime provides one, otherwise the
+ * task-store adapter (legacy layout — file and Drizzle task stores both
+ * implement the mission block).
+ */
+export function resolveMissionStore(ctx: { missionStore?: MissionStore; registry: TaskStore }): MissionStore {
+  return ctx.missionStore ?? taskStoreMissionAdapter(ctx.registry);
+}
+
+/**
+ * Resolve the mission a task belongs to — the single home of the legacy
+ * fallback: `missionId` (direct FK) is preferred; tasks created before the
+ * missionId field resolve by `group` name.
+ */
+export async function resolveMissionForTask(
+  missions: MissionStore,
+  task: { missionId?: string; group?: string },
+): Promise<Mission | undefined> {
+  if (task.missionId) return missions.getMission(task.missionId);
+  if (task.group) return missions.getMissionByName(task.group);
+  return undefined;
+}

--- a/packages/core/src/orchestrator-context.ts
+++ b/packages/core/src/orchestrator-context.ts
@@ -14,6 +14,7 @@ import type { ApprovalStore } from "./approval-store.js";
 import type { CheckpointStore } from "./checkpoint-store.js";
 import type { DelayStore } from "./delay-store.js";
 import type { ConfigStore } from "./config-store.js";
+import type { MissionStore } from "./mission-store.js";
 import type { TeamStore } from "./team-store.js";
 import type { AgentStore } from "./agent-store.js";
 import type { PolpoConfig, PolpoFileConfig, Task, AssessmentResult, ReviewContext, ReasoningLevel, ModelConfig } from "./types.js";
@@ -103,4 +104,9 @@ export interface OrchestratorContext {
   readonly delayStore?: DelayStore;
   /** Config persistence store (when storage is "postgres", injected by shell). */
   readonly configStore?: ConfigStore;
+  /**
+   * Mission persistence store. When omitted, consumers fall back to the
+   * task store's legacy mission block via resolveMissionStore(ctx).
+   */
+  readonly missionStore?: MissionStore;
 }

--- a/packages/core/src/orchestrator-engine.ts
+++ b/packages/core/src/orchestrator-engine.ts
@@ -13,6 +13,7 @@
 
 import type { OrchestratorContext } from "./orchestrator-context.js";
 import { TickWaiter } from "./tick-waiter.js";
+import { resolveMissionStore, resolveMissionForTask } from "./mission-store.js";
 import type { TaskManager } from "./task-manager.js";
 import type { AgentManager } from "./agent-manager.js";
 import type { ApprovalManager } from "./approval-manager.js";
@@ -342,9 +343,7 @@ export class OrchestratorEngine {
       let isReady = true;
       if (task.group) {
         // Resolve mission via direct ID (preferred) or group name (legacy fallback)
-        const mission = task.missionId
-          ? await this.ctx.registry.getMission?.(task.missionId)
-          : await this.ctx.registry.getMissionByName?.(task.group);
+        const mission = await resolveMissionForTask(resolveMissionStore(this.ctx), task);
         if (mission && (mission.status === "cancelled" || mission.status === "completed" || mission.status === "paused")) { isReady = false; }
 
         // Check quality gates — task may be blocked by a gate even if deps are done
@@ -539,7 +538,7 @@ export class OrchestratorEngine {
     // Clean up any schedule tied to this mission group — resolve via task.missionId first
     const groupTasks = (await this.ctx.registry.getAllTasks()).filter(t => t.group === group);
     const mid = groupTasks.find(t => t.missionId)?.missionId;
-    const mission = mid ? await this.ctx.registry.getMission?.(mid) : await this.ctx.registry.getMissionByName?.(group);
+    const mission = await resolveMissionForTask(resolveMissionStore(this.ctx), { missionId: mid, group });
     if (mission) this.scheduler?.unregisterMission(mission.id);
     return count;
   }

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -1,4 +1,5 @@
 import type { OrchestratorContext } from "./orchestrator-context.js";
+import { resolveMissionStore } from "./mission-store.js";
 import type { ScheduleEntry, Mission } from "./types.js";
 import { isCronExpression, nextCronOccurrence } from "./cron.js";
 
@@ -27,7 +28,7 @@ export class Scheduler {
   }
 
   async init(): Promise<void> {
-    const missions = await this.ctx.registry.getAllMissions?.() ?? [];
+    const missions = await resolveMissionStore(this.ctx).getAllMissions();
     const terminalStates = new Set(["completed", "cancelled", "draft"]);
     for (const mission of missions) {
       if (!mission.schedule) continue;
@@ -36,7 +37,7 @@ export class Scheduler {
     }
 
     this.missionCompletedHandler = async ({ missionId }) => {
-      const mission = await this.ctx.registry.getMission?.(missionId);
+      const mission = await resolveMissionStore(this.ctx).getMission(missionId);
       if (!mission?.schedule) return;
       if (mission.status === "recurring" || mission.status === "scheduled") {
         this.registerMission(mission);
@@ -113,7 +114,7 @@ export class Scheduler {
   }
 
   private async triggerSchedule(schedId: string, entry: ScheduleEntry): Promise<void> {
-    const mission = await this.ctx.registry.getMission?.(entry.missionId);
+    const mission = await resolveMissionStore(this.ctx).getMission(entry.missionId);
     if (!mission) {
       entry.enabled = false;
       return;
@@ -128,7 +129,7 @@ export class Scheduler {
       if (Date.now() >= endTime) {
         entry.enabled = false;
         entry.nextRunAt = undefined;
-        await this.ctx.registry.updateMission?.(entry.missionId, { status: "completed" });
+        await resolveMissionStore(this.ctx).updateMission(entry.missionId, { status: "completed" });
         this.ctx.emitter.emit("schedule:expired", {
           scheduleId: schedId,
           missionId: entry.missionId,

--- a/packages/core/src/sla-monitor.ts
+++ b/packages/core/src/sla-monitor.ts
@@ -1,4 +1,5 @@
 import type { OrchestratorContext } from "./orchestrator-context.js";
+import { resolveMissionStore } from "./mission-store.js";
 import type { SLAConfig } from "./types.js";
 
 /**
@@ -68,7 +69,7 @@ export class SLAMonitor {
       await this.checkEntity(task.id, "task", task.deadline, task.createdAt, now);
     }
 
-    const missions = await this.ctx.registry.getAllMissions?.() ?? [];
+    const missions = await resolveMissionStore(this.ctx).getAllMissions();
     for (const mission of missions) {
       if (!mission.deadline) continue;
       if (mission.status === "completed" || mission.status === "failed" || mission.status === "cancelled" ||

--- a/packages/core/src/task-manager.ts
+++ b/packages/core/src/task-manager.ts
@@ -1,4 +1,5 @@
 import type { OrchestratorContext } from "./orchestrator-context.js";
+import { resolveMissionStore, resolveMissionForTask } from "./mission-store.js";
 import type { Task, TaskExpectation, ExpectedOutcome, RetryPolicy, ReviewContext, ScopedNotificationRules } from "./types.js";
 import { setAssessment } from "./types.js";
 import { sanitizeExpectations } from "./schemas.js";
@@ -246,11 +247,10 @@ export class TaskManager {
     }
     // Resolve mission via task.missionId (direct FK) first, fallback to group name
     const mid = groupTasks.find(t => t.missionId)?.missionId;
-    const mission = mid
-      ? await this.ctx.registry.getMission?.(mid)
-      : await this.ctx.registry.getMissionByName?.(group);
+    const missions = resolveMissionStore(this.ctx);
+    const mission = await resolveMissionForTask(missions, { missionId: mid, group });
     if (mission && mission.status === "active") {
-      await this.ctx.registry.updateMission?.(mission.id, { status: "cancelled" });
+      await missions.updateMission(mission.id, { status: "cancelled" });
     }
     return count;
   }

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
 import type { OrchestratorContext } from "./orchestrator-context.js";
+import { resolveMissionStore, resolveMissionForTask } from "./mission-store.js";
 import type { Task, TaskResult, RunnerConfig } from "./types.js";
 import { agentMemoryScope } from "./memory-store.js";
 import type { RunRecord } from "./run-store.js";
@@ -418,9 +419,7 @@ export class TaskRunner {
     if (task.group) {
       try {
         // Resolve mission via direct ID (preferred) or group name (legacy fallback)
-        const mission = task.missionId
-          ? await this.ctx.registry.getMission?.(task.missionId)
-          : await this.ctx.registry.getMissionByName?.(task.group);
+        const mission = await resolveMissionForTask(resolveMissionStore(this.ctx), task);
         const missionParts: string[] = [];
 
         // Original user prompt that generated this mission (the "why")

--- a/packages/core/src/task-store.ts
+++ b/packages/core/src/task-store.ts
@@ -30,12 +30,21 @@ export interface TaskStore {
   // Lifecycle
   close?(): Promise<void> | void;
 
-  // Mission persistence (optional)
+  // Mission persistence (legacy layout). The canonical contract is the
+  // MissionStore interface (mission-store.ts) — consumers should go through
+  // resolveMissionStore(ctx) rather than calling these optionals directly.
+  /** @deprecated Implement/consume MissionStore (mission-store.ts) instead. */
   saveMission?(mission: Omit<Mission, "id" | "createdAt" | "updatedAt">): Promise<Mission>;
+  /** @deprecated Implement/consume MissionStore (mission-store.ts) instead. */
   getMission?(missionId: string): Promise<Mission | undefined>;
+  /** @deprecated Implement/consume MissionStore (mission-store.ts) instead. */
   getMissionByName?(name: string): Promise<Mission | undefined>;
+  /** @deprecated Implement/consume MissionStore (mission-store.ts) instead. */
   getAllMissions?(): Promise<Mission[]>;
+  /** @deprecated Implement/consume MissionStore (mission-store.ts) instead. */
   updateMission?(missionId: string, updates: Partial<Omit<Mission, "id">>): Promise<Mission>;
+  /** @deprecated Implement/consume MissionStore (mission-store.ts) instead. */
   deleteMission?(missionId: string): Promise<boolean>;
+  /** @deprecated Implement/consume MissionStore (mission-store.ts) instead. */
   nextMissionName?(): Promise<string>;
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -13,7 +13,7 @@ import type { MemoryStore } from "./memory-store.js";
 import type { LogStore } from "./log-store.js";
 import { assessTask } from "../assessment/assessor.js";
 import { analyzeBlockedTasks, resolveDeadlock, isResolving } from "./deadlock-resolver.js";
-import { OrchestratorEngine } from "@polpo-ai/core";
+import { OrchestratorEngine, resolveMissionStore } from "@polpo-ai/core";
 import type { DeadlockResolverPort, DeadlockFacade } from "@polpo-ai/core";
 import { TypedEmitter } from "./events.js";
 import type { TaskStore } from "./task-store.js";
@@ -508,7 +508,7 @@ export class Orchestrator extends TypedEmitter {
           return `Task created: [${task.id}] "${task.title}" → ${task.assignTo}`;
         }
         case "execute_mission": {
-          const mission = await this.registry.getMission?.(action.missionId);
+          const mission = await resolveMissionStore({ registry: this.registry }).getMission(action.missionId);
           if (!mission) throw new Error(`Mission "${action.missionId}" not found`);
           const result = await this.missionExec.executeMission(action.missionId);
           return `Mission "${mission.name}" executed: ${result.tasks.length} tasks created`;


### PR DESCRIPTION
Missions were bolted onto TaskStore as seven OPTIONAL methods, forcing every consumer into defensive `store.getMission?.()` calls and leaving "does this deployment support missions?" implicit.

- **MissionStore**: the non-optional interface (core/mission-store.ts)
- **taskStoreMissionAdapter**: adapts the legacy TaskStore mission block (reads degrade gracefully, writes throw descriptive errors)
- **resolveMissionStore(ctx)**: explicit `missionStore` port when provided (new optional port on OrchestratorContext), task-store adapter otherwise — zero breaking changes for the cloud
- **resolveMissionForTask**: the ONE home of the missionId/group legacy fallback (was copy-pasted in five places)
- All core consumers and the shell migrate off the optional calls; TaskStore's mission block is `@deprecated` for one release cycle

Third piece of the store-contract cleanup from the July architecture assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)