### PR TITLE
feat: InProcessSpawner — the task loop can run inside the server (ProxyTool P0)

### DIFF
--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -219,7 +219,10 @@ export class TaskRunner {
         if (elapsed > timeout) {
           this.ctx.emitter.emit("log", { level: "warn", message: `[${run.taskId}] Timed out (${Math.round(elapsed / 1000)}s)` });
           this.ctx.emitter.emit("task:timeout", { taskId: run.taskId, elapsed, timeout });
-          if (run.pid > 0) {
+          // pid 0 = untracked (sandbox spawners); positive = OS subprocess;
+          // negative = in-process synthetic pid — both of the latter are
+          // killable through the spawner that issued them.
+          if (run.pid !== 0) {
             try { this.ctx.spawner.kill(run.pid); } catch { /* already dead */ }
           }
           // Mark run as killed so we don't retry every tick
@@ -238,7 +241,8 @@ export class TaskRunner {
         if (idle > staleThreshold * 2) {
           this.ctx.emitter.emit("log", { level: "error", message: `[${run.taskId}] Agent unresponsive for ${Math.round(idle / 1000)}s — killing` });
           this.ctx.emitter.emit("agent:stale", { taskId: run.taskId, agentName: run.agentName, idleMs: idle, action: "killed" });
-          if (run.pid > 0) {
+          // Same pid convention as the timeout branch above (0 = untracked).
+          if (run.pid !== 0) {
             try { this.ctx.spawner.kill(run.pid); } catch { /* already dead */ }
           }
           // Mark run as killed so we don't retry every tick

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -169,6 +169,13 @@ export interface PolpoSettings {
   /** Storage backend for tasks, missions, and runs. Default: "file" (filesystem JSON).
    *  "postgres" requires @polpo-ai/drizzle and a databaseUrl. */
   storage?: "file" | "sqlite" | "postgres";
+  /** How task runs execute. Default: "subprocess" (a detached runner is
+   *  forked per task). "in-process" runs the same lifecycle inside the
+   *  orchestrator process against its own stores — the first building
+   *  block of the proxy execution model (LLM loop in the server, tools
+   *  proxied to the sandbox in later phases). Per-task/per-agent policy
+   *  is future work; this is a global opt-in. */
+  taskExecution?: "subprocess" | "in-process";
   /** PostgreSQL connection URL (required when storage is "postgres").
    *  Example: "postgres://user:pass@localhost:5432/polpo" */
   databaseUrl?: string;

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -649,6 +649,27 @@ describe("DrizzleLogStore", () => {
     expect(pruned).toBe(1);
     expect(await stores.logStore.listSessions()).toHaveLength(1);
   });
+
+  it("createLogStore returns independent instances over the same db (no session hijack)", async () => {
+    // One dedicated instance per consumer (e.g. per in-process task run):
+    // each keeps its OWN current session…
+    const a = stores.createLogStore!();
+    const b = stores.createLogStore!();
+    const sessA = await a.startSession();
+    const sessB = await b.startSession();
+    expect(sessA).not.toBe(sessB);
+
+    await a.append({ ts: "2025-01-01T00:00:00Z", event: "from-a", data: null });
+    await b.append({ ts: "2025-01-01T00:00:01Z", event: "from-b", data: null });
+
+    expect((await a.getSessionEntries()).map(e => e.event)).toEqual(["from-a"]);
+    expect((await b.getSessionEntries()).map(e => e.event)).toEqual(["from-b"]);
+
+    // …while the shared bundle logStore's current session is untouched,
+    // and all sessions live in the same database (cross-readable by id).
+    expect(await stores.logStore.getSessionId()).toBeUndefined();
+    expect((await stores.logStore.getSessionEntries(sessB)).map(e => e.event)).toEqual(["from-b"]);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -97,6 +97,15 @@ export interface DrizzleStores {
   vaultStore: VaultStore;
   playbookStore: PlaybookStore;
   skillStore: SkillStore;
+  /**
+   * Fresh LogStore over the SAME db handle (no second connection).
+   * LogStore keeps its current session as instance state, so anything
+   * that needs a private transcript session per consumer (e.g. one per
+   * in-process task run) must get a dedicated instance instead of
+   * sharing `logStore` — sharing would hijack its current session.
+   * Optional for backward compatibility with external bundles.
+   */
+  createLogStore?(): LogStore;
 }
 
 // ── PostgreSQL factory ────────────────────────────────────────────────
@@ -118,6 +127,7 @@ export function createPgStores(db: any): DrizzleStores {
     loopRunStore: new DrizzleLoopRunStore(db, loopRunsPg, "pg"),
     sessionStore: new DrizzleSessionStore(db, sessionsPg, messagesPg, "pg"),
     logStore: new DrizzleLogStore(db, logSessionsPg, logEntriesPg, "pg"),
+    createLogStore: () => new DrizzleLogStore(db, logSessionsPg, logEntriesPg, "pg"),
     approvalStore: new DrizzleApprovalStore(db, approvalsPg, "pg"),
     memoryStore: new DrizzleMemoryStore(db, memoryPg),
     checkpointStore: new DrizzleCheckpointStore(db, metadataPg, "pg"),
@@ -150,6 +160,7 @@ export function createSqliteStores(db: any): DrizzleStores {
     loopRunStore: new DrizzleLoopRunStore(db, loopRunsSqlite, "sqlite"),
     sessionStore: new DrizzleSessionStore(db, sessionsSqlite, messagesSqlite, "sqlite"),
     logStore: new DrizzleLogStore(db, logSessionsSqlite, logEntriesSqlite, "sqlite"),
+    createLogStore: () => new DrizzleLogStore(db, logSessionsSqlite, logEntriesSqlite, "sqlite"),
     approvalStore: new DrizzleApprovalStore(db, approvalsSqlite, "sqlite"),
     memoryStore: new DrizzleMemoryStore(db, memorySqlite),
     checkpointStore: new DrizzleCheckpointStore(db, metadataSqlite, "sqlite"),

--- a/packages/node/src/__tests__/in-process-spawner.test.ts
+++ b/packages/node/src/__tests__/in-process-spawner.test.ts
@@ -1,0 +1,448 @@
+/**
+ * InProcessSpawner — the task lifecycle running INSIDE the orchestrator
+ * process (ProxyTool P0, Phase B).
+ *
+ * Contract under test:
+ *
+ * 1. E2E: spawn(config) → the same lifecycle as the subprocess runner
+ *    (both call executeRun): task run goes running → completed against the
+ *    INJECTED stores (no second store/DB), result + transcript persisted.
+ * 2. Lifecycle: isAlive(pid) is true while the run is in flight and false
+ *    after; kill(pid) aborts the run → run record "killed" (exitCode 1),
+ *    matching the subprocess SIGTERM semantics.
+ * 3. Reactive tick: SpawnResult.onExit fires when the run settles — through
+ *    the real orchestrator, task completion is collected via the run:exited
+ *    wake event without waiting out the poll interval.
+ * 4. Durable turns in-process: per-turn checkpoints land on the run record;
+ *    a respawn with config.resumeState resumes at turn + 1 without
+ *    re-executing recorded tools — identical to the subprocess path.
+ * 5. Parity: the same task executed through subprocess-style deps (own
+ *    stores built from polpoDir, exactly what core/runner.ts main() wires)
+ *    and through the InProcessSpawner yields the same observable outcome:
+ *    status, result shape, transcript event sequence.
+ * 6. A run that throws NEVER crashes the orchestrator: spawn() resolves,
+ *    onExit still fires, and the failure is persisted best-effort.
+ *
+ * Mock strategy: same as engine-behavior/run-lifecycle — vi.mock
+ * @polpo-ai/llm so resolveModel returns a MockLanguageModelV3. Everything
+ * else (spawner, executeRun, stores, tools, filesystem) runs for real.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { mkdtemp, mkdir, rm, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedModel } from "@polpo-ai/llm";
+import {
+  MockLanguageModelV3,
+  mockTextModel,
+  mockTurnSequenceModel,
+  mockResolvedModel,
+} from "./helpers/mock-llm.js";
+
+// ── Mock the LLM module BEFORE any imports that pull it in ──
+
+let activeResolvedModel: ResolvedModel = mockResolvedModel(mockTextModel("default"));
+
+vi.mock("@polpo-ai/llm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@polpo-ai/llm")>();
+  return {
+    ...actual,
+    resolveModel: () => activeResolvedModel,
+    enforceModelAllowlist: () => {},
+    mapReasoningToProviderOptions: () => undefined,
+  };
+});
+
+import { InProcessSpawner } from "../adapters/in-process-spawner.js";
+import { executeRun } from "../core/run-lifecycle.js";
+import { Orchestrator } from "../core/orchestrator.js";
+import { InMemoryRunStore, InMemoryTaskStore, createTestAgent } from "./fixtures.js";
+import { FileRunStore } from "@polpo-ai/file-stores";
+import type { AgentConfig, Task, RunnerConfig } from "@polpo-ai/core/types";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
+
+// ── Helpers ─────────────────────────────────────────────
+
+function setMockModel(model: MockLanguageModelV3, overrides: Partial<ResolvedModel> = {}) {
+  activeResolvedModel = { ...mockResolvedModel(model), ...overrides };
+}
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { name: "inproc-agent", role: "developer", ...overrides };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-inproc-1",
+    title: "In-process task",
+    description: "Do the scripted thing.",
+    state: "in_progress",
+    expectations: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    assignedTo: "inproc-agent",
+    ...overrides,
+  } as Task;
+}
+
+let tmpRoot: string;
+let cwd: string;
+let polpoDir: string;
+let runSeq = 0;
+
+function makeConfig(overrides: Partial<RunnerConfig> = {}): RunnerConfig {
+  const runId = `run-ip-${++runSeq}`;
+  return {
+    runId,
+    taskId: makeTask().id,
+    agent: makeAgent(),
+    task: makeTask(),
+    polpoDir,
+    cwd,
+    outputDir: join(polpoDir, "output", runId),
+    ...overrides,
+  };
+}
+
+/** Await a SpawnResult.onExit callback as a promise. */
+function onExitPromise(spawnResult: { onExit?: (cb: () => void) => void }): Promise<void> {
+  return new Promise((resolve) => spawnResult.onExit!(resolve));
+}
+
+/** Read the transcript event-type sequence from the JSONL activity log. */
+async function transcriptShape(dir: string, runId: string): Promise<string[]> {
+  const raw = await readFile(join(dir, "logs", `run-${runId}.jsonl`), "utf-8");
+  return raw.trim().split("\n")
+    .map((l) => JSON.parse(l))
+    .map((e) => (e.event ?? e.type ?? "?") as string)
+    .filter((t) => t !== "activity"); // poll-timing dependent
+}
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "polpo-inproc-spawner-"));
+  cwd = join(tmpRoot, "work");
+  polpoDir = join(tmpRoot, ".polpo");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(polpoDir, { recursive: true });
+});
+
+afterAll(async () => {
+  if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true });
+});
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("InProcessSpawner", () => {
+  test("E2E: task runs in-process against the injected stores, result + transcript persisted", async () => {
+    setMockModel(mockTurnSequenceModel([
+      { type: "tool-call", toolName: "write", args: { path: "ip-a.txt", content: "in-process" } },
+      { type: "text", text: "in-process done" },
+    ]));
+    const store = new InMemoryRunStore();
+    const spawner = new InProcessSpawner(() => ({ runStore: store }));
+    const config = makeConfig();
+
+    const spawnResult = await spawner.spawn(config);
+    // Synthetic negative pid — never a real OS pid, never 0 (0 = untracked).
+    expect(spawnResult.pid).toBeLessThan(0);
+    expect(spawnResult.configPath).toBe(`memory://run-${config.runId}`);
+
+    await onExitPromise(spawnResult);
+
+    // The run completed against the INJECTED store.
+    const run = await store.getRun(config.runId);
+    expect(run?.status).toBe("completed");
+    expect(run?.result?.exitCode).toBe(0);
+    expect(run?.result?.stdout).toBe("in-process done");
+    expect(run?.pid).toBe(spawnResult.pid);
+
+    // Tool side-effect + transcript log on disk, like the subprocess.
+    expect(await readFile(join(cwd, "ip-a.txt"), "utf-8")).toBe("in-process");
+    const shape = await transcriptShape(polpoDir, config.runId);
+    expect(shape).toContain("tool_use");
+    expect(shape).toContain("assistant");
+    // Output dir was created (NodeSpawner parity).
+    expect(existsSync(config.outputDir)).toBe(true);
+  });
+
+  test("lifecycle: isAlive during the run, false after; kill() → run killed", async () => {
+    // Model blocks until aborted.
+    setMockModel(new MockLanguageModelV3({
+      doStream: (opts) => new Promise((_resolve, reject) => {
+        const fail = () => reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        if (opts.abortSignal?.aborted) return fail();
+        opts.abortSignal?.addEventListener("abort", fail, { once: true });
+      }),
+    }));
+
+    const store = new InMemoryRunStore();
+    const spawner = new InProcessSpawner(() => ({ runStore: store }));
+    const config = makeConfig();
+
+    const spawnResult = await spawner.spawn(config);
+    expect(spawner.isAlive(spawnResult.pid)).toBe(true);
+
+    // Kill mid-turn — the AbortController reaches the engine.
+    spawner.kill(spawnResult.pid);
+    await onExitPromise(spawnResult);
+
+    expect(spawner.isAlive(spawnResult.pid)).toBe(false);
+    const run = await store.getRun(config.runId);
+    expect(run?.status).toBe("killed");
+    expect(run?.result?.exitCode).toBe(1);
+    expect(run?.result?.stderr).toContain("Killed by SIGTERM (timeout or shutdown)");
+  });
+
+  test("kill of an unknown pid is a safe no-op", () => {
+    const spawner = new InProcessSpawner(() => ({ runStore: new InMemoryRunStore() }));
+    expect(() => spawner.kill(-999)).not.toThrow();
+    expect(spawner.isAlive(-999)).toBe(false);
+    expect(spawner.isAlive(0)).toBe(false);
+  });
+
+  test("durable turns in-process: checkpoint persisted, resume skips recorded tools", async () => {
+    // ── Run 1: turn 0 writes a file, then the model crashes ──
+    let calls = 0;
+    const inner = mockTurnSequenceModel([
+      { type: "tool-call", toolName: "write", args: { path: "ip-resume.txt", content: "turn zero" } },
+    ]);
+    setMockModel(new MockLanguageModelV3({
+      doStream: (opts) => {
+        if (calls++ >= 1) throw new Error("simulated crash");
+        return inner.doStream(opts);
+      },
+    }));
+
+    const store = new InMemoryRunStore();
+    const spawner = new InProcessSpawner(() => ({ runStore: store }));
+    const config = makeConfig();
+
+    const first = await spawner.spawn(config);
+    await onExitPromise(first);
+
+    const crashed = await store.getRun(config.runId);
+    expect(crashed?.status).toBe("failed");
+    const checkpoint = crashed?.resumeState as LoopResumeState;
+    expect(checkpoint?.turn).toBe(0);
+    expect(JSON.stringify(checkpoint.history)).toContain("ip-resume.txt");
+
+    // Wipe the side-effect so re-execution would be visible.
+    await rm(join(cwd, "ip-resume.txt"));
+
+    // ── Run 2: respawn with the harvested checkpoint (what orphan recovery does) ──
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "resumed in-process" }]));
+    const config2 = makeConfig({ resumeState: checkpoint });
+    const second = await spawner.spawn(config2);
+    await onExitPromise(second);
+
+    const resumed = await store.getRun(config2.runId);
+    expect(resumed?.status).toBe("completed");
+    expect(resumed?.result?.stdout).toBe("resumed in-process");
+    // Temporal semantics: the recorded tool did NOT re-execute.
+    expect(existsSync(join(cwd, "ip-resume.txt"))).toBe(false);
+    // Turn numbering continued past the checkpoint.
+    expect((resumed?.resumeState as LoopResumeState)?.turn).toBe(1);
+  });
+
+  test("a run whose lifecycle throws never crashes the host: onExit fires, failure persisted", async () => {
+    setMockModel(mockTextModel("irrelevant"));
+    const store = new InMemoryRunStore();
+    // Sabotage the very first store write — the one failure executeRun
+    // cannot persist by itself (its own entry point).
+    const upsert = store.upsertRun.bind(store);
+    let failFirst = true;
+    store.upsertRun = async (run) => {
+      if (failFirst) { failFirst = false; throw new Error("store down"); }
+      return upsert(run);
+    };
+    const spawner = new InProcessSpawner(() => ({ runStore: store }));
+    const config = makeConfig();
+
+    const spawnResult = await spawner.spawn(config);
+    await onExitPromise(spawnResult); // resolves — no crash, no unhandled rejection
+    expect(spawner.isAlive(spawnResult.pid)).toBe(false);
+  });
+});
+
+// ── Parity: subprocess-style deps vs InProcessSpawner ───
+
+describe("parity: subprocess lifecycle vs InProcessSpawner", () => {
+  /** The scripted task both hosts execute. */
+  const script = () => mockTurnSequenceModel([
+    { type: "tool-call", toolName: "write", args: { path: "parity.txt", content: "same task" } },
+    { type: "text", text: "parity done" },
+  ]);
+
+  test("same task → same status, result and transcript shape", async () => {
+    // ── Host A: subprocess-style — exactly what core/runner.ts main() wires:
+    //    its own FileRunStore over polpoDir, own fs/shell, process pid.
+    const subDir = join(tmpRoot, "sub");
+    await mkdir(join(subDir, "work"), { recursive: true });
+    await mkdir(join(subDir, ".polpo"), { recursive: true });
+    setMockModel(script());
+    const subStore = new FileRunStore(join(subDir, ".polpo"));
+    const subConfig = makeConfig({
+      polpoDir: join(subDir, ".polpo"),
+      cwd: join(subDir, "work"),
+      outputDir: join(subDir, ".polpo", "output", "t"),
+    });
+    const subOutcome = await executeRun(subConfig, {
+      runStore: subStore,
+      pid: process.pid,
+      configPath: join(subDir, ".polpo", "tmp", `run-${subConfig.runId}.json`),
+    });
+    const subRun = await subStore.getRun(subConfig.runId);
+
+    // ── Host B: InProcessSpawner over injected stores.
+    const inDir = join(tmpRoot, "inp");
+    await mkdir(join(inDir, "work"), { recursive: true });
+    await mkdir(join(inDir, ".polpo"), { recursive: true });
+    setMockModel(script());
+    const inStore = new InMemoryRunStore();
+    const spawner = new InProcessSpawner(() => ({ runStore: inStore }));
+    const inConfig = makeConfig({
+      polpoDir: join(inDir, ".polpo"),
+      cwd: join(inDir, "work"),
+      outputDir: join(inDir, ".polpo", "output", "t"),
+    });
+    const spawnResult = await spawner.spawn(inConfig);
+    await onExitPromise(spawnResult);
+    const inRun = await inStore.getRun(inConfig.runId);
+
+    // Observable outcome is identical.
+    expect(inRun?.status).toBe(subRun?.status);
+    expect(inRun?.status).toBe("completed");
+    expect(inRun?.result?.exitCode).toBe(subRun?.result?.exitCode);
+    expect(inRun?.result?.stdout).toBe(subRun?.result?.stdout);
+    expect(inRun?.result?.stderr).toBe(subRun?.result?.stderr);
+    expect(inRun?.activity.toolCalls).toBe(subRun?.activity.toolCalls);
+    // Same files created (paths differ only by each host's temp workdir).
+    const basename = (p: string) => p.split("/").pop();
+    expect(inRun?.activity.filesCreated.map(basename)).toEqual(subRun?.activity.filesCreated.map(basename));
+
+    // Same side-effects on disk…
+    expect(await readFile(join(subDir, "work", "parity.txt"), "utf-8")).toBe("same task");
+    expect(await readFile(join(inDir, "work", "parity.txt"), "utf-8")).toBe("same task");
+
+    // …and the same transcript event sequence.
+    const subShape = await transcriptShape(join(subDir, ".polpo"), subConfig.runId);
+    const inShape = await transcriptShape(join(inDir, ".polpo"), inConfig.runId);
+    expect(inShape).toEqual(subShape);
+  });
+});
+
+// ── Reactive tick through the real orchestrator ─────────
+
+describe("orchestrator + InProcessSpawner (reactive tick)", () => {
+  test("task → running → done, collected via run:exited without waiting the poll", async () => {
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "orchestrated" }]));
+
+    const orchDir = join(tmpRoot, "orch");
+    await mkdir(orchDir, { recursive: true });
+    const store = new InMemoryTaskStore();
+    const runStore = new InMemoryRunStore();
+    // The spawner reuses the orchestrator's run store — the very stores the
+    // tick reads. Deps are lazy, exactly how the orchestrator wires them.
+    const spawner = new InProcessSpawner(() => ({ runStore }));
+
+    const orchestrator = new Orchestrator({
+      workDir: orchDir,
+      store,
+      runStore,
+      spawner,
+      assessFn: async () => ({
+        passed: true, checks: [], metrics: [], timestamp: new Date().toISOString(),
+      }),
+    });
+    await orchestrator.initInteractive("inproc-tick-test", {
+      name: "team",
+      agents: [createTestAgent({ name: "worker" })],
+    });
+
+    const exited = new Promise<void>((resolve) => {
+      orchestrator.on("run:exited", () => resolve());
+    });
+
+    await orchestrator.engine.createTask({
+      title: "In-process tick task",
+      description: "Say something",
+      assignTo: "worker",
+    });
+
+    // Tick 1: spawns the in-process run.
+    await orchestrator.tick();
+    const task = (await store.listTasks())[0];
+    expect(task.status).toBe("in_progress");
+
+    // The reactive wake: run:exited fires when the run settles — no
+    // simulated runner, no poll-interval wait.
+    await exited;
+
+    // Tick 2: collect the REAL in-process result.
+    await orchestrator.tick();
+    await vi.waitFor(async () => {
+      expect((await store.getTask(task.id))!.status).toBe("done");
+    });
+    expect((await store.getTask(task.id))!.result?.stdout).toBe("orchestrated");
+  });
+
+  test("timeout health check reaches the in-process engine (negative pid kill)", async () => {
+    // Model blocks until aborted — only a real kill can settle the run.
+    setMockModel(new MockLanguageModelV3({
+      doStream: (opts) => new Promise((_resolve, reject) => {
+        const fail = () => reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        if (opts.abortSignal?.aborted) return fail();
+        opts.abortSignal?.addEventListener("abort", fail, { once: true });
+      }),
+    }));
+
+    const orchDir = join(tmpRoot, "orch-timeout");
+    await mkdir(orchDir, { recursive: true });
+    const store = new InMemoryTaskStore();
+    const runStore = new InMemoryRunStore();
+    const spawner = new InProcessSpawner(() => ({ runStore }));
+
+    const orchestrator = new Orchestrator({
+      workDir: orchDir,
+      store,
+      runStore,
+      spawner,
+      assessFn: async () => ({
+        passed: true, checks: [], metrics: [], timestamp: new Date().toISOString(),
+      }),
+    });
+    await orchestrator.initInteractive("inproc-timeout-test", {
+      name: "team",
+      agents: [createTestAgent({ name: "worker" })],
+    });
+
+    await orchestrator.engine.createTask({
+      title: "Hung in-process task",
+      description: "Never finishes on its own",
+      assignTo: "worker",
+    });
+
+    // Tick 1: spawn the (hung) in-process run.
+    await orchestrator.tick();
+    const task = (await store.listTasks())[0];
+    const run = (await runStore.getRunByTaskId(task.id))!;
+    expect(run.pid).toBeLessThan(0);
+    expect(spawner.isAlive(run.pid)).toBe(true);
+
+    // Rewind the clock: the run is now far beyond the default task timeout.
+    await runStore.upsertRun({
+      ...run,
+      startedAt: new Date(Date.now() - 31 * 60 * 1000).toISOString(),
+    });
+
+    // Tick 2: enforceHealthChecks must kill THROUGH the spawner — a
+    // negative (in-process) pid is killable, only pid 0 means untracked.
+    await orchestrator.tick();
+    await vi.waitFor(() => {
+      expect(spawner.isAlive(run.pid)).toBe(false);
+    });
+    expect((await runStore.getRun(run.id))?.status).toBe("killed");
+  });
+});

