### PR TITLE
Release v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/src/__tests__/migrator-pg.test.ts
+++ b/packages/drizzle/src/__tests__/migrator-pg.test.ts
@@ -50,7 +50,7 @@ describe.skipIf(!canConnect)("migratePgSchema", () => {
 
     // Simulate a v-old database: drop everything, then create a degraded
     // tasks table with only the original column subset.
-    await db.execute(sql.raw(`DROP TABLE IF EXISTS log_entries, messages, attachments, approvals, runs, loop_runs, tasks, missions, processes, metadata, sessions, log_sessions, memory, agents, teams, vault, playbooks, skills CASCADE`));
+    await db.execute(sql.raw(`DROP TABLE IF EXISTS log_entries, messages, approvals, runs, loop_runs, tasks, missions, processes, metadata, sessions, log_sessions, memory, agents, teams, vault, playbooks, skills CASCADE`));
     await db.execute(sql.raw(`CREATE TABLE tasks (
       id          TEXT PRIMARY KEY,
       title       TEXT NOT NULL,

--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -224,18 +224,6 @@ export async function ensurePgTables(db: any): Promise<void> {
 
 
 
-  // Migration: add message_id column if missing (added in v0.2.16)
-  await db.execute(sql`
-    DO $$ BEGIN
-      IF NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'attachments' AND column_name = 'message_id'
-      ) THEN
-        ALTER TABLE attachments ADD COLUMN message_id TEXT;
-      END IF;
-    END $$
-  `);
-
   await db.execute(sql`CREATE TABLE IF NOT EXISTS skills (
     name          TEXT PRIMARY KEY,
     description   TEXT NOT NULL DEFAULT '',

--- a/packages/file-stores/package.json
+++ b/packages/file-stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/file-stores",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "File-based store implementations for Polpo — the default zero-dependency persistence backend (JSON/Markdown files)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/node",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Polpo Node.js runtime — orchestrator wiring, adapters, server assembly, runner entry. The composition root behind the polpo-ai package.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump 0.11.1 → 0.12.0 across all 12 packages. **The clean release** — zero deprecated APIs, ghost domains, god objects, or hand-kept copies.

## Breaking changes
**Renames**: `OrchestratorContext.registry`→`taskStore` · `addTask`→`createTask` · `getAllTasks`→`listTasks` · `removeTask(s)`→`deleteTask(s)` · `saveMission`→`createMission` · `getAllMissions`→`listMissions` · `spawnEngine` removed (use `spawnLoopEngine`) · Orchestrator façade slimmed (69 pass-throughs removed — use `orchestrator.engine.X`)

**Removed**: TaskStore's deprecated mission block (MissionStore is the contract; `DrizzleStores.missionStore` explicit) · AttachmentStore + dead client attachment API · Template aliases · `team` singular · ProjectConfig/JsonConfigStore · positional `session.create` · ghost peer/gateway domain + whatsapp entries · mission group-name fallback (missionId FK only) · `polpo-ai/core` and `polpo-ai/assessment` exports

## Cloud bump guide (0.10.x → 0.12.0)
1. Mechanical renames above (~10 call sites, e.g. handler.ts addTask)
2. Delete the 3 local copies: `buildResolvedVault`→`resolveAgentVault` from core; `ensureCloudTenantSchema`→`migratePgSchema` from drizzle; loops CRUD → `loopRoutes`
3. Fix the fossil: `create-snapshot.ts` installs `polpo-ai@0.3.1` hardcoded
4. Included since 0.11: event-driven tick, task pipelines, custom providers, working compaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)