### PR TITLE
feat: durable turns — per-turn checkpoints and crash resume

### DIFF
--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -3,6 +3,7 @@ import type { VaultStore } from "@polpo-ai/core/vault-store";
 import type { MemoryStore } from "@polpo-ai/core/memory-store";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import type { Shell } from "@polpo-ai/core/shell";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
 
 /**
  * Handle returned by the engine after spawning an agent.
@@ -60,4 +61,19 @@ export interface SpawnContext {
   shell?: Shell;
   /** LLM gateway configuration — passed per-request for multi-tenant support. */
   gatewayConfig?: unknown;
+  /**
+   * Durable-turns checkpoint from a previous interrupted run. The engine
+   * seeds its conversation history from it and continues at turn + 1 —
+   * tools that already ran are replayed from their recorded results in the
+   * history, never re-executed. Only single-session loops resume; pipeline
+   * (project-loop graph) task runs ignore it and start fresh.
+   */
+  resumeState?: LoopResumeState;
+  /**
+   * Durable-turns checkpoint sink: called at most once per completed turn
+   * with the serialized post-compaction history. The runner wires it to
+   * RunStore.updateResumeState. Best-effort — implementations should not
+   * throw (the engine swallows errors anyway).
+   */
+  onTurnCheckpoint?: (state: LoopResumeState) => void | Promise<void>;
 }

--- a/packages/core/src/loop/run-store.ts
+++ b/packages/core/src/loop/run-store.ts
@@ -28,6 +28,27 @@ export interface LoopResumeState {
   attempts?: number;
   createdAt: string;
   updatedAt?: string;
+
+  // ── Durable turns (task path) — per-turn conversation checkpoint ──
+  // The pipeline fields above describe WHERE a project-loop pipeline
+  // stopped; these additive fields describe WHERE a turn-based LLM session
+  // stopped. Both live in the same state so the task runner and the
+  // completions resume path share one format instead of inventing two.
+
+  /** Name of the loop session this checkpoint belongs to (e.g. "default"). */
+  loopName?: string;
+  /** Index of the last COMPLETED turn (0-based). Resume starts at turn + 1. */
+  turn?: number;
+  /**
+   * Serialized conversation history (AI SDK ModelMessage[]) including
+   * tool-call and tool-result parts — always post-compaction, since the
+   * checkpoint is taken at end-of-turn and compaction rewrites the history
+   * at the start of a model step. A resumed run replays completed
+   * side-effects from these recorded results; it never re-executes them.
+   */
+  history?: unknown[];
+  /** Assistant text accumulated across completed turns. */
+  accumText?: string;
 }
 
 export interface LoopApprovalSnapshot {

--- a/packages/core/src/loop/runner.test.ts
+++ b/packages/core/src/loop/runner.test.ts
@@ -133,3 +133,115 @@ describe("LoopRunner", () => {
     expect(result.context.done).toBe(true);
   });
 });