--- a/packages/node/src/__tests__/in-process-spawner.test.ts
+++ b/packages/node/src/__tests__/in-process-spawner.test.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { mkdtemp, mkdir, rm, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -56,6 +56,7 @@ vi.mock("@polpo-ai/llm", async (importOriginal) => {
 });
 
 import { InProcessSpawner } from "../adapters/in-process-spawner.js";
+import { NodeSpawner } from "../adapters/node-spawner.js";
 import { executeRun } from "../core/run-lifecycle.js";
 import { Orchestrator } from "../core/orchestrator.js";
 import { InMemoryRunStore, InMemoryTaskStore, createTestAgent } from "./fixtures.js";
@@ -444,5 +445,77 @@ describe("orchestrator + InProcessSpawner (reactive tick)", () => {
       expect(spawner.isAlive(run.pid)).toBe(false);
     });
     expect((await runStore.getRun(run.id))?.status).toBe("killed");
+  });
+});
+
+// ── settings.taskExecution selection ────────────────────
+
+describe("settings.taskExecution selection", () => {
+  /** Prepare an isolated project dir, optionally with a polpo.json. */
+  async function makeProject(name: string, settings?: Record<string, unknown>): Promise<string> {
+    const dir = join(tmpRoot, name);
+    await mkdir(join(dir, ".polpo"), { recursive: true });
+    if (settings) {
+      await writeFile(
+        join(dir, ".polpo", "polpo.json"),
+        JSON.stringify({ project: name, settings: { maxRetries: 2, workDir: ".", logLevel: "normal", ...settings } }),
+      );
+    }
+    return dir;
+  }
+
+  function spawnerOf(orchestrator: Orchestrator): unknown {
+    return (orchestrator as unknown as { spawner: unknown }).spawner;
+  }
+
+  test("default: no opt-in → subprocess NodeSpawner (zero behavior change)", async () => {
+    const dir = await makeProject("sel-default", {});
+    const orchestrator = new Orchestrator({ workDir: dir });
+    await orchestrator.initInteractive("sel-default", {
+      name: "team", agents: [createTestAgent({ name: "worker" })],
+    });
+    expect(spawnerOf(orchestrator)).toBeInstanceOf(NodeSpawner);
+  });
+
+  test("in-process opt-in: task completes end-to-end without a fork", async () => {
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "selected in-process" }]));
+    const dir = await makeProject("sel-inproc", { taskExecution: "in-process" });
+    const orchestrator = new Orchestrator({
+      workDir: dir,
+      assessFn: async () => ({
+        passed: true, checks: [], metrics: [], timestamp: new Date().toISOString(),
+      }),
+    });
+    await orchestrator.initInteractive("sel-inproc", {
+      name: "team", agents: [createTestAgent({ name: "worker" })],
+    });
+    expect(spawnerOf(orchestrator)).toBeInstanceOf(InProcessSpawner);
+
+    // End-to-end through the orchestrator's OWN (file) stores — proving the
+    // lazy deps wiring, not just the instance swap. A forked subprocess
+    // could never complete here: the LLM mock only exists in this process.
+    const exited = new Promise<void>((resolve) => orchestrator.on("run:exited", () => resolve()));
+    await orchestrator.engine.createTask({
+      title: "Selected task", description: "Say it", assignTo: "worker",
+    });
+    await orchestrator.tick();
+    await exited;
+    await orchestrator.tick();
+
+    const store = orchestrator.getStore();
+    await vi.waitFor(async () => {
+      expect((await store.listTasks())[0].status).toBe("done");
+    });
+    expect((await store.listTasks())[0].result?.stdout).toBe("selected in-process");
+  });
+
+  test("an injected spawner always wins over the setting", async () => {
+    const dir = await makeProject("sel-injected", { taskExecution: "in-process" });
+    const injected = new InProcessSpawner(() => ({ runStore: new InMemoryRunStore() }));
+    const orchestrator = new Orchestrator({ workDir: dir, spawner: injected });
+    await orchestrator.initInteractive("sel-injected", {
+      name: "team", agents: [createTestAgent({ name: "worker" })],
+    });
+    expect(spawnerOf(orchestrator)).toBe(injected);
   });
 });

