### PR TITLE
Release v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/file-stores/package.json
+++ b/packages/file-stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/file-stores",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "File-based store implementations for Polpo — the default zero-dependency persistence backend (JSON/Markdown files)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump 0.10.13 → 0.11.0 across all 11 packages (includes the new @polpo-ai/file-stores).

Highlights since 0.10.13:
- **Single agent loop**: tasks run on the core LoopRunner; project loop graphs (.polpo/loops/) work in tasks; legacy manual loop removed
- **Event-driven tick**: task wall time drops from ~10s fixed to work-bound (smoke: 536ms, spawn: ~10ms)
- **Compaction fixed** for AI SDK v6 tool messages (tool-heavy tasks now actually compact)
- Custom baseUrl providers work for task agents
- Canonical vault resolver + MissionStore contracts, idempotent `migratePgSchema` (cloud can drop its 3 local copies)
- New `@polpo-ai/file-stores` package; turborepo build graph; runtime-agnostic bench suite in `bench/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)