### PR TITLE
fix: relocatable browser profiles root (Chrome singleton vs mounts)

### DIFF
--- a/packages/node/src/__tests__/spawn-helpers-browser-profile.test.ts
+++ b/packages/node/src/__tests__/spawn-helpers-browser-profile.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { join } from "node:path";
+import { prepareSpawn } from "../adapters/spawn-helpers.js";
+import type { AgentConfig } from "@polpo-ai/core";
+
+const agent = { name: "navigator", description: "", model: "anthropic/claude-sonnet-4-5", allowedTools: ["browser_navigate"] } as unknown as AgentConfig;
+const ctx = { polpoDir: "/proj/.polpo" } as any;
+
+describe("browser profile root override", () => {
+  afterEach(() => { delete process.env.POLPO_BROWSER_PROFILES_ROOT; });
+
+  it("defaults under polpoDir", () => {
+    const prep = prepareSpawn(agent, "/proj", ctx);
+    expect(prep.browserProfileDir).toBe(join("/proj/.polpo", "browser-profiles", "navigator"));
+  });
+
+  it("relocates via POLPO_BROWSER_PROFILES_ROOT (Chrome needs symlink-capable fs)", () => {
+    process.env.POLPO_BROWSER_PROFILES_ROOT = "/home/daytona/.polpo/browser-profiles";
+    const prep = prepareSpawn(agent, "/proj", ctx);
+    expect(prep.browserProfileDir).toBe(join("/home/daytona/.polpo/browser-profiles", "navigator"));
+  });
+});

--- a/packages/node/src/adapters/spawn-helpers.ts
+++ b/packages/node/src/adapters/spawn-helpers.ts
@@ -362,8 +362,13 @@ export function prepareSpawn(agentConfig: AgentConfig, cwd: string, ctx?: SpawnC
   const fs: FileSystem = ctx?.fs ?? new NodeFileSystem();
   const shell: Shell = ctx?.shell ?? new NodeShell();
 
-  // Browser profile directory for agent-browser persistent state (cookies, auth, localStorage)
-  const browserProfileDir = join(polpoDir, "browser-profiles", agentConfig.browserProfile || agentConfig.name);
+  // Browser profile directory for agent-browser persistent state (cookies, auth, localStorage).
+  // POLPO_BROWSER_PROFILES_ROOT relocates the root: Chrome's ProcessSingleton needs
+  // symlink support, which network/volume mounts (e.g. the cloud sandbox project dir)
+  // may not provide — the cloud points this at sandbox-local disk and hydrates/persists
+  // the profile around the run.
+  const browserProfilesRoot = process.env.POLPO_BROWSER_PROFILES_ROOT || join(polpoDir, "browser-profiles");
+  const browserProfileDir = join(browserProfilesRoot, agentConfig.browserProfile || agentConfig.name);
 
   // Check if extended tools (browser, email, image, video, audio, excel, pdf, docx) are requested via allowedTools
   // Note: vault tools are now core — always available, no need to check here.


### PR DESCRIPTION
Chrome cannot create its SingletonLock symlink on mounts without symlink support — task-spawned browsers crashed with exit 21 in cloud sandboxes (profile under the project mount), while completions already hydrate profiles to sandbox-local disk. `POLPO_BROWSER_PROFILES_ROOT` relocates the task-side profile root so the cloud can point it at local disk and reuse its hydrate/persist mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)