--- a/packages/node/src/__tests__/run-lifecycle.test.ts
+++ b/packages/node/src/__tests__/run-lifecycle.test.ts
@@ -1,0 +1,326 @@
+/**
+ * executeRun — the shared run lifecycle (run-lifecycle.ts).
+ *
+ * This is the exact code path the subprocess runner (core/runner.ts) has
+ * always executed, now extracted so the InProcessSpawner can share it.
+ * Contract under test:
+ *
+ * 1. Happy path: initial "running" record → engine → terminal "completed"
+ *    record with the TaskResult, plus the JSONL activity log with the
+ *    spawning/spawned/done lifecycle events and the transcript entries.
+ * 2. Engine failure → run "failed" with the error in stderr (exitCode 1);
+ *    executeRun resolves — it never throws for run-level failures.
+ * 3. Abort (the SIGTERM path) → engine killed, run "killed", exitCode
+ *    forced to 1 with the historical "Killed by SIGTERM" stderr marker.
+ * 4. Durable turns: per-turn checkpoints land on the run record via
+ *    RunStore.updateResumeState; config.resumeState resumes at turn + 1
+ *    without re-executing recorded tools.
+ * 5. Spawn failure (engine cannot even start) → run "failed" and
+ *    spawnError: true (the subprocess entry exits 1 on this — the one
+ *    non-zero-exit lifecycle path).
+ *
+ * Mock strategy: same as engine-behavior/loop-engine-durable-turns —
+ * vi.mock @polpo-ai/llm so resolveModel returns a MockLanguageModelV3;
+ * stores and filesystem run for real against a temp dir.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { mkdtemp, mkdir, rm, readFile, unlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedModel } from "@polpo-ai/llm";
+import {
+  MockLanguageModelV3,
+  mockTextModel,
+  mockTurnSequenceModel,
+  mockResolvedModel,
+  type MockResponse,
+} from "./helpers/mock-llm.js";
+
+// ── Mock the LLM module BEFORE any imports that pull it in ──
+
+let activeResolvedModel: ResolvedModel = mockResolvedModel(mockTextModel("default"));
+
+vi.mock("@polpo-ai/llm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@polpo-ai/llm")>();
+  return {
+    ...actual,
+    resolveModel: () => activeResolvedModel,
+    enforceModelAllowlist: () => {},
+    mapReasoningToProviderOptions: () => undefined,
+  };
+});
+
+// Switchable engine-spawn failure (for the spawnError path).
+let throwOnSpawn: Error | undefined;
+vi.mock("../adapters/loop-engine.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../adapters/loop-engine.js")>();
+  return {
+    ...actual,
+    spawnLoopEngine: (...args: Parameters<typeof actual.spawnLoopEngine>) => {
+      if (throwOnSpawn) throw throwOnSpawn;
+      return actual.spawnLoopEngine(...args);
+    },
+  };
+});
+
+import { executeRun } from "../core/run-lifecycle.js";
+import { InMemoryRunStore } from "./fixtures.js";
+import type { AgentConfig, Task, RunnerConfig } from "@polpo-ai/core/types";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
+
+// ── Helpers ─────────────────────────────────────────────
+
+function setMockModel(model: MockLanguageModelV3, overrides: Partial<ResolvedModel> = {}) {
+  activeResolvedModel = { ...mockResolvedModel(model), ...overrides };
+}
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { name: "lifecycle-agent", role: "developer", ...overrides };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-lifecycle-1",
+    title: "Lifecycle task",
+    description: "Do the scripted thing.",
+    state: "in_progress",
+    expectations: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    assignedTo: "lifecycle-agent",
+    ...overrides,
+  } as Task;
+}
+
+let tmpRoot: string;
+let cwd: string;
+let polpoDir: string;
+let runSeq = 0;
+
+function makeConfig(overrides: Partial<RunnerConfig> = {}): RunnerConfig {
+  const runId = `run-lc-${++runSeq}`;
+  return {
+    runId,
+    taskId: makeTask().id,
+    agent: makeAgent(),
+    task: makeTask(),
+    polpoDir,
+    cwd,
+    outputDir: join(polpoDir, "output", runId),
+    ...overrides,
+  };
+}
+
+/** Read the JSONL activity log for a run. */
+async function readActivityLog(runId: string): Promise<Array<Record<string, unknown>>> {
+  const raw = await readFile(join(polpoDir, "logs", `run-${runId}.jsonl`), "utf-8");
+  return raw.trim().split("\n").map((l) => JSON.parse(l));
+}
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "polpo-run-lifecycle-"));
+  cwd = join(tmpRoot, "work");
+  polpoDir = join(tmpRoot, ".polpo");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(polpoDir, { recursive: true });
+});
+
+afterAll(async () => {
+  if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true });
+});
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("executeRun — shared run lifecycle", () => {
+  test("happy path: running → completed, result + transcript persisted", async () => {
+    setMockModel(mockTurnSequenceModel([
+      { type: "tool-call", toolName: "write", args: { path: "lc-a.txt", content: "hello" } },
+      { type: "text", text: "lifecycle done" },
+    ]));
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+
+    const outcome = await executeRun(config, {
+      runStore: store,
+      pid: 4242,
+      configPath: `memory://${config.runId}`,
+    });
+
+    expect(outcome.status).toBe("completed");
+    expect(outcome.spawnError).toBeUndefined();
+    expect(outcome.result.exitCode).toBe(0);
+    expect(outcome.result.stdout).toBe("lifecycle done");
+
+    // Terminal run record with the result and the injected pid.
+    const run = await store.getRun(config.runId);
+    expect(run?.status).toBe("completed");
+    expect(run?.pid).toBe(4242);
+    expect(run?.result?.stdout).toBe("lifecycle done");
+    expect(run?.configPath).toBe(`memory://${config.runId}`);
+
+    // Tool side-effect ran for real.
+    expect(await readFile(join(cwd, "lc-a.txt"), "utf-8")).toBe("hello");
+
+    // JSONL activity log: lifecycle events + transcript entries.
+    const log = await readActivityLog(config.runId);
+    const events = log.map((e) => e.event ?? e.type);
+    expect(events).toContain("spawning");
+    expect(events).toContain("spawned");
+    expect(events).toContain("done");
+    expect(events).toContain("tool_use");
+    expect(events).toContain("tool_result");
+    expect(events).toContain("assistant");
+    expect(log[0].pid).toBe(4242);
+  });
+
+  test("engine failure: run marked failed, executeRun resolves (never throws)", async () => {
+    setMockModel(new MockLanguageModelV3({
+      doStream: () => { throw new Error("model exploded"); },
+    }));
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+
+    const outcome = await executeRun(config, {
+      runStore: store, pid: 1, configPath: "memory://x",
+    });
+
+    expect(outcome.status).toBe("failed");
+    expect(outcome.spawnError).toBeUndefined();
+    expect(outcome.result.exitCode).toBe(1);
+    const run = await store.getRun(config.runId);
+    expect(run?.status).toBe("failed");
+    // The AI SDK surfaces stream errors as its "No output generated" error
+    // — the exact legacy path (see loop-engine.ts modelStep).
+    expect(run?.result?.stderr).toContain("No output generated");
+  });
+
+  test("abort: engine killed, run 'killed', exitCode forced to 1", async () => {
+    // A model that never finishes its stream until aborted.
+    let releaseStream: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => { releaseStream = resolve; });
+    setMockModel(new MockLanguageModelV3({
+      doStream: async (opts) => {
+        // Block until the abort signal fires, then throw AbortError like a
+        // real provider would.
+        await new Promise<void>((resolve, reject) => {
+          const signal = opts.abortSignal;
+          if (signal?.aborted) return reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          signal?.addEventListener("abort", () => reject(Object.assign(new Error("aborted"), { name: "AbortError" })), { once: true });
+          void blocked.then(resolve);
+        });
+        return { stream: new ReadableStream() };
+      },
+    }));
+
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+    const abort = new AbortController();
+
+    const running = executeRun(config, {
+      runStore: store, pid: 7, configPath: "memory://x", signal: abort.signal,
+    });
+
+    // Wait for the run record to appear, then abort mid-turn.
+    await vi.waitFor(async () => {
+      expect((await store.getRun(config.runId))?.status).toBe("running");
+    });
+    abort.abort();
+
+    const outcome = await running;
+    releaseStream?.();
+
+    expect(outcome.status).toBe("killed");
+    expect(outcome.result.exitCode).toBe(1);
+    expect(outcome.result.stderr).toContain("Killed by SIGTERM (timeout or shutdown)");
+    expect((await store.getRun(config.runId))?.status).toBe("killed");
+    const log = await readActivityLog(config.runId);
+    expect(log.map((e) => e.event)).toContain("sigterm");
+  });
+
+  test("durable turns: checkpoints land on the run record, resume skips recorded tools", async () => {
+    // ── Run 1: turn 0 writes a file, then the model crashes ──
+    let calls = 0;
+    const inner = mockTurnSequenceModel([
+      { type: "tool-call", toolName: "write", args: { path: "lc-resume.txt", content: "turn zero" } },
+    ]);
+    setMockModel(new MockLanguageModelV3({
+      doStream: (opts) => {
+        if (calls++ >= 1) throw new Error("simulated crash");
+        return inner.doStream(opts);
+      },
+    }));
+
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+    const crash = await executeRun(config, { runStore: store, pid: 1, configPath: "memory://x" });
+    expect(crash.status).toBe("failed");
+
+    // The turn-0 checkpoint was persisted through RunStore.updateResumeState.
+    const crashedRun = await store.getRun(config.runId);
+    const checkpoint = crashedRun?.resumeState as LoopResumeState;
+    expect(checkpoint?.turn).toBe(0);
+    expect(checkpoint?.loopName).toBe("default");
+    expect(JSON.stringify(checkpoint.history)).toContain("lc-resume.txt");
+
+    // Wipe the side-effect so re-execution would be visible.
+    await unlink(join(cwd, "lc-resume.txt"));
+
+    // ── Run 2: resume from the harvested checkpoint ──
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "resumed fine" }]));
+    const config2 = makeConfig({ resumeState: checkpoint });
+    const resumed = await executeRun(config2, { runStore: store, pid: 2, configPath: "memory://y" });
+
+    expect(resumed.status).toBe("completed");
+    expect(resumed.result.stdout).toBe("resumed fine");
+    // Temporal semantics: the recorded turn-0 tool did NOT re-execute.
+    expect(existsSync(join(cwd, "lc-resume.txt"))).toBe(false);
+    // Turn numbering continued past the checkpoint.
+    const resumedRun = await store.getRun(config2.runId);
+    expect((resumedRun?.resumeState as LoopResumeState)?.turn).toBe(1);
+    // The lifecycle logged the resume.
+    const log = await readActivityLog(config2.runId);
+    expect(log.map((e) => e.event)).toContain("resuming");
+  });
+
+  test("spawn failure: run failed + spawnError=true (subprocess exits 1 on this)", async () => {
+    throwOnSpawn = new Error("engine could not start");
+    try {
+      const store = new InMemoryRunStore();
+      const config = makeConfig();
+      const outcome = await executeRun(config, { runStore: store, pid: 1, configPath: "memory://x" });
+
+      expect(outcome.spawnError).toBe(true);
+      expect(outcome.status).toBe("failed");
+      expect(outcome.result.stderr).toContain("engine could not start");
+      expect((await store.getRun(config.runId))?.status).toBe("failed");
+    } finally {
+      throwOnSpawn = undefined;
+    }
+  });
+
+  test("transcript goes through the injected log session (DB-mode parity)", async () => {
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "with session" }]));
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+    const appended: Array<{ event: string }> = [];
+
+    const outcome = await executeRun(config, {
+      runStore: store,
+      pid: 1,
+      configPath: "memory://x",
+      createLogSession: async () => ({
+        sessionId: "sess-123",
+        append: async (entry) => { appended.push(entry as { event: string }); },
+      }),
+    });
+
+    expect(outcome.status).toBe("completed");
+    // sessionId linked on the run record's activity from the very start.
+    const run = await store.getRun(config.runId);
+    expect(run?.activity.sessionId).toBe("sess-123");
+    // Transcript entries flowed through the session.
+    expect(appended.some((e) => e.event === "transcript:assistant")).toBe(true);
+  });
+});

