### PR TITLE
fix: browser-profile test must not require provider keys

### DIFF
--- a/packages/node/src/__tests__/spawn-helpers-browser-profile.test.ts
+++ b/packages/node/src/__tests__/spawn-helpers-browser-profile.test.ts
@@ -3,6 +3,9 @@ import { join } from "node:path";
 import { prepareSpawn } from "../adapters/spawn-helpers.js";
 import type { AgentConfig } from "@polpo-ai/core";
 
+// resolveModel needs a provider key; CI has no secrets by design.
+process.env.ANTHROPIC_API_KEY ||= "test-key-not-real";
+
 const agent = { name: "navigator", description: "", model: "anthropic/claude-sonnet-4-5", allowedTools: ["browser_navigate"] } as unknown as AgentConfig;
 const ctx = { polpoDir: "/proj/.polpo" } as any;
 


### PR DESCRIPTION
The new spawn-helpers test called resolveModel, which needs a provider key — green locally (keys in env), red in the keyless release workflow. Dummy key in the fixture; verified with provider env vars stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)