### PR TITLE
fix: restore NPM token on the core publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Pack all workspace packages
         run: |
           pnpm --filter @polpo-ai/core pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/file-stores pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/vault-crypto pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/drizzle pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/llm pack --pack-destination /tmp/tarballs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Publish @polpo-ai/core
         run: pnpm --filter @polpo-ai/core publish --no-git-checks --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @polpo-ai/file-stores
         run: pnpm --filter @polpo-ai/file-stores publish --no-git-checks --provenance --access public


### PR DESCRIPTION
The file-stores publish step landed between the core publish `run:` and its `env:` block, leaving @polpo-ai/core without NODE_AUTH_TOKEN — the v0.11.0 release failed with npm E404 on the first publish. Every publish step now carries its own token env (12/12).

v0.11.0 will be re-tagged on top of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)