--- a/packages/node/src/adapters/in-process-spawner.ts
+++ b/packages/node/src/adapters/in-process-spawner.ts
@@ -1,0 +1,118 @@
+/**
+ * In-process Spawner — runs the agent lifecycle inside the orchestrator
+ * process (no fork). First building block of the proxy execution model
+ * (ProxyTool): the LLM loop lives in the server process; tools still run
+ * locally through the injected fs/shell (sandbox tool proxying arrives in
+ * later phases).
+ *
+ * Same lifecycle as the subprocess runner — both hosts call executeRun()
+ * (core/run-lifecycle.ts). What differs is captured entirely in the deps:
+ *
+ *   - stores are the orchestrator's own (no second store/DB connection);
+ *   - pid is a synthetic NEGATIVE id: never a real OS pid (positive) and
+ *     never 0 (the "untracked" sandbox convention). isAlive()/kill()
+ *     resolve against the in-memory active-run map;
+ *   - kill() aborts via AbortController → engine abort → run "killed",
+ *     mirroring the subprocess SIGTERM path (no SIGKILL escalation: the
+ *     abort is the only lever; a run that ignores it is reaped by the
+ *     orchestrator's stale/timeout health checks, same as a wedged
+ *     subprocess);
+ *   - SpawnResult.onExit fires when the run promise settles, so the
+ *     reactive tick (run:exited wake event) works identically.
+ *
+ * A failing run can NEVER crash the orchestrator: executeRun persists all
+ * run-level failures itself, and a last-resort catch here absorbs anything
+ * thrown before the run record exists (degrading to the same stale-kill
+ * fallback a subprocess that died pre-persist would get).
+ */
+import { mkdirSync, existsSync } from "node:fs";
+import type { Spawner, SpawnResult } from "@polpo-ai/core/spawner";
+import type { RunnerConfig } from "@polpo-ai/core/types";
+import type { RunStore } from "@polpo-ai/core/run-store";
+import type { VaultStore } from "@polpo-ai/core/vault-store";
+import type { MemoryStore } from "@polpo-ai/core/memory-store";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import type { Shell } from "@polpo-ai/core/shell";
+import { executeRun, errorResult, type TranscriptSession } from "../core/run-lifecycle.js";
+
+/**
+ * Stores and ports the in-process lifecycle runs against — the
+ * orchestrator's own instances (see ExecuteRunDeps for per-field
+ * semantics). createLogSession must open a DEDICATED LogStore
+ * session per run: sharing the orchestrator's log-sink instance would
+ * hijack its current session.
+ */
+export interface InProcessSpawnerDeps {
+  runStore: RunStore;
+  createLogSession?: () => Promise<TranscriptSession>;
+  vaultStore?: VaultStore;
+  memoryStore?: MemoryStore;
+  fs?: FileSystem;
+  shell?: Shell;
+}
+
+export class InProcessSpawner implements Spawner {
+  /** Synthetic pid sequence: -1, -2, … (see module header). */
+  private pidSeq = 0;
+  /** Active in-process runs, keyed by synthetic pid. */
+  private active = new Map<number, AbortController>();
+
+  /**
+   * Deps are resolved lazily at spawn() time: the orchestrator constructs
+   * the spawner during init before some stores exist (e.g. the vault), and
+   * per-run resolution keeps the spawner correct across hot-reloads.
+   */
+  constructor(private getDeps: () => InProcessSpawnerDeps) {}
+
+  async spawn(config: RunnerConfig): Promise<SpawnResult> {
+    // Parity with NodeSpawner: the output dir exists before the engine starts.
+    if (!existsSync(config.outputDir)) {
+      mkdirSync(config.outputDir, { recursive: true });
+    }
+
+    const pid = --this.pidSeq;
+    const abort = new AbortController();
+    this.active.set(pid, abort);
+
+    // Nothing is written to disk — the config only lives on the run record
+    // (TaskRunner persists it right after spawn, as with every spawner).
+    const configPath = `memory://run-${config.runId}`;
+    const deps = this.getDeps();
+
+    let exited = false;
+    const exitCallbacks: Array<() => void> = [];
+
+    // Fire-and-forget: spawn() returns immediately, like a fork would.
+    void executeRun(config, { ...deps, pid, configPath, signal: abort.signal })
+      .catch(async (err) => {
+        // executeRun persists every run-level failure itself; this is the
+        // last resort (e.g. the initial upsertRun threw). Never let a run
+        // error escape into the orchestrator process.
+        try {
+          await deps.runStore.completeRun(config.runId, "failed", errorResult(err));
+        } catch { /* store is gone too — health checks will reap the run */ }
+      })
+      .finally(() => {
+        exited = true;
+        this.active.delete(pid);
+        for (const cb of exitCallbacks.splice(0)) cb();
+      });
+
+    return {
+      pid,
+      configPath,
+      onExit: (cb: () => void) => {
+        if (exited) cb();
+        else exitCallbacks.push(cb);
+      },
+    };
+  }
+
+  isAlive(pid: number): boolean {
+    return this.active.has(pid);
+  }
+
+  kill(pid: number): void {
+    this.active.get(pid)?.abort();
+  }
+}