+
+describe("LoopRunner durable turns", () => {
+  it("emits a checkpoint after every completed turn, after tool execution", async () => {
+    const events: string[] = [];
+    const checkpoints: Array<{ turn: number; turns: number; text: string; toolResults: unknown[] }> = [];
+
+    const runner = new LoopRunner();
+    const result = await runner.run({
+      loop: { name: "default" },
+      maxTurns: 5,
+      model: async ({ turn }) => {
+        if (turn === 0) {
+          return {
+            text: "working",
+            toolCalls: [{ id: "call-1", name: "bash", args: { command: "true" } }],
+          };
+        }
+        return { text: "done" };
+      },
+      executeTool: async (toolCall) => {
+        events.push(`tool:${toolCall.name}`);
+        return "ok";
+      },
+      onTurnCheckpoint: async (cp) => {
+        events.push(`checkpoint:${cp.turn}`);
+        checkpoints.push({
+          turn: cp.turn,
+          turns: cp.turns,
+          text: cp.text,
+          toolResults: cp.toolResults,
+        });
+      },
+    });
+
+    expect(result.status).toBe("completed");
+    // One checkpoint per turn; the turn-0 checkpoint fires AFTER its tools ran.
+    expect(events).toEqual(["tool:bash", "checkpoint:0", "checkpoint:1"]);
+    expect(checkpoints).toHaveLength(2);
+    expect(checkpoints[0]).toMatchObject({ turn: 0, turns: 1, text: "working" });
+    expect(checkpoints[0].toolResults).toHaveLength(1);
+    expect(checkpoints[0].toolResults[0]).toMatchObject({ result: "ok", isError: false });
+    expect(checkpoints[1]).toMatchObject({ turn: 1, turns: 2, text: "done" });
+    expect(checkpoints[1].toolResults).toHaveLength(0);
+  });
+
+  it("resumes from startTurn: earlier turns are never re-executed", async () => {
+    const modelTurns: number[] = [];
+    let toolCalls = 0;
+
+    const runner = new LoopRunner();
+    const result = await runner.run({
+      loop: { name: "default" },
+      maxTurns: 4,
+      startTurn: 2,
+      model: async ({ turn }) => {
+        modelTurns.push(turn);
+        return { text: `t${turn}` };
+      },
+      executeTool: async () => {
+        toolCalls++;
+        return "unused";
+      },
+    });
+
+    // The model is first invoked at the resumed turn — turns 0 and 1 are
+    // history, never replayed; no tool from a completed turn re-executes.
+    expect(modelTurns).toEqual([2]);
+    expect(toolCalls).toBe(0);
+    expect(result.status).toBe("completed");
+    // Turn accounting stays cumulative across the logical run.
+    expect(result.turns).toBe(3);
+  });
+
+  it("startTurn preserves the maxTurns budget", async () => {
+    const modelTurns: number[] = [];
+    const runner = new LoopRunner();
+    const result = await runner.run({
+      loop: { name: "default" },
+      maxTurns: 4,
+      startTurn: 2,
+      model: async ({ turn }) => {
+        modelTurns.push(turn);
+        return {
+          text: "loop",
+          toolCalls: [{ id: `c${turn}`, name: "bash", args: {} }],
+        };
+      },
+      executeTool: async () => "ok",
+    });
+
+    // Only turns 2 and 3 run — the budget counts completed history too.
+    expect(modelTurns).toEqual([2, 3]);
+    expect(result.reason).toBe("max_turns");
+    expect(result.turns).toBe(4);
+  });
+
+  it("a throwing checkpoint sink never fails the run", async () => {
+    const runner = new LoopRunner();
+    const result = await runner.run({
+      loop: { name: "default" },
+      maxTurns: 2,
+      model: async () => ({ text: "fine" }),
+      executeTool: async () => "unused",
+      onTurnCheckpoint: async () => {
+        throw new Error("store unavailable");
+      },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.text).toBe("fine");
+  });
+});

--- a/packages/core/src/loop/runner.ts
+++ b/packages/core/src/loop/runner.ts
@@ -34,6 +34,30 @@ export interface LoopRunResult {
   toolResults: LoopToolResult[];
 }
 
+/**
+ * Snapshot emitted after every completed turn (durable turns).
+ *
+ * The runner does not own conversation history — the host does (loop-engine's
+ * `messages`, the completions runtime's message array). This checkpoint
+ * carries the loop-level position; the host closure enriches it with the
+ * serialized history before persisting. Temporal semantics: a resumed run
+ * replays completed side-effects from recorded results (they live in the
+ * history as tool-call/tool-result pairs), it never re-executes them.
+ */
+export interface LoopTurnCheckpoint {
+  loop: LoopRuntimeConfig;
+  /** 0-based index of the turn that just completed. */
+  turn: number;
+  /** Turns completed so far in the logical run (== turn + 1, cumulative across resumes). */
+  turns: number;
+  context: ContextBag;
+  /** Text produced by this turn. */
+  text: string;
+  toolCalls: LoopToolCall[];
+  /** Tool results of this turn — already executed, part of history. */
+  toolResults: LoopToolResult[];
+}
+
 export interface LoopRunnerOptions {
   agent?: AgentConfig;
   loop: LoopConfig & { name?: string };
@@ -41,8 +65,24 @@ export interface LoopRunnerOptions {
   input?: unknown;
   hooks?: LoopHookRegistry;
   maxTurns?: number;
+  /**
+   * Resume support (durable turns): first turn index to execute. Turns
+   * before it already ran in a previous process — their side-effects are
+   * recorded in the host's history and must not be replayed. The maxTurns
+   * budget still counts them (indices are absolute, not relative).
+   */
+  startTurn?: number;
   model: (input: LoopModelInput) => Promise<LoopModelResult>;
   executeTool: (toolCall: LoopToolCall, input: LoopModelInput) => Promise<string>;
+  /**
+   * Durable-turns port: invoked once per completed turn, AFTER the turn's
+   * tools have executed and the step:after hooks ran — i.e. when the host's
+   * history is consistent (and post-compaction, since compaction happens at
+   * the start of a model step). Persistence is best-effort by contract:
+   * errors are swallowed so a flaky store can never fail a healthy run.
+   * Core stays pure — wiring to a store lives in the host (loop-engine/runner).
+   */
+  onTurnCheckpoint?: (checkpoint: LoopTurnCheckpoint) => void | Promise<void>;
 }
 
 const DEFAULT_MAX_TURNS = 20;
@@ -86,8 +126,9 @@ export class LoopRunner {
     const loop = normalizeLoop(options.loop);
     const context = options.context ?? {};
     const maxTurns = options.maxTurns ?? loop.maxTurns ?? DEFAULT_MAX_TURNS;
+    const startTurn = options.startTurn ?? 0;
     let finalText = "";
-    let turns = 0;
+    let turns = startTurn;
     const allToolResults: LoopToolResult[] = [];
 
     const start = await hooks.runBefore("loop:start", {
@@ -109,7 +150,7 @@ export class LoopRunner {
       });
     }
 
-    for (let turn = 0; turn < maxTurns; turn++) {
+    for (let turn = startTurn; turn < maxTurns; turn++) {
       turns = turn + 1;
       const step = await hooks.runBefore("step:before", {
         agent: options.agent,
@@ -210,6 +251,23 @@ export class LoopRunner {
         toolResults,
         usage: modelResult.usage,
       });
+
+      // Durable turns: the turn is complete (tools executed, hooks ran) —
+      // hand the host a checkpoint. Best-effort: a failing sink must never
+      // take down a healthy run.
+      if (options.onTurnCheckpoint) {
+        try {
+          await options.onTurnCheckpoint({
+            loop,
+            turn,
+            turns,
+            context,
+            text: modelResult.text,
+            toolCalls: modelResult.toolCalls ?? [],
+            toolResults,
+          });
+        } catch { /* checkpoint persistence is best-effort */ }
+      }
 
       const stop = shouldStopAfterTurn(loop, context, modelResult, turn, maxTurns, this.evaluator);
       const stopResult = await hooks.runBefore("loop:stop", {

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -1,4 +1,5 @@
 import type { AgentActivity, TaskResult, TaskOutcome, RunnerConfig } from "./types.js";
+import type { LoopResumeState } from "./loop/run-store.js";
 
 export type RunStatus = "running" | "completed" | "failed" | "killed";
 
@@ -23,6 +24,12 @@ export interface RunRecord {
    * parent Task. Used for per-user analytics and billing attribution.
    */
   user?: string;
+  /**
+   * Durable-turns checkpoint (history + turn position), written by the
+   * runner once per completed turn. Orphan recovery reads it to re-spawn
+   * the task with a resume instead of retrying from zero.
+   */
+  resumeState?: LoopResumeState;
 }
 
 export interface RunStore {
@@ -30,6 +37,13 @@ export interface RunStore {
   updateActivity(runId: string, activity: AgentActivity): Promise<void>;
   /** Store auto-collected outcomes on the run record (called before completeRun). */
   updateOutcomes(runId: string, outcomes: TaskOutcome[]): Promise<void>;
+  /**
+   * Persist the durable-turns resume checkpoint (one write per completed
+   * turn). Optional and best-effort: stores that don't implement it simply
+   * lose crash-resumability, never correctness — recovery falls back to
+   * retry-from-zero.
+   */
+  updateResumeState?(runId: string, state: LoopResumeState): Promise<void>;
   completeRun(runId: string, status: RunStatus, result: TaskResult): Promise<void>;
   getRun(runId: string): Promise<RunRecord | undefined>;
   getRunByTaskId(taskId: string): Promise<RunRecord | undefined>;

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -4,6 +4,27 @@ import { resolveMissionStore, resolveMissionForTask } from "./mission-store.js";
 import type { Task, TaskResult, RunnerConfig } from "./types.js";
 import { agentMemoryScope } from "./memory-store.js";
 import type { RunRecord } from "./run-store.js";
+import type { LoopResumeState } from "./loop/run-store.js";
+
+/**
+ * Durable turns: max age of a resume checkpoint before orphan recovery
+ * ignores it and falls back to retry-from-zero. Crash/deploy restarts are
+ * a matter of minutes; beyond this window the sandbox/workdir state the
+ * conversation refers to can no longer be trusted.
+ */
+export const RESUME_CHECKPOINT_MAX_AGE_MS = 60 * 60 * 1000;
+
+/** A checkpoint is resumable if it has at least one completed turn of
+ *  history and is fresh enough to trust. */
+function usableCheckpoint(state: LoopResumeState | undefined): LoopResumeState | undefined {
+  if (!state) return undefined;
+  if (typeof state.turn !== "number" || state.turn < 0) return undefined;
+  if (!Array.isArray(state.history) || state.history.length === 0) return undefined;
+  const stamp = state.updatedAt ?? state.createdAt;
+  const age = Date.now() - new Date(stamp).getTime();
+  if (!Number.isFinite(age) || age > RESUME_CHECKPOINT_MAX_AGE_MS) return undefined;
+  return state;
+}
 
 // ── Pure path helpers (no node:path dependency) ─────────────────────────
 
@@ -31,6 +52,14 @@ export class TaskRunner {
   private lastActivity = new Map<string, string>();
   /** Tracks files already seen per task to emit incremental file:changed events */
   private knownFiles = new Map<string, Set<string>>();
+  /**
+   * Durable turns: checkpoints harvested from dead runs during orphan
+   * recovery, consumed (one-shot) by the next spawn of the same task so it
+   * resumes at turn + 1 instead of retrying from zero. Recovery and the
+   * respawning tick happen in the same orchestrator process, so in-memory
+   * handoff is sufficient — the durable copy lives on the run record.
+   */
+  private pendingResume = new Map<string, LoopResumeState>();
 
   constructor(private ctx: OrchestratorContext) {}
 
@@ -297,7 +326,17 @@ export class TaskRunner {
         // Runner still alive — leave it running, work is NOT lost!
         this.ctx.emitter.emit("log", { level: "info", message: `Runner PID ${run.pid} still alive for task ${run.taskId} — reconnecting` });
       } else {
-        // Runner died — clean up the run record
+        // Runner died — harvest its durable-turns checkpoint (if fresh)
+        // so the respawn resumes at turn + 1 instead of starting over.
+        const checkpoint = usableCheckpoint(run.resumeState);
+        if (checkpoint) {
+          this.pendingResume.set(run.taskId, checkpoint);
+          this.ctx.emitter.emit("log", {
+            level: "info",
+            message: `[${run.taskId}] Runner died mid-run — checkpoint at turn ${checkpoint.turn! + 1} saved for resume`,
+          });
+        }
+        // Clean up the run record (unchanged fallback path)
         await this.ctx.runStore.completeRun(run.id, "failed", {
           exitCode: 1, stdout: "", stderr: "Runner process died", duration: 0,
         });
@@ -338,6 +377,14 @@ export class TaskRunner {
     // Clear stale process list
     if (recovered > 0 || tasks.some(t => orphanStates.has(t.status))) {
       await this.ctx.taskStore.setState({ processes: [] });
+    }
+
+    // Drop harvested checkpoints whose task did NOT end up pending (task
+    // already done/failed, or still owned by a live runner) — a leaked
+    // entry would wrongly resume a future, unrelated execution.
+    for (const taskId of [...this.pendingResume.keys()]) {
+      const task = await this.ctx.taskStore.getTask(taskId);
+      if (!task || task.status !== "pending") this.pendingResume.delete(taskId);
     }
 
     return recovered;
@@ -452,6 +499,18 @@ export class TaskRunner {
     }
 
 
+    // Durable turns: consume (one-shot) a checkpoint harvested by orphan
+    // recovery — the runner resumes the conversation at turn + 1 instead
+    // of redoing completed work. Absent checkpoint = spawn from zero.
+    const resumeState = this.pendingResume.get(task.id);
+    if (resumeState) {
+      this.pendingResume.delete(task.id);
+      this.ctx.emitter.emit("log", {
+        level: "info",
+        message: `[${task.id}] Resuming from checkpoint (turn ${resumeState.turn! + 1}) instead of retrying from zero`,
+      });
+    }
+
     const runnerConfig: RunnerConfig = {
       runId,
       taskId: task.id,
@@ -466,6 +525,7 @@ export class TaskRunner {
       emailAllowedDomains: agent.emailAllowedDomains ?? this.ctx.config.settings.emailAllowedDomains,
       reasoning: this.ctx.config.settings.reasoning,
       providers: this.ctx.config.providers,
+      resumeState,
     };
 
     try {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -7,6 +7,7 @@ import type { Task, RetryPolicy } from "./task.js";
 import type { AgentConfig, AgentProcess, Team, ReasoningLevel } from "./agent.js";
 import type { ApprovalGate, SLAConfig } from "./mission.js";
 import type { NotificationsConfig, EscalationPolicy } from "./notifications.js";
+import type { LoopResumeState } from "../loop/run-store.js";
 
 // === Runner Config ===
 
@@ -35,6 +36,13 @@ export interface RunnerConfig {
    * inside the runner.
    */
   providers?: Record<string, ProviderConfig>;
+  /**
+   * Durable-turns resume checkpoint from a previous interrupted run
+   * (orphan recovery). When present, the engine seeds its conversation
+   * from the recorded history and continues at turn + 1 instead of
+   * starting the task over.
+   */
+  resumeState?: LoopResumeState;
 }
 
 // === Polpo File Config (.polpo/polpo.json — persistent project configuration) ===

--- a/packages/drizzle/src/__tests__/stores-pg.test.ts
+++ b/packages/drizzle/src/__tests__/stores-pg.test.ts
@@ -373,6 +373,43 @@ describe.skipIf(!canConnect)("PostgreSQL Drizzle stores", () => {
       await stores.runStore.deleteRun("r1");
       expect(await stores.runStore.getRun("r1")).toBeUndefined();
     });
+
+    it("updateResumeState round-trips the durable-turns checkpoint (jsonb)", async () => {
+      await stores.runStore.upsertRun(makeRun("r-resume", "t-resume") as any);
+
+      await stores.runStore.updateResumeState!("r-resume", {
+        context: {}, steps: [], loopName: "default", turn: 2,
+        history: [
+          { role: "user", content: "do the thing" },
+          { role: "assistant", content: [{ type: "tool-call", toolCallId: "c1", toolName: "bash", input: {} }] },
+        ],
+        accumText: "working",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as any);
+
+      const fetched = await stores.runStore.getRun("r-resume");
+      expect(fetched!.resumeState).toMatchObject({ loopName: "default", turn: 2, accumText: "working" });
+      expect(fetched!.resumeState!.history).toHaveLength(2);
+
+      const active = await stores.runStore.getActiveRuns();
+      expect(active.find((r) => r.id === "r-resume")!.resumeState!.turn).toBe(2);
+    });
+
+    it("upsertRun on conflict preserves an existing resume checkpoint", async () => {
+      await stores.runStore.upsertRun(makeRun("r-keep", "t-keep") as any);
+      await stores.runStore.updateResumeState!("r-keep", {
+        context: {}, steps: [], loopName: "default", turn: 1,
+        history: [{ role: "user", content: "hi" }],
+        createdAt: new Date().toISOString(),
+      } as any);
+
+      await stores.runStore.upsertRun({ ...makeRun("r-keep", "t-keep"), pid: 4242 } as any);
+
+      const fetched = await stores.runStore.getRun("r-keep");
+      expect(fetched!.pid).toBe(4242);
+      expect(fetched!.resumeState!.turn).toBe(1);
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -354,6 +354,53 @@ describe("DrizzleRunStore", () => {
     await stores.runStore.deleteRun("r1");
     expect(await stores.runStore.getRun("r1")).toBeUndefined();
   });
+
+  it("updateResumeState round-trips the durable-turns checkpoint", async () => {
+    await stores.runStore.upsertRun(makeRun("r-resume", "t-resume") as any);
+
+    const checkpoint = {
+      context: {},
+      steps: [],
+      loopName: "default",
+      turn: 2,
+      history: [
+        { role: "user", content: "do the thing" },
+        { role: "assistant", content: [{ type: "tool-call", toolCallId: "c1", toolName: "bash", input: {} }] },
+        { role: "tool", content: [{ type: "tool-result", toolCallId: "c1", toolName: "bash", output: { type: "text", value: "ok" } }] },
+      ],
+      accumText: "working",
+      createdAt: now,
+      updatedAt: now,
+    };
+    await stores.runStore.updateResumeState!("r-resume", checkpoint as any);
+
+    const fetched = await stores.runStore.getRun("r-resume");
+    expect(fetched!.resumeState).toBeDefined();
+    expect(fetched!.resumeState).toMatchObject({ loopName: "default", turn: 2, accumText: "working" });
+    expect(fetched!.resumeState!.history).toHaveLength(3);
+
+    // Recovery reads active runs — the checkpoint must ride along.
+    const active = await stores.runStore.getActiveRuns();
+    expect(active.find((r) => r.id === "r-resume")!.resumeState!.turn).toBe(2);
+  });
+
+  it("upsertRun on conflict preserves an existing resume checkpoint", async () => {
+    await stores.runStore.upsertRun(makeRun("r-keep", "t-keep") as any);
+    await stores.runStore.updateResumeState!("r-keep", {
+      context: {}, steps: [], loopName: "default", turn: 1,
+      history: [{ role: "user", content: "hi" }],
+      createdAt: now, updatedAt: now,
+    } as any);
+
+    // A later upsert without resumeState (e.g. runner re-registering its
+    // PID) must not clobber a checkpoint written in between.
+    await stores.runStore.upsertRun({ ...makeRun("r-keep", "t-keep"), pid: 4242 } as any);
+
+    const fetched = await stores.runStore.getRun("r-keep");
+    expect(fetched!.pid).toBe(4242);
+    expect(fetched!.resumeState).toBeDefined();
+    expect(fetched!.resumeState!.turn).toBe(1);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/drizzle/src/schema/runs.ts
+++ b/packages/drizzle/src/schema/runs.ts
@@ -20,6 +20,8 @@ export const runsSqlite = sqliteTable("runs", {
   configPath: text("config_path").notNull(),
   /** Propagated from Task.user at spawn time. Used for per-user run analytics. */
   user: text("user"),
+  /** Durable-turns checkpoint (LoopResumeState JSON) — written once per completed turn. */
+  resumeState: text("resume_state"),
 }, (table) => [
   index("idx_runs_status").on(table.status),
   index("idx_runs_task_id").on(table.taskId),
@@ -45,6 +47,8 @@ export const runsPg = pgTable("runs", {
   configPath: pgText("config_path").notNull(),
   /** Propagated from Task.user at spawn time. Used for per-user run analytics. */
   user: pgText("user"),
+  /** Durable-turns checkpoint (LoopResumeState JSON) — written once per completed turn. */
+  resumeState: jsonb("resume_state"),
 }, (table) => [
   pgIndex("idx_pg_runs_status").on(table.status),
   pgIndex("idx_pg_runs_task_id").on(table.taskId),

--- a/packages/drizzle/src/stores/run-store.ts
+++ b/packages/drizzle/src/stores/run-store.ts
@@ -1,6 +1,7 @@
 import { eq, desc, inArray } from "drizzle-orm";
 import type { RunStore, RunRecord, RunStatus } from "@polpo-ai/core/run-store";
 import type { AgentActivity, TaskResult, TaskOutcome, RunnerConfig } from "@polpo-ai/core/types";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
 import { type Dialect, serializeJson, deserializeJson } from "../utils.js";
 
 type AnyTable = any;
@@ -35,6 +36,7 @@ export class DrizzleRunStore implements RunStore {
       config: deserializeJson<RunnerConfig | undefined>(row.config, undefined, d),
       configPath: row.configPath,
       user: row.user ?? undefined,
+      resumeState: deserializeJson<LoopResumeState | undefined>(row.resumeState, undefined, d),
     };
   }
 
@@ -56,6 +58,7 @@ export class DrizzleRunStore implements RunStore {
       config: serializeJson(run.config, d),
       configPath: run.configPath,
       user: run.user ?? null,
+      resumeState: serializeJson(run.resumeState, d),
     };
     await this.db.insert(this.runs).values(values)
       .onConflictDoUpdate({
@@ -69,8 +72,18 @@ export class DrizzleRunStore implements RunStore {
           result: values.result,
           outcomes: values.outcomes,
           config: values.config,
+          // resumeState deliberately NOT in the conflict set: an upsert
+          // without a checkpoint (runner re-registering its PID) must not
+          // clobber a checkpoint written by updateResumeState in between.
         },
       });
+  }
+
+  async updateResumeState(runId: string, state: LoopResumeState): Promise<void> {
+    await this.db.update(this.runs).set({
+      resumeState: serializeJson(state, this.dialect),
+      updatedAt: new Date().toISOString(),
+    }).where(eq(this.runs.id, runId));
   }
 
   async updateActivity(runId: string, activity: AgentActivity): Promise<void> {

--- a/packages/file-stores/src/__tests__/file-run-store.test.ts
+++ b/packages/file-stores/src/__tests__/file-run-store.test.ts
@@ -1,0 +1,93 @@
+/**
+ * FileRunStore — durable-turns checkpoint persistence.
+ *
+ * The runner subprocess writes one checkpoint per completed turn via
+ * updateResumeState; orphan recovery reads it back from the active run.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunRecord } from "@polpo-ai/core/run-store";
+import { FileRunStore } from "../file-run-store.js";
+
+function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
+  const now = new Date().toISOString();
+  return {
+    id: "run-1",
+    taskId: "task-1",
+    pid: 1234,
+    agentName: "agent-1",
+    status: "running",
+    startedAt: now,
+    updatedAt: now,
+    activity: { filesCreated: [], filesEdited: [], toolCalls: 0, totalTokens: 0, lastUpdate: now },
+    configPath: "/tmp/run.json",
+    ...overrides,
+  };
+}
+
+describe("FileRunStore durable turns", () => {
+  let dir: string;
+  let store: FileRunStore;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "polpo-file-run-store-"));
+    store = new FileRunStore(dir);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("updateResumeState round-trips the checkpoint", async () => {
+    await store.upsertRun(makeRun());
+
+    await store.updateResumeState!("run-1", {
+      context: {},
+      steps: [],
+      loopName: "default",
+      turn: 3,
+      history: [
+        { role: "user", content: "task prompt" },
+        { role: "assistant", content: [{ type: "text", text: "on it" }] },
+      ],
+      accumText: "on it",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const fetched = await store.getRun("run-1");
+    expect(fetched!.resumeState).toMatchObject({ loopName: "default", turn: 3 });
+    expect(fetched!.resumeState!.history).toHaveLength(2);
+
+    // Recovery path reads active runs.
+    const active = await store.getActiveRuns();
+    expect(active[0].resumeState!.turn).toBe(3);
+  });
+
+  it("updateResumeState on a missing run is a no-op", async () => {
+    await expect(
+      store.updateResumeState!("nope", {
+        context: {}, steps: [], turn: 0, history: [], createdAt: new Date().toISOString(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("updateActivity preserves an existing checkpoint", async () => {
+    await store.upsertRun(makeRun());
+    await store.updateResumeState!("run-1", {
+      context: {}, steps: [], loopName: "default", turn: 1,
+      history: [{ role: "user", content: "hi" }],
+      createdAt: new Date().toISOString(),
+    });
+
+    await store.updateActivity("run-1", {
+      filesCreated: [], filesEdited: [], toolCalls: 5, totalTokens: 100, lastUpdate: new Date().toISOString(),
+    });
+
+    const fetched = await store.getRun("run-1");
+    expect(fetched!.activity.toolCalls).toBe(5);
+    expect(fetched!.resumeState!.turn).toBe(1);
+  });
+});

--- a/packages/file-stores/src/file-run-store.ts
+++ b/packages/file-stores/src/file-run-store.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import type { AgentActivity, TaskResult, TaskOutcome } from "@polpo-ai/core/types";
 import type { RunStore, RunRecord, RunStatus } from "@polpo-ai/core/run-store";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
 
 function safeJsonParse<T>(raw: string, fallback: T): T {
   try {
@@ -95,6 +96,14 @@ export class FileRunStore implements RunStore {
     const run = this.readRun(runId);
     if (!run) return;
     run.outcomes = outcomes;
+    run.updatedAt = new Date().toISOString();
+    this.writeRun(run);
+  }
+
+  async updateResumeState(runId: string, state: LoopResumeState): Promise<void> {
+    const run = this.readRun(runId);
+    if (!run) return;
+    run.resumeState = state;
     run.updatedAt = new Date().toISOString();
     this.writeRun(run);
   }

--- a/packages/node/src/__tests__/fixtures.ts
+++ b/packages/node/src/__tests__/fixtures.ts
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
 import type { Task, TaskStatus, TaskOutcome, PolpoState, AgentConfig, AgentActivity, TaskResult, AgentHandle, TaskStore, RunStore, RunRecord, RunStatus, Team } from "../core/index.js";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
 import type { TeamStore } from "@polpo-ai/core/team-store";
 import type { AgentStore } from "@polpo-ai/core/agent-store";
 import { assertValidTransition } from "@polpo-ai/core/state-machine";
@@ -166,6 +167,14 @@ export class InMemoryRunStore implements RunStore {
     const run = this.runs.get(runId);
     if (run) {
       run.outcomes = outcomes;
+      run.updatedAt = new Date().toISOString();
+    }
+  }
+
+  async updateResumeState(runId: string, state: LoopResumeState): Promise<void> {
+    const run = this.runs.get(runId);
+    if (run) {
+      run.resumeState = state;
       run.updatedAt = new Date().toISOString();
     }
   }

--- a/packages/node/src/__tests__/loop-engine-durable-turns.test.ts
+++ b/packages/node/src/__tests__/loop-engine-durable-turns.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Durable turns — per-turn checkpointing and resume on the task loop engine.
+ *
+ * Contract under test (Phase A):
+ * 1. Every completed turn emits exactly one checkpoint through
+ *    ctx.onTurnCheckpoint, carrying the serialized conversation history
+ *    (ModelMessage[] incl. tool-call/tool-result parts) and the turn index.
+ * 2. A run interrupted mid-task leaves the last checkpoint behind; a new
+ *    spawn with ctx.resumeState continues at turn + 1: recorded history is
+ *    replayed to the model, completed tools are NEVER re-executed
+ *    (Temporal semantics — side-effects ride in as recorded results).
+ * 3. Checkpoints are post-compaction: after the compactor rewrites history,
+ *    the next checkpoint carries the compacted messages, never the
+ *    pre-compaction transcript.
+ * 4. Oversized histories (> MAX_CHECKPOINT_BYTES) are not persisted — the
+ *    previous checkpoint is kept and the run itself is unaffected.
+ *
+ * Mock strategy: same as engine-behavior.test.ts (vi.mock @polpo-ai/llm so
+ * resolveModel returns a MockLanguageModelV3); tool layer and filesystem
+ * run for real against a temp dir.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { mkdtemp, mkdir, rm, readFile, unlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedModel } from "@polpo-ai/llm";
+import {
+  MockLanguageModelV3,
+  mockTextModel,
+  mockTurnSequenceModel,
+  mockResolvedModel,
+  type MockResponse,
+} from "./helpers/mock-llm.js";
+
+// ── Mock pi-client BEFORE any imports that pull it in ──
+
+let activeResolvedModel: ResolvedModel = mockResolvedModel(mockTextModel("default"));
+
+vi.mock("@polpo-ai/llm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@polpo-ai/llm")>();
+  return {
+    ...actual,
+    resolveModel: () => activeResolvedModel,
+    enforceModelAllowlist: () => {},
+    mapReasoningToProviderOptions: () => undefined,
+  };
+});
+
+import { spawnLoopEngine, MAX_CHECKPOINT_BYTES } from "../adapters/loop-engine.js";
+import type { AgentConfig, Task } from "@polpo-ai/core/types";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
+
+// ── Helpers ─────────────────────────────────────────────
+
+function setMockModel(model: MockLanguageModelV3, overrides: Partial<ResolvedModel> = {}) {
+  activeResolvedModel = { ...mockResolvedModel(model), ...overrides };
+}
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { name: "durable-agent", role: "developer", ...overrides };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-durable-1",
+    title: "Durable task",
+    description: "Do the scripted thing.",
+    state: "in_progress",
+    expectations: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    assignedTo: "durable-agent",
+    ...overrides,
+  } as Task;
+}
+
+/** Sequence model that also captures every doStream prompt (the messages
+ *  the engine actually sent to the LLM) — used to prove history seeding. */
+function capturingSequenceModel(responses: MockResponse[], prompts: unknown[][]): MockLanguageModelV3 {
+  const inner = mockTurnSequenceModel(responses);
+  return new MockLanguageModelV3({
+    doGenerate: (opts) => inner.doGenerate(opts),
+    doStream: (opts) => {
+      prompts.push(opts.prompt as unknown[]);
+      return inner.doStream(opts);
+    },
+  });
+}
+
+/** Sequence model that plays `responses` then throws — simulates a runner
+ *  crash mid-task (the run fails, whatever checkpoint exists survives). */
+function crashingAfterModel(responses: MockResponse[]): MockLanguageModelV3 {
+  const inner = mockTurnSequenceModel(responses);
+  let calls = 0;
+  return new MockLanguageModelV3({
+    doStream: (opts) => {
+      if (calls++ >= responses.length) throw new Error("simulated crash");
+      return inner.doStream(opts);
+    },
+  });
+}
+
+/** JSON round-trip — a checkpoint always crosses a store boundary. */
+function throughStore(state: LoopResumeState): LoopResumeState {
+  return JSON.parse(JSON.stringify(state)) as LoopResumeState;
+}
+
+let tmpRoot: string;
+let cwd: string;
+let polpoDir: string;
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "polpo-durable-turns-"));
+  cwd = join(tmpRoot, "work");
+  polpoDir = join(tmpRoot, ".polpo");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(polpoDir, { recursive: true });
+});
+
+afterAll(async () => {
+  if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true });
+});
+
+interface RunOptions {
+  agent?: AgentConfig;
+  resumeState?: LoopResumeState;
+  taskOverrides?: Partial<Task>;
+}
+
+async function runEngine(
+  model: MockLanguageModelV3,
+  modelOverrides: Partial<ResolvedModel> = {},
+  options: RunOptions = {},
+) {
+  setMockModel(model, modelOverrides);
+  const checkpoints: LoopResumeState[] = [];
+  const handle = spawnLoopEngine(
+    options.agent ?? makeAgent(),
+    makeTask(options.taskOverrides),
+    cwd,
+    {
+      polpoDir,
+      resumeState: options.resumeState,
+      onTurnCheckpoint: (state) => {
+        checkpoints.push(throughStore(state));
+      },
+    },
+  );
+  const result = await handle.done;
+  return { handle, result, checkpoints };
+}
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("loop-engine durable turns", () => {
+  test("emits one checkpoint per completed turn with history and position", async () => {
+    const { result, checkpoints } = await runEngine(
+      mockTurnSequenceModel([
+        { type: "tool-call", toolName: "write", args: { path: "cp-a.txt", content: "alpha" } },
+        { type: "text", text: "all done" },
+      ]),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(checkpoints).toHaveLength(2);
+
+    // Turn 0: assistant tool-call + tool result are already in history.
+    const cp0 = checkpoints[0];
+    expect(cp0.loopName).toBe("default");
+    expect(cp0.turn).toBe(0);
+    expect(cp0.createdAt).toBeTruthy();
+    expect(cp0.updatedAt).toBeTruthy();
+    const cp0Json = JSON.stringify(cp0.history);
+    expect(cp0Json).toContain("tool-call");
+    expect(cp0Json).toContain("tool-result");
+    expect(cp0Json).toContain("cp-a.txt");
+    // First message is the task prompt.
+    expect(JSON.stringify(cp0.history![0])).toContain("Durable task");
+
+    // Turn 1: history grew, position advanced, same logical run.
+    const cp1 = checkpoints[1];
+    expect(cp1.turn).toBe(1);
+    expect(cp1.history!.length).toBeGreaterThan(cp0.history!.length);
+    expect(cp1.createdAt).toBe(cp0.createdAt);
+    expect(cp1.accumText).toContain("all done");
+  });
+
+  test("crash mid-task, then resume: history replayed, no tool re-executed", async () => {
+    // ── Run 1: turn 0 writes a file, turn 1 crashes ──
+    const crash = await runEngine(
+      crashingAfterModel([
+        { type: "tool-call", toolName: "write", args: { path: "resume-a.txt", content: "first turn" } },
+      ]),
+    );
+
+    expect(crash.result.exitCode).toBe(1);
+    // The turn-0 checkpoint survived the crash.
+    expect(crash.checkpoints).toHaveLength(1);
+    const checkpoint = crash.checkpoints[0];
+    expect(checkpoint.turn).toBe(0);
+    expect(await readFile(join(cwd, "resume-a.txt"), "utf-8")).toBe("first turn");
+
+    // Wipe the side-effect so any re-execution would be visible.
+    await unlink(join(cwd, "resume-a.txt"));
+
+    // ── Run 2: resume from the checkpoint ──
+    const prompts: unknown[][] = [];
+    const resumed = await runEngine(
+      capturingSequenceModel(
+        [
+          { type: "tool-call", toolName: "write", args: { path: "resume-b.txt", content: "second turn" } },
+          { type: "text", text: "resumed done" },
+        ],
+        prompts,
+      ),
+      {},
+      { resumeState: checkpoint },
+    );
+
+    expect(resumed.result.exitCode).toBe(0);
+    expect(resumed.result.stdout).toBe("resumed done");
+
+    // Temporal semantics: the completed turn's tool did NOT re-execute…
+    expect(existsSync(join(cwd, "resume-a.txt"))).toBe(false);
+    // …while the resumed run's new tool did.
+    expect(await readFile(join(cwd, "resume-b.txt"), "utf-8")).toBe("second turn");
+
+    // The model saw the recorded turn-0 history (tool-call + result),
+    // not a fresh conversation.
+    const firstPrompt = JSON.stringify(prompts[0]);
+    expect(firstPrompt).toContain("resume-a.txt");
+    expect(firstPrompt).toContain("tool-result");
+
+    // Turn numbering continues: the first new checkpoint is turn 1.
+    expect(resumed.checkpoints[0].turn).toBe(1);
+    expect(resumed.checkpoints.map((c) => c.turn)).toEqual([1, 2]);
+  });
+
+  test("resume state for a different loop is ignored — fresh start, no crash", async () => {
+    const prompts: unknown[][] = [];
+    const stale: LoopResumeState = {
+      context: {},
+      steps: [],
+      loopName: "some-other-loop",
+      turn: 5,
+      history: [
+        { role: "user", content: "old prompt" },
+        { role: "assistant", content: [{ type: "text", text: "old answer" }] },
+      ],
+      createdAt: new Date().toISOString(),
+    };
+
+    const { result, checkpoints } = await runEngine(
+      capturingSequenceModel([{ type: "text", text: "fresh" }], prompts),
+      {},
+      { resumeState: stale },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("fresh");
+    // History was NOT seeded from the mismatched checkpoint…
+    expect(JSON.stringify(prompts[0])).not.toContain("old prompt");
+    // …and checkpointing restarted from turn 0.
+    expect(checkpoints[0].turn).toBe(0);
+  });
+
+  test("checkpoints are post-compaction: compacted history is what gets persisted", async () => {
+    // Same trigger recipe as the engine-behavior compaction test: an
+    // over-threshold task description plus one tool turn makes the
+    // summarize phase fire at turn 1 — the turn-1 checkpoint must carry
+    // the compacted history, strictly smaller than the turn-0 one.
+    const { result, checkpoints } = await runEngine(
+      mockTurnSequenceModel([
+        { type: "tool-call", toolName: "bash", args: { command: "true" } },
+        { type: "text", text: "compacted and finished" },
+      ]),
+      { contextWindow: 3000, maxTokens: 256 },
+      { taskOverrides: { description: "analyze this dataset. ".repeat(600) } },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(checkpoints).toHaveLength(2);
+    const size0 = JSON.stringify(checkpoints[0].history).length;
+    const size1 = JSON.stringify(checkpoints[1].history).length;
+    // Turn 1 ADDED messages (assistant text) yet its checkpoint is smaller:
+    // only possible if the persisted history is the post-compaction one.
+    expect(size1).toBeLessThan(size0);
+    expect(JSON.stringify(checkpoints[1].history)).not.toContain("analyze this dataset. analyze this dataset.");
+  });
+
+  test("oversized history is not persisted (cap) and the run is unaffected", async () => {
+    const bigContent = "x".repeat(MAX_CHECKPOINT_BYTES + 512 * 1024);
+    const { result, checkpoints } = await runEngine(
+      mockTurnSequenceModel([
+        { type: "tool-call", toolName: "write", args: { path: "big.txt", content: bigContent } },
+        { type: "text", text: "big done" },
+      ]),
+      // Huge context window: keep the compactor out of this test.
+      { contextWindow: 100_000_000 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("big done");
+    // The 4MB+ tool-call args live in the history of every turn — no
+    // checkpoint fits under the cap, so none is persisted.
+    expect(checkpoints).toHaveLength(0);
+  });
+
+  test("a throwing checkpoint sink never fails the run", async () => {
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "still fine" }]));
+    const handle = spawnLoopEngine(makeAgent(), makeTask(), cwd, {
+      polpoDir,
+      onTurnCheckpoint: () => {
+        throw new Error("store went away");
+      },
+    });
+    const result = await handle.done;
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("still fine");
+  });
+});

--- a/packages/node/src/__tests__/resilience.test.ts
+++ b/packages/node/src/__tests__/resilience.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { Orchestrator } from "../core/orchestrator.js";
 import { InMemoryTaskStore, InMemoryRunStore, createTestAgent, createTestActivity } from "./fixtures.js";
 import type { RunRecord } from "@polpo-ai/core/run-store";
+import type { RunnerConfig } from "@polpo-ai/core/types";
+import type { Spawner } from "@polpo-ai/core/spawner";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
 
 function createTestRunRecord(overrides: Partial<RunRecord> = {}): RunRecord {
   const now = new Date().toISOString();
@@ -594,5 +597,184 @@ describe("Orchestrator Resilience", () => {
 
       expect(killCalls).toHaveLength(0);
     });
+  });
+});
+
+// ─── Durable Turns: orphan recovery resumes from checkpoint ──────────
+
+describe("Durable turns recovery", () => {
+  let store: InMemoryTaskStore;
+  let runStore: InMemoryRunStore;
+  let orchestrator: Orchestrator;
+  let spawnedConfigs: RunnerConfig[];
+
+  /** Spawner double: records configs, reports every PID as dead. */
+  function fakeSpawner(): Spawner {
+    return {
+      spawn: async (config) => {
+        spawnedConfigs.push(config);
+        return { pid: 4242, configPath: "/tmp/fake-runner.json" };
+      },
+      isAlive: () => false,
+      kill: () => {},
+    };
+  }
+
+  function makeCheckpoint(overrides: Partial<LoopResumeState> = {}): LoopResumeState {
+    const now = new Date().toISOString();
+    return {
+      context: {},
+      steps: [],
+      loopName: "default",
+      turn: 1,
+      history: [
+        { role: "user", content: "original task prompt" },
+        { role: "assistant", content: [{ type: "tool-call", toolCallId: "c1", toolName: "bash", input: { command: "true" } }] },
+        { role: "tool", content: [{ type: "tool-result", toolCallId: "c1", toolName: "bash", output: { type: "text", value: "ok" } }] },
+      ],
+      accumText: "",
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    };
+  }
+
+  function runRecord(taskId: string, overrides: Partial<RunRecord> = {}): RunRecord {
+    const now = new Date().toISOString();
+    return {
+      id: `run-${taskId}`,
+      taskId,
+      pid: 99999,
+      agentName: "agent-1",
+      status: "running",
+      startedAt: now,
+      updatedAt: now,
+      activity: createTestActivity(),
+      configPath: "/tmp/run.json",
+      ...overrides,
+    };
+  }
+
+  async function createOrphanTask(title: string) {
+    const task = await orchestrator.engine.createTask({
+      title,
+      description: "interrupted work",
+      assignTo: "agent-1",
+    });
+    await store.transition(task.id, "assigned");
+    await store.transition(task.id, "in_progress");
+    return task;
+  }
+
+  /** Recovery reset the task to pending — now let the runner spawn it. */
+  async function respawn(taskId: string) {
+    const task = await store.getTask(taskId);
+    expect(task!.status).toBe("pending");
+    await (orchestrator.engine as any).runner.spawnForTask(task);
+  }
+
+  beforeEach(async () => {
+    store = new InMemoryTaskStore();
+    runStore = new InMemoryRunStore();
+    spawnedConfigs = [];
+
+    orchestrator = new Orchestrator({
+      workDir: "/tmp/orchestra-durable-turns-test",
+      store,
+      runStore,
+      spawner: fakeSpawner(),
+      assessFn: async () => ({
+        passed: true,
+        checks: [],
+        metrics: [],
+        timestamp: new Date().toISOString(),
+      }),
+    });
+    await orchestrator.initInteractive("test-project", {
+      name: "test-team",
+      agents: [createTestAgent({ name: "agent-1" })],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dead runner with a fresh checkpoint: respawn carries resumeState (one-shot)", async () => {
+    const task = await createOrphanTask("Resumable task");
+    await runStore.upsertRun(runRecord(task.id, { resumeState: makeCheckpoint() }));
+
+    const recovered = await orchestrator.engine.recoverOrphanedTasks();
+    expect(recovered).toBe(1);
+    // Run record is cleaned up exactly like before.
+    expect(await runStore.getRun(`run-${task.id}`)).toBeUndefined();
+
+    await respawn(task.id);
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeDefined();
+    expect(spawnedConfigs[0].resumeState!.turn).toBe(1);
+    expect(spawnedConfigs[0].resumeState!.loopName).toBe("default");
+    expect(spawnedConfigs[0].resumeState!.history).toHaveLength(3);
+
+    // The handoff is one-shot: a later spawn of the same task (e.g. a real
+    // retry after a genuine failure) starts from zero again.
+    await store.unsafeSetStatus(task.id, "pending", "test reset");
+    await (orchestrator.engine as any).runner.spawnForTask(await store.getTask(task.id));
+    expect(spawnedConfigs).toHaveLength(2);
+    expect(spawnedConfigs[1].resumeState).toBeUndefined();
+  });
+
+  it("dead runner without checkpoint: unchanged fallback, retry from zero", async () => {
+    const task = await createOrphanTask("No checkpoint");
+    await runStore.upsertRun(runRecord(task.id));
+
+    const recovered = await orchestrator.engine.recoverOrphanedTasks();
+    expect(recovered).toBe(1);
+
+    await respawn(task.id);
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeUndefined();
+  });
+
+  it("stale checkpoint (older than the max age) is ignored", async () => {
+    const task = await createOrphanTask("Stale checkpoint");
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    await runStore.upsertRun(runRecord(task.id, {
+      resumeState: makeCheckpoint({ createdAt: twoHoursAgo, updatedAt: twoHoursAgo }),
+    }));
+
+    await orchestrator.engine.recoverOrphanedTasks();
+    await respawn(task.id);
+
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeUndefined();
+  });
+
+  it("empty-history checkpoint is ignored (no turn ever completed)", async () => {
+    const task = await createOrphanTask("Empty checkpoint");
+    await runStore.upsertRun(runRecord(task.id, {
+      resumeState: makeCheckpoint({ history: [] }),
+    }));
+
+    await orchestrator.engine.recoverOrphanedTasks();
+    await respawn(task.id);
+
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeUndefined();
+  });
+
+  it("checkpoint of a task no longer pending after recovery is dropped", async () => {
+    // Dead run with a checkpoint, but its task is already done — nothing
+    // to resume, and the entry must not leak into a future spawn.
+    const task = await createOrphanTask("Already done");
+    await store.unsafeSetStatus(task.id, "done", "finished elsewhere");
+    await runStore.upsertRun(runRecord(task.id, { resumeState: makeCheckpoint() }));
+
+    await orchestrator.engine.recoverOrphanedTasks();
+
+    await store.unsafeSetStatus(task.id, "pending", "test reset");
+    await (orchestrator.engine as any).runner.spawnForTask(await store.getTask(task.id));
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeUndefined();
   });
 });

--- a/packages/node/src/adapters/loop-engine.ts
+++ b/packages/node/src/adapters/loop-engine.ts
@@ -53,7 +53,7 @@ import {
   type PolpoTool,
   type ToolResult,
 } from "@polpo-ai/core";
-import type { LoopToolCall, LoopConfig, ProjectLoopConfig } from "@polpo-ai/core";
+import type { LoopToolCall, LoopConfig, LoopResumeState, ProjectLoopConfig } from "@polpo-ai/core";
 import { projectLoopConfigSchema } from "@polpo-ai/core/schemas";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import { NodeFileSystem } from "./node-filesystem.js";
@@ -96,6 +96,30 @@ async function loadProjectLoop(fs: FileSystem, polpoDir: string, name: string): 
  *  in the system prompt). */
 function isImplicitDefault(agent: AgentConfig, selectionName: string): boolean {
   return selectionName === "default" && !agent.defaultLoop && !agent.loops?.default;
+}
+
+// ─── Durable turns ─────────────────────────────────────
+
+/**
+ * Serialized-history cap for a single checkpoint write. Post-compaction
+ * histories sit well under this; anything larger (e.g. multi-MB tool-call
+ * args) is skipped and the previous checkpoint stays the resume point —
+ * losing one turn of resumability is better than multi-MB writes per turn.
+ */
+export const MAX_CHECKPOINT_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Validate a resume checkpoint against the session about to start. A
+ * checkpoint only applies to the same loop session and must carry actual
+ * history and a completed-turn index; anything else falls back to a fresh
+ * start (never fails the run).
+ */
+function usableResumeState(resume: LoopResumeState | undefined, loopName: string): LoopResumeState | undefined {
+  if (!resume) return undefined;
+  if (resume.loopName !== loopName) return undefined;
+  if (typeof resume.turn !== "number" || resume.turn < 0) return undefined;
+  if (!Array.isArray(resume.history) || resume.history.length === 0) return undefined;
+  return resume;
 }
 
 // ─── Engine ────────────────────────────────────────────
@@ -230,8 +254,13 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
     loopName: string;
     loop: LoopConfig;
     contextPrompt?: string;
+    /** Durable-turns checkpoint to resume from (single-session paths only). */
+    resume?: LoopResumeState;
+    /** Durable-turns checkpoint sink — wired to RunStore.updateResumeState by the runner. */
+    onCheckpoint?: (state: LoopResumeState) => void | Promise<void>;
   }): Promise<{ lastText: string; accumText: string }> {
     const { sessionAgent, loopName, loop, contextPrompt } = options;
+    const resume = usableResumeState(options.resume, loopName);
 
     const prep = prepareSpawn(sessionAgent, cwd, ctx);
     const { model, providerOptions } = prep;
@@ -246,9 +275,14 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
     const toolDescriptions = allPolpoTools.map((t) => ({ description: t.description ?? "" }));
 
     // Conversation state owned by the host, exactly like the legacy loop.
-    let messages: ModelMessage[] = [{ role: "user", content: buildPrompt(task) }];
+    // On resume the recorded history (already containing tool-call and
+    // tool-result pairs from completed turns) replaces the fresh prompt —
+    // side-effects replay from recorded results, they never re-execute.
+    let messages: ModelMessage[] = resume
+      ? [...(resume.history as ModelMessage[])]
+      : [{ role: "user", content: buildPrompt(task) }];
     let lastStepText = "";
-    let accumText = "";
+    let accumText = resume?.accumText ?? "";
 
     const summarize: SummarizeFn = async (msgs, compactionPrompt) => {
       const response = await generateText({
@@ -395,13 +429,38 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
       return llmText;
     };
 
+    // ── Durable turns: one checkpoint write per completed turn ──
+    // Emitted at end-of-turn, so `messages` is post-tool-execution and
+    // post-compaction by construction (compaction rewrites `messages` at
+    // the START of a model step). The JSON round-trip here pins store
+    // fidelity: what a resumed run sees is exactly what survives JSON.
+    const checkpointCreatedAt = resume?.createdAt ?? new Date().toISOString();
+    const onTurnCheckpoint = options.onCheckpoint
+      ? async ({ turn }: { turn: number }) => {
+          const serialized = JSON.stringify(messages);
+          if (serialized.length > MAX_CHECKPOINT_BYTES) return; // keep the previous checkpoint
+          await options.onCheckpoint!({
+            context: {},
+            steps: [],
+            loopName,
+            turn,
+            history: JSON.parse(serialized) as unknown[],
+            accumText,
+            createdAt: checkpointCreatedAt,
+            updatedAt: new Date().toISOString(),
+          });
+        }
+      : undefined;
+
     const runner = new LoopRunner();
     await runner.run({
       agent: sessionAgent,
       loop: { ...loop, name: loopName },
       maxTurns,
+      startTurn: resume ? resume.turn! + 1 : 0,
       model: modelStep,
       executeTool,
+      onTurnCheckpoint,
     });
 
     return { lastText: lastStepText, accumText };
@@ -411,6 +470,12 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
    * Run a project loop graph (.polpo/loops/<name>.json) through the
    * PipelineExecutor: agent steps are independent LLM sessions that share
    * the context bag; tool steps execute deterministically with no LLM turn.
+   *
+   * Durable turns (Phase A) does NOT checkpoint pipeline task runs: a
+   * pipeline checkpoint needs pipeline position + per-step session history
+   * (the LoopResumeState pipeline fields cover position, per-step history
+   * does not exist yet) — Phase B. Pipeline runs ignore ctx.resumeState
+   * and start fresh, which is the pre-existing behavior.
    */
   async function runPipeline(projectLoop: ProjectLoopConfig): Promise<string> {
     const normalized = normalizeProjectLoop(projectLoop);
@@ -507,6 +572,8 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
           sessionAgent: agentConfig,
           loopName: "default",
           loop: { maxTurns: agentConfig.maxTurns },
+          resume: ctx?.resumeState,
+          onCheckpoint: ctx?.onTurnCheckpoint,
         });
         stdout = session.lastText;
       } else {
@@ -517,6 +584,8 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
           sessionAgent: stepAgent,
           loopName: selection.name,
           loop: selection.loop,
+          resume: ctx?.resumeState,
+          onCheckpoint: ctx?.onTurnCheckpoint,
         });
         stdout = session.lastText;
       }

--- a/packages/node/src/core/runner.ts
+++ b/packages/node/src/core/runner.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { FileRunStore } from "@polpo-ai/file-stores";
 import { spawnLoopEngine } from "../adapters/loop-engine.js";
 import type { RunStore, RunRecord } from "@polpo-ai/core/run-store";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
 import type { LogStore } from "@polpo-ai/core/log-store";
 import type { RunnerConfig, TaskResult } from "@polpo-ai/core/types";
 import { sanitizeTranscriptEntry } from "../server/security.js";
@@ -224,8 +225,23 @@ async function main(): Promise<void> {
       // Runner is a subprocess — creates its own fs/shell instances
       fs: new NodeFileSystem(),
       shell: new NodeShell(),
+      // Durable turns: resume checkpoint handed over by orphan recovery,
+      // and the per-turn checkpoint sink (one RunStore write per turn,
+      // best-effort — a flaky store must never fail a healthy run).
+      resumeState: config.resumeState,
+      onTurnCheckpoint: async (state: LoopResumeState) => {
+        try {
+          await runStore.updateResumeState?.(config.runId, state);
+        } catch { /* best effort */ }
+      },
     };
     handle = spawnLoopEngine(config.agent, config.task, config.cwd, spawnCtx);
+    if (config.resumeState) {
+      actLog.logEvent("resuming", {
+        loopName: config.resumeState.loopName,
+        fromTurn: (config.resumeState.turn ?? -1) + 1,
+      });
+    }
     // Propagate the LogStore sessionId onto the agent's activity blob so
     // the poll loop's updateActivity() persists it on every tick. Without
     // this the run record has activity.sessionId = undefined forever, and

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig(({ mode }) => {
   return {
     test: {
       env,
+      // Some suites bootstrap the full server stack (orchestrator + SSE
+      // bridge + app) in beforeAll via dynamic imports; under a saturated
+      // worker pool that hook already takes ~9-11s, so the default 10s
+      // hookTimeout flakes depending on file scheduling. Assertion/test
+      // timeouts stay at their defaults.
+      hookTimeout: 30_000,
     },
   };
 });


### PR DESCRIPTION
Phase A of the v2 execution chapter: the agent loop's state becomes durable.

- **Per-turn checkpoints**: LoopRunner gains `onTurnCheckpoint` (best-effort callback, core stays pure) + `startTurn`; loop-engine serializes the message history at the end of every turn (1 write/turn, 4MB cap, post-compaction by construction) into `RunRecord.resumeState` — the extended `LoopResumeState` format already used by completions project-loop resume. One format for both paths.
- **Persistence**: optional `RunStore.updateResumeState` implemented on file, SQLite and PG stores (schema column auto-migrated by both derived migrators). Stores that don't implement it lose resumability, never correctness.
- **Recovery = resume, not retry-from-zero**: orphaned running tasks with a dead PID and a fresh checkpoint (≤1h) re-spawn with the seeded history and restart from turn+1 — recorded tool calls are replayed from history, **never re-executed** (Temporal semantics, asserted by test). No checkpoint → exact current behavior.
- 11 new tests (6 durable-turns incl. crash→resume with model-visible history verification, size cap, post-compaction; 5 recovery) — full suite 1942 green, typecheck clean, all API changes additive.

Honest leftovers tracked for Phase B: pipeline runs don't checkpoint yet; live-orchestrator crash detection still retries from zero (resume is startup-recovery only); oversized-history handling is conservative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)