--- a/packages/node/src/core/config.ts
+++ b/packages/node/src/core/config.ts
@@ -163,6 +163,10 @@ function parseSettings(raw: any): PolpoSettings {
   if (raw?.storage && ["file", "sqlite", "postgres"].includes(raw.storage)) {
     settings.storage = raw.storage;
   }
+  // Task execution mode (opt-in; default = subprocess)
+  if (raw?.taskExecution && ["subprocess", "in-process"].includes(raw.taskExecution)) {
+    settings.taskExecution = raw.taskExecution;
+  }
   if (raw?.databaseUrl && typeof raw.databaseUrl === "string") {
     settings.databaseUrl = raw.databaseUrl;
   }

--- a/packages/node/src/core/orchestrator.ts
+++ b/packages/node/src/core/orchestrator.ts
@@ -57,7 +57,9 @@ import type { VaultStore } from "@polpo-ai/core/vault-store";
 import type { PlaybookStore } from "@polpo-ai/core/playbook-store";
 import { FilePlaybookStore } from "@polpo-ai/file-stores";
 import { NodeSpawner } from "../adapters/node-spawner.js";
+import { InProcessSpawner } from "../adapters/in-process-spawner.js";
 import type { Spawner } from "@polpo-ai/core/spawner";
+import type { LogEntry } from "@polpo-ai/core/log-store";
 import { NodeFileSystem } from "../adapters/node-filesystem.js";
 import { NodeShell } from "../adapters/node-shell.js";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
@@ -87,6 +89,8 @@ export class Orchestrator extends TypedEmitter {
   private stopped = false;
   private assessFn: AssessFn;
   private spawner: Spawner;
+  /** True when the caller injected a spawner — settings never override it. */
+  private spawnerInjected = false;
   private injectedStore?: TaskStore;
   private injectedRunStore?: RunStore;
   private memoryStore!: MemoryStore;
@@ -165,8 +169,48 @@ export class Orchestrator extends TypedEmitter {
       this.assessFn = opts.assessFn ?? assessTask;
       this.injectedStore = opts.store;
       this.injectedRunStore = opts.runStore;
+      this.spawnerInjected = !!opts.spawner;
       this.spawner = opts.spawner ?? new NodeSpawner({ polpoDir: this.polpoDir, cwd: this.workDir });
     }
+  }
+
+  /**
+   * Select the task-execution spawner from settings (opt-in, additive).
+   * Default stays the subprocess NodeSpawner; `settings.taskExecution:
+   * "in-process"` switches to the InProcessSpawner, which runs the exact
+   * same lifecycle (executeRun) inside this process against the
+   * orchestrator's own stores. An explicitly injected spawner always wins.
+   * Per-task/per-agent policy is deliberately out of scope (Phase C).
+   *
+   * Must run after stores are created and before initManagers() — the
+   * managers' OrchestratorContext captures ctx.spawner once.
+   */
+  private applyTaskExecutionMode(): void {
+    if (this.spawnerInjected) return;
+    if (this.config.settings.taskExecution !== "in-process") return;
+    // Deps resolve lazily at spawn() time: the vault store is initialized
+    // after the managers, and hot-reload may swap store instances.
+    this.spawner = new InProcessSpawner(() => {
+      // A DEDICATED LogStore instance per run over the same DB handle —
+      // sharing the orchestrator's log sink would hijack its current
+      // session (LogStore keeps the session as instance state). File mode
+      // has no per-run log sessions, same as the subprocess runner.
+      const makeLogStore = this.drizzleStores?.createLogStore?.bind(this.drizzleStores);
+      return {
+        runStore: this.runStore,
+        createLogSession: makeLogStore
+          ? async () => {
+              const logStore = makeLogStore();
+              const sessionId = await logStore.startSession();
+              return { sessionId, append: (entry: LogEntry) => logStore.append(entry) };
+            }
+          : undefined,
+        vaultStore: this.vaultStore,
+        memoryStore: this.memoryStore,
+        fs: this.fs,
+        shell: this.shell,
+      };
+    });
   }
 
   /** Drizzle store bundle — populated when storage is "sqlite" or "postgres". */
@@ -277,6 +321,7 @@ export class Orchestrator extends TypedEmitter {
     // Validate API keys (after stores are available so we can read per-agent models)
     await this.validateProviders();
 
+    this.applyTaskExecutionMode();
     await this.initManagers();
 
     // Sync config.teams from stores (authoritative source — agents.json / teams.json)
@@ -608,6 +653,7 @@ export class Orchestrator extends TypedEmitter {
       };
     }
 
+    this.applyTaskExecutionMode();
     await this.initManagers();
 
     // Sync config.teams from stores (authoritative source — agents.json / teams.json)

--- a/packages/node/src/core/orchestrator.ts
+++ b/packages/node/src/core/orchestrator.ts
@@ -738,10 +738,13 @@ export class Orchestrator extends TypedEmitter {
     if (activeRuns.length > 0) {
       this.emit("log", { level: "warn", message: `Shutting down ${activeRuns.length} running agent(s)...` });
 
-      // Send SIGTERM to all runner subprocesses
+      // Send SIGTERM to all runner subprocesses; in-process runs (negative
+      // synthetic pids) are aborted through the spawner instead.
       for (const run of activeRuns) {
         if (run.pid > 0) {
           try { process.kill(run.pid, "SIGTERM"); } catch { /* already dead */ }
+        } else if (run.pid < 0) {
+          try { this.spawner.kill(run.pid); } catch { /* already gone */ }
         }
       }
 

--- a/packages/node/src/core/run-lifecycle.ts
+++ b/packages/node/src/core/run-lifecycle.ts
@@ -1,0 +1,294 @@
+/**
+ * Shared run lifecycle — executeRun().
+ *
+ * The complete lifecycle of ONE agent run (initial run record, engine spawn,
+ * transcript + activity persistence, durable-turns checkpoint sink, terminal
+ * completeRun) extracted from the subprocess runner so two hosts can execute
+ * the exact same code path:
+ *
+ *   - the detached subprocess entry (core/runner.ts, spawned by NodeSpawner):
+ *     builds its own store connections, pid = process.pid, SIGTERM → abort;
+ *   - the InProcessSpawner (adapters/in-process-spawner.ts): reuses the
+ *     orchestrator's stores, synthetic negative pid, kill() → abort.
+ *
+ * Contract:
+ *   - executeRun NEVER exits the process and NEVER closes the injected
+ *     stores — both lifetimes belong to the host.
+ *   - Every failure path is persisted on the run record via completeRun
+ *     (the in-process host must never crash because a run failed).
+ *   - Abort (deps.signal) carries the subprocess SIGTERM semantics: kill
+ *     the engine, force exitCode 1, mark the run "killed".
+ */
+
+import { appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { FileMemoryStore } from "@polpo-ai/file-stores";
+import { spawnLoopEngine } from "../adapters/loop-engine.js";
+import type { RunStore, RunRecord, RunStatus } from "@polpo-ai/core/run-store";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
+import type { LogEntry } from "@polpo-ai/core/log-store";
+import type { RunnerConfig, TaskResult } from "@polpo-ai/core/types";
+import type { AgentHandle } from "@polpo-ai/core/adapter";
+import type { FileSystem } from "@polpo-ai/core/filesystem";
+import type { Shell } from "@polpo-ai/core/shell";
+import { sanitizeTranscriptEntry } from "../server/security.js";
+import { EncryptedVaultStore } from "../vault/encrypted-store.js";
+import type { VaultStore } from "@polpo-ai/core/vault-store";
+import type { MemoryStore } from "@polpo-ai/core/memory-store";
+import { NodeFileSystem } from "../adapters/node-filesystem.js";
+import { NodeShell } from "../adapters/node-shell.js";
+
+const ACTIVITY_POLL_MS = 1500;
+
+export function errorResult(err: unknown): TaskResult {
+  const msg = err instanceof Error ? err.message : String(err);
+  return { exitCode: 1, stdout: "", stderr: `Runner error: ${msg}`, duration: 0 };
+}
+
+/** Persistent per-run activity log (JSONL file in .polpo/logs/) */
+export class RunActivityLog {
+  private logPath: string;
+  private lastSnapshot = "";
+
+  constructor(polpoDir: string, runId: string, taskId: string, agentName: string, pid: number) {
+    const logsDir = join(polpoDir, "logs");
+    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
+    this.logPath = join(logsDir, `run-${runId}.jsonl`);
+    // Write header
+    this.write({ _run: true, runId, taskId, agentName, startedAt: new Date().toISOString(), pid });
+  }
+
+  /** Log activity diff — only writes if something changed */
+  logActivity(activity: Record<string, unknown>): void {
+    const snapshot = JSON.stringify(activity);
+    if (snapshot === this.lastSnapshot) return;
+    this.lastSnapshot = snapshot;
+    this.write({ ts: new Date().toISOString(), event: "activity", data: activity });
+  }
+
+  /** Log a transcript entry from the engine (assistant text, tool_use, tool_result, etc.) */
+  logTranscript(entry: Record<string, unknown>): void {
+    this.write({ ts: new Date().toISOString(), ...sanitizeTranscriptEntry(entry) });
+  }
+
+  /** Log a lifecycle event */
+  logEvent(event: string, data?: Record<string, unknown>): void {
+    this.write({ ts: new Date().toISOString(), event, ...(data ? { data } : {}) });
+  }
+
+  private write(obj: Record<string, unknown>): void {
+    try { appendFileSync(this.logPath, JSON.stringify(obj) + "\n", "utf-8"); } catch { /* best effort */ }
+  }
+}
+
+/**
+ * One transcript persistence session (a LogStore session scoped to this run).
+ *
+ * Injected as a factory instead of a LogStore because LogStore keeps its
+ * "current session" as instance state: the subprocess owns a private
+ * instance (startSession is safe), while the in-process host must open a
+ * dedicated instance/session per run or concurrent runs would hijack each
+ * other's (and the orchestrator's) session.
+ */
+export interface TranscriptSession {
+  sessionId: string;
+  append(entry: LogEntry): Promise<void>;
+}
+
+export interface ExecuteRunDeps {
+  /** Run persistence. NOT closed by executeRun — the host owns it. */
+  runStore: RunStore;
+  /**
+   * Per-run transcript session factory (DB storage modes). Undefined = file
+   * mode: the JSONL activity log is the only transcript side-channel,
+   * matching the historical subprocess behavior.
+   */
+  createLogSession?: () => Promise<TranscriptSession>;
+  /** Vault store. Default: EncryptedVaultStore(polpoDir), best-effort. */
+  vaultStore?: VaultStore;
+  /** Memory store. Default: FileMemoryStore(polpoDir). */
+  memoryStore?: MemoryStore;
+  /** FileSystem for tools. Default: a fresh NodeFileSystem. */
+  fs?: FileSystem;
+  /** Shell for tools. Default: a fresh NodeShell. */
+  shell?: Shell;
+  /** Pid recorded on the run record: process.pid (subprocess) or a synthetic negative id (in-process). */
+  pid: number;
+  /** Where the config was persisted ("file:///path", "db://runId", "memory://…"). */
+  configPath: string;
+  /** Abort = graceful kill (subprocess SIGTERM / in-process spawner.kill). */
+  signal?: AbortSignal;
+}
+
+export interface ExecuteRunOutcome {
+  status: RunStatus;
+  result: TaskResult;
+  /** True when the engine could not even be spawned (the subprocess entry exits 1 on this). */
+  spawnError?: boolean;
+}
+
+/**
+ * Execute one agent run end-to-end against the injected stores.
+ * See module header for the host contract.
+ */
+export async function executeRun(config: RunnerConfig, deps: ExecuteRunDeps): Promise<ExecuteRunOutcome> {
+  const { runStore, pid, configPath } = deps;
+  const actLog = new RunActivityLog(config.polpoDir, config.runId, config.taskId, config.agent.name, pid);
+
+  // When a transcript session is available (postgres/sqlite), persist the
+  // transcript to the DB. This ensures it survives sandbox destruction.
+  let logSession: TranscriptSession | undefined;
+  if (deps.createLogSession) {
+    logSession = await deps.createLogSession();
+  }
+
+  const now = new Date().toISOString();
+  const initialRecord: RunRecord = {
+    id: config.runId,
+    taskId: config.taskId,
+    pid,
+    agentName: config.agent.name,
+    status: "running",
+    startedAt: now,
+    updatedAt: now,
+    // sessionId starts at the LogStore session we just opened, so the
+    // run record is linked to its transcript from the very first poll.
+    // Without this, downstream readers (the cloud task-activity endpoint,
+    // a future dashboard, anything that joins runs to log sessions) have
+    // to guess by time-proximity — fragile on cold sandboxes where the
+    // log session is created hundreds of ms before the first stream
+    // chunk lands. In file mode this is mostly cosmetic because
+    // RunActivityLog writes a parallel JSONL side-channel; in DB mode
+    // (cloud) it's the only link that ever gets persisted.
+    activity: {
+      filesCreated: [], filesEdited: [], toolCalls: 0, totalTokens: 0, lastUpdate: now,
+      ...(logSession ? { sessionId: logSession.sessionId } : {}),
+    },
+    configPath,
+  };
+  // In DB mode, run record already exists (created by spawner) — update it with PID
+  await runStore.upsertRun(initialRecord);
+  actLog.logEvent("spawning", { task: config.task.title });
+
+  let handle: AgentHandle;
+  try {
+    // Use the injected vault store when available (postgres/sqlite or
+    // orchestrator-owned), fall back to file-based
+    let vaultStore: VaultStore | undefined = deps.vaultStore;
+    if (!vaultStore) {
+      try { vaultStore = new EncryptedVaultStore(config.polpoDir); } catch { /* vault unavailable */ }
+    }
+
+    const memoryStore: MemoryStore = deps.memoryStore ?? new FileMemoryStore(config.polpoDir);
+
+    const spawnCtx = {
+      polpoDir: config.polpoDir,
+      outputDir: config.outputDir,
+      emailAllowedDomains: config.emailAllowedDomains,
+      reasoning: config.reasoning,
+      vaultStore,
+      memoryStore,
+      // Subprocess hosts create their own fs/shell; the in-process host
+      // injects the orchestrator's instances.
+      fs: deps.fs ?? new NodeFileSystem(),
+      shell: deps.shell ?? new NodeShell(),
+      // Durable turns: resume checkpoint handed over by orphan recovery,
+      // and the per-turn checkpoint sink (one RunStore write per turn,
+      // best-effort — a flaky store must never fail a healthy run).
+      resumeState: config.resumeState,
+      onTurnCheckpoint: async (state: LoopResumeState) => {
+        try {
+          await runStore.updateResumeState?.(config.runId, state);
+        } catch { /* best effort */ }
+      },
+    };
+    handle = spawnLoopEngine(config.agent, config.task, config.cwd, spawnCtx);
+    if (config.resumeState) {
+      actLog.logEvent("resuming", {
+        loopName: config.resumeState.loopName,
+        fromTurn: (config.resumeState.turn ?? -1) + 1,
+      });
+    }
+    // Propagate the LogStore sessionId onto the agent's activity blob so
+    // the poll loop's updateActivity() persists it on every tick. Without
+    // this the run record has activity.sessionId = undefined forever, and
+    // downstream readers (cloud task-activity endpoint, dashboards) can't
+    // resolve the transcript except via fragile time-proximity fallback.
+    if (logSession) {
+      handle.activity.sessionId = logSession.sessionId;
+    }
+    // Wire transcript persistence — every agent message gets written to the run log
+    handle.onTranscript = (entry) => {
+      actLog.logTranscript(entry);
+      // Persist transcript to DB when a log session is available
+      if (logSession) {
+        const event = entry.type === "assistant" ? "transcript:assistant"
+          : entry.type === "tool_result" ? "transcript:tool_result"
+          : entry.type === "tool_use" ? "transcript:tool_use"
+          : `transcript:${entry.type ?? "unknown"}`;
+        logSession.append({ ts: new Date().toISOString(), event, data: sanitizeTranscriptEntry(entry) })
+          .catch(() => {}); // best-effort, don't block engine
+      }
+    };
+    actLog.logEvent("spawned");
+  } catch (err) {
+    const result = errorResult(err);
+    actLog.logEvent("error", { message: result.stderr });
+    await runStore.completeRun(config.runId, "failed", result);
+    return { status: "failed", result, spawnError: true };
+  }
+
+  // Activity polling + persistent logging
+  const poll = setInterval(async () => {
+    try {
+      await runStore.updateActivity(config.runId, handle.activity);
+      actLog.logActivity({ ...handle.activity });
+    } catch { /* DB temporarily locked */
+    }
+  }, ACTIVITY_POLL_MS);
+
+  // Abort handler: graceful kill (SIGTERM in the subprocess host,
+  // spawner.kill()/timeout in the in-process host)
+  let aborted = false;
+  const onAbort = () => {
+    aborted = true;
+    actLog.logEvent("sigterm");
+    handle.kill();
+  };
+  if (deps.signal?.aborted) onAbort();
+  else deps.signal?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    const result = await handle.done;
+    clearInterval(poll);
+    // Final activity + sessionId flush before marking terminal
+    try { await runStore.updateActivity(config.runId, handle.activity); } catch { /* best effort */ }
+    actLog.logActivity({ ...handle.activity });
+
+    // Store auto-collected outcomes on the run record
+    if (handle.outcomes && handle.outcomes.length > 0) {
+      try { await runStore.updateOutcomes(config.runId, handle.outcomes); } catch { /* best effort */ }
+      actLog.logEvent("outcomes", { count: handle.outcomes.length, types: handle.outcomes.map((o: any) => o.type) });
+    }
+
+    // If we were aborted (timeout/shutdown/kill), force exitCode=1 regardless
+    // of what the engine returned — an aborted task is not a successful task.
+    if (aborted) {
+      result.exitCode = 1;
+      result.stderr = (result.stderr ? result.stderr + "\n" : "") + "Killed by SIGTERM (timeout or shutdown)";
+    }
+    const status: RunStatus = aborted ? "killed" : (result.exitCode === 0 ? "completed" : "failed");
+    actLog.logEvent("done", { status, exitCode: result.exitCode, duration: result.duration });
+    await runStore.completeRun(config.runId, status, result);
+    return { status, result };
+  } catch (err) {
+    clearInterval(poll);
+    try { await runStore.updateActivity(config.runId, handle.activity); } catch { /* best effort */ }
+    actLog.logEvent("error", { message: err instanceof Error ? err.message : String(err) });
+    const result = errorResult(err);
+    await runStore.completeRun(config.runId, "failed", result);
+    return { status: "failed", result };
+  } finally {
+    deps.signal?.removeEventListener("abort", onAbort);
+  }
+}

--- a/packages/node/src/core/runner.ts
+++ b/packages/node/src/core/runner.ts
@@ -4,31 +4,30 @@
  * Detached subprocess runner.
  * Spawned by the orchestrator for each agent task.
  * Lifecycle:
- *   1. Read --config <path> from args
+ *   1. Read --config <path> from args (or --run-id <id> --db <url> in DB mode)
  *   2. Open own RunStore connection (Drizzle SQLite or PG)
- *   3. Spawn agent via built-in engine
- *   4. Poll activity, write to RunStore
- *   5. Await handle.done, write result
- *   6. Cleanup & exit
+ *   3. Delegate the run lifecycle to executeRun() (shared with the
+ *      InProcessSpawner — see run-lifecycle.ts)
+ *   4. Cleanup & exit
+ *
+ * Exit code contract (unchanged — this file is the cloud sandbox entry,
+ * `polpo-ai/dist/core/runner.js`):
+ *   - exit 1: bad CLI args, unreadable config, engine spawn failure, fatal error
+ *   - exit 0: everything else — task-level failures are persisted on the
+ *     run record (status failed/killed), not surfaced as a process error
  */
 
-import { readFileSync, unlinkSync, appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { FileRunStore } from "@polpo-ai/file-stores";
-import { spawnLoopEngine } from "../adapters/loop-engine.js";
-import type { RunStore, RunRecord } from "@polpo-ai/core/run-store";
-import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
+import type { RunStore } from "@polpo-ai/core/run-store";
 import type { LogStore } from "@polpo-ai/core/log-store";
-import type { RunnerConfig, TaskResult } from "@polpo-ai/core/types";
-import { sanitizeTranscriptEntry } from "../server/security.js";
-import { EncryptedVaultStore } from "../vault/encrypted-store.js";
+import type { RunnerConfig } from "@polpo-ai/core/types";
 import type { VaultStore } from "@polpo-ai/core/vault-store";
 import type { MemoryStore } from "@polpo-ai/core/memory-store";
-import { FileMemoryStore } from "@polpo-ai/file-stores";
 import { NodeFileSystem } from "../adapters/node-filesystem.js";
 import { NodeShell } from "../adapters/node-shell.js";
-
-const ACTIVITY_POLL_MS = 1500;
+import { executeRun } from "./run-lifecycle.js";
 
 function readConfigFromFile(): RunnerConfig {
   const idx = process.argv.indexOf("--config");
@@ -76,47 +75,6 @@ async function readConfigFromDb(): Promise<RunnerConfig> {
 
   await sql.end();
   return run.config;
-}
-
-function errorResult(err: unknown): TaskResult {
-  const msg = err instanceof Error ? err.message : String(err);
-  return { exitCode: 1, stdout: "", stderr: `Runner error: ${msg}`, duration: 0 };
-}
-
-/** Persistent per-run activity log (JSONL file in .polpo/logs/) */
-class RunActivityLog {
-  private logPath: string;
-  private lastSnapshot = "";
-
-  constructor(polpoDir: string, runId: string, taskId: string, agentName: string) {
-    const logsDir = join(polpoDir, "logs");
-    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
-    this.logPath = join(logsDir, `run-${runId}.jsonl`);
-    // Write header
-    this.write({ _run: true, runId, taskId, agentName, startedAt: new Date().toISOString(), pid: process.pid });
-  }
-
-  /** Log activity diff — only writes if something changed */
-  logActivity(activity: Record<string, unknown>): void {
-    const snapshot = JSON.stringify(activity);
-    if (snapshot === this.lastSnapshot) return;
-    this.lastSnapshot = snapshot;
-    this.write({ ts: new Date().toISOString(), event: "activity", data: activity });
-  }
-
-  /** Log a transcript entry from the engine (assistant text, tool_use, tool_result, etc.) */
-  logTranscript(entry: Record<string, unknown>): void {
-    this.write({ ts: new Date().toISOString(), ...sanitizeTranscriptEntry(entry) });
-  }
-
-  /** Log a lifecycle event */
-  logEvent(event: string, data?: Record<string, unknown>): void {
-    this.write({ ts: new Date().toISOString(), event, ...(data ? { data } : {}) });
-  }
-
-  private write(obj: Record<string, unknown>): void {
-    try { appendFileSync(this.logPath, JSON.stringify(obj) + "\n", "utf-8"); } catch { /* best effort */ }
-  }
 }
 
 interface RunnerStores {
@@ -167,160 +125,46 @@ async function main(): Promise<void> {
     const { setProviderOverrides } = await import("@polpo-ai/llm");
     setProviderOverrides(config.providers);
   }
-  const { runStore, logStore, vaultStore: drizzleVaultStore, memoryStore: drizzleMemoryStore } = await createStores(config);
-  const actLog = new RunActivityLog(config.polpoDir, config.runId, config.taskId, config.agent.name);
+  const { runStore, logStore, vaultStore, memoryStore } = await createStores(config);
 
-  // When LogStore is available (postgres/sqlite), persist transcript to DB.
-  // This ensures transcript survives sandbox destruction.
-  let logSessionId: string | undefined;
-  if (logStore) {
-    logSessionId = await logStore.startSession();
-  }
+  // SIGTERM handler: graceful kill (executeRun marks the run "killed")
+  const abort = new AbortController();
+  process.on("SIGTERM", () => abort.abort());
 
-  const now = new Date().toISOString();
-  const initialRecord: RunRecord = {
-    id: config.runId,
-    taskId: config.taskId,
+  const configPath = isDbMode
+    ? `db://${config.runId}`
+    : join(process.argv[process.argv.indexOf("--config") + 1]);
+
+  const outcome = await executeRun(config, {
+    runStore,
+    // The runner owns a private LogStore instance, so a per-run session is
+    // simply startSession() on it (postgres/sqlite only — file mode keeps
+    // the JSONL activity log as the sole transcript side-channel).
+    createLogSession: logStore
+      ? async () => {
+          const sessionId = await logStore.startSession();
+          return { sessionId, append: (entry) => logStore.append(entry) };
+        }
+      : undefined,
+    vaultStore,
+    memoryStore,
+    // Runner is a subprocess — creates its own fs/shell instances
+    fs: new NodeFileSystem(),
+    shell: new NodeShell(),
     pid: process.pid,
-    agentName: config.agent.name,
-    status: "running",
-    startedAt: now,
-    updatedAt: now,
-    // sessionId starts at the LogStore session we just opened, so the
-    // run record is linked to its transcript from the very first poll.
-    // Without this, downstream readers (the cloud task-activity endpoint,
-    // a future dashboard, anything that joins runs to log sessions) have
-    // to guess by time-proximity — fragile on cold sandboxes where the
-    // log session is created hundreds of ms before the first stream
-    // chunk lands. In file mode this is mostly cosmetic because
-    // RunActivityLog writes a parallel JSONL side-channel; in DB mode
-    // (cloud) it's the only link that ever gets persisted.
-    activity: {
-      filesCreated: [], filesEdited: [], toolCalls: 0, totalTokens: 0, lastUpdate: now,
-      ...(logSessionId ? { sessionId: logSessionId } : {}),
-    },
-    configPath: isDbMode ? `db://${config.runId}` : join(process.argv[process.argv.indexOf("--config") + 1]),
-  };
-  // In DB mode, run record already exists (created by spawner) — update it with PID
-  await runStore.upsertRun(initialRecord);
-  actLog.logEvent("spawning", { task: config.task.title });
+    configPath,
+    signal: abort.signal,
+  });
 
-  let handle;
-  try {
-    // Use Drizzle vault store when available (postgres/sqlite), fall back to file-based
-    let vaultStore: VaultStore | undefined = drizzleVaultStore;
-    if (!vaultStore) {
-      try { vaultStore = new EncryptedVaultStore(config.polpoDir); } catch { /* vault unavailable */ }
-    }
-
-    const memoryStore: MemoryStore = drizzleMemoryStore ?? new FileMemoryStore(config.polpoDir);
-
-    const spawnCtx = {
-      polpoDir: config.polpoDir,
-      outputDir: config.outputDir,
-      emailAllowedDomains: config.emailAllowedDomains,
-      reasoning: config.reasoning,
-      vaultStore,
-      memoryStore,
-      // Runner is a subprocess — creates its own fs/shell instances
-      fs: new NodeFileSystem(),
-      shell: new NodeShell(),
-      // Durable turns: resume checkpoint handed over by orphan recovery,
-      // and the per-turn checkpoint sink (one RunStore write per turn,
-      // best-effort — a flaky store must never fail a healthy run).
-      resumeState: config.resumeState,
-      onTurnCheckpoint: async (state: LoopResumeState) => {
-        try {
-          await runStore.updateResumeState?.(config.runId, state);
-        } catch { /* best effort */ }
-      },
-    };
-    handle = spawnLoopEngine(config.agent, config.task, config.cwd, spawnCtx);
-    if (config.resumeState) {
-      actLog.logEvent("resuming", {
-        loopName: config.resumeState.loopName,
-        fromTurn: (config.resumeState.turn ?? -1) + 1,
-      });
-    }
-    // Propagate the LogStore sessionId onto the agent's activity blob so
-    // the poll loop's updateActivity() persists it on every tick. Without
-    // this the run record has activity.sessionId = undefined forever, and
-    // downstream readers (cloud task-activity endpoint, dashboards) can't
-    // resolve the transcript except via fragile time-proximity fallback.
-    if (logSessionId) {
-      handle.activity.sessionId = logSessionId;
-    }
-    // Wire transcript persistence — every agent message gets written to the run log
-    handle.onTranscript = (entry) => {
-      actLog.logTranscript(entry);
-      // Persist transcript to DB when LogStore is available
-      if (logStore && logSessionId) {
-        const event = entry.type === "assistant" ? "transcript:assistant"
-          : entry.type === "tool_result" ? "transcript:tool_result"
-          : entry.type === "tool_use" ? "transcript:tool_use"
-          : `transcript:${entry.type ?? "unknown"}`;
-        logStore.append({ ts: new Date().toISOString(), event, data: sanitizeTranscriptEntry(entry) })
-          .catch(() => {}); // best-effort, don't block engine
-      }
-    };
-    actLog.logEvent("spawned");
-  } catch (err) {
-    const result = errorResult(err);
-    actLog.logEvent("error", { message: result.stderr });
-    await runStore.completeRun(config.runId, "failed", result);
+  // Engine spawn failure is the one lifecycle path that exits non-zero.
+  if (outcome.spawnError) {
     await runStore.close();
     process.exit(1);
   }
 
-  // Activity polling + persistent logging
-  const poll = setInterval(async () => {
-    try {
-      await runStore.updateActivity(config.runId, handle.activity);
-      actLog.logActivity({ ...handle.activity });
-    } catch { /* DB temporarily locked */
-    }
-  }, ACTIVITY_POLL_MS);
-
-  // SIGTERM handler: graceful kill
-  let sigterm = false;
-  process.on("SIGTERM", () => {
-    sigterm = true;
-    actLog.logEvent("sigterm");
-    handle.kill();
-  });
-
-  try {
-    const result = await handle.done;
-    clearInterval(poll);
-    // Final activity + sessionId flush before marking terminal
-    try { await runStore.updateActivity(config.runId, handle.activity); } catch { /* best effort */ }
-    actLog.logActivity({ ...handle.activity });
-
-    // Store auto-collected outcomes on the run record
-    if (handle.outcomes && handle.outcomes.length > 0) {
-      try { await runStore.updateOutcomes(config.runId, handle.outcomes); } catch { /* best effort */ }
-      actLog.logEvent("outcomes", { count: handle.outcomes.length, types: handle.outcomes.map((o: any) => o.type) });
-    }
-
-    // If we received SIGTERM (timeout/shutdown), force exitCode=1 regardless of
-    // what the engine returned — an aborted task is not a successful task.
-    if (sigterm) {
-      result.exitCode = 1;
-      result.stderr = (result.stderr ? result.stderr + "\n" : "") + "Killed by SIGTERM (timeout or shutdown)";
-    }
-    const status = sigterm ? "killed" : (result.exitCode === 0 ? "completed" : "failed");
-    actLog.logEvent("done", { status, exitCode: result.exitCode, duration: result.duration });
-    await runStore.completeRun(config.runId, status, result);
-  } catch (err) {
-    clearInterval(poll);
-    try { await runStore.updateActivity(config.runId, handle.activity); } catch { /* best effort */ }
-    actLog.logEvent("error", { message: err instanceof Error ? err.message : String(err) });
-    await runStore.completeRun(config.runId, "failed", errorResult(err));
-  }
-
   // Cleanup config file (only in file mode, not DB mode)
   if (!isDbMode) {
-    try { unlinkSync(join(process.argv[process.argv.indexOf("--config") + 1])); } catch { /* already gone */ }
+    try { unlinkSync(configPath); } catch { /* already gone */ }
   }
 
   await runStore.close();

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -8,6 +8,13 @@ export { FileTaskStore, FileRunStore, JsonTaskStore } from "@polpo-ai/file-store
 // Engine
 export { spawnLoopEngine } from "./adapters/loop-engine.js";
 
+// Spawners — subprocess (default) and in-process (settings.taskExecution: "in-process")
+export { NodeSpawner } from "./adapters/node-spawner.js";
+export { InProcessSpawner } from "./adapters/in-process-spawner.js";
+export type { InProcessSpawnerDeps } from "./adapters/in-process-spawner.js";
+export { executeRun } from "./core/run-lifecycle.js";
+export type { ExecuteRunDeps, ExecuteRunOutcome, TranscriptSession } from "./core/run-lifecycle.js";
+
 // Assessment
 export { assessTask, runCheck, runMetric } from "./assessment/assessor.js";
 export { runLLMReview, computeWeightedScore, buildRubricSection, DEFAULT_DIMENSIONS, validateReviewPayload, ReviewPayloadSchema, findLogForTask, buildExecutionSummary } from "./assessment/index.js";


### PR DESCRIPTION
Phase B of the v2 execution chapter — first brick of the proxy model:

- **`executeRun(config, deps)`**: the run lifecycle extracted verbatim from the subprocess runner (record → engine with durable-turns wiring → transcript/JSONL → completion) into one shared function. The sandbox/subprocess entry (`runner.ts`) keeps its CLI and exit-code contract untouched and now delegates to it — one lifecycle, every host.
- **`InProcessSpawner implements Spawner`**: spawn() runs `executeRun` un-awaited with synthetic negative pids, kill = AbortController (the engine already threaded an abort signal — zero engine changes), `onExit` fires the reactive tick identically. A throwing run can never crash the orchestrator.
- **Opt-in**: `settings.taskExecution: "subprocess" | "in-process"` (default subprocess — zero behavior change). Stores are reused from the orchestrator (no second DB connection).
- **Durable turns work in-process**: checkpoints + resume without tool re-execution, asserted by test.
- Core kill-guard fix (behavior-preserving, TDD-pinned): timeout/stale guards accept negative pids so in-process runs are actually terminated, not just marked.

+18 tests (E2E mock-LLM, lifecycle/kill, reactive tick, durable resume, subprocess-parity at the executeRun seam, settings selection) — suite 1960 green, typecheck clean, all additive.

Next (Phase C): per-task/per-agent execution policy + sandbox tool proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)