### PR TITLE
feat: adaptive isolation — execution mode as a per-run policy

### DIFF
--- a/packages/core/src/__tests__/execution-mode.test.ts
+++ b/packages/core/src/__tests__/execution-mode.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolveExecutionMode } from "../execution-mode.js";
+
+describe("resolveExecutionMode — adaptive isolation precedence", () => {
+  it("defaults to subprocess with nothing set", () => {
+    expect(resolveExecutionMode()).toBe("subprocess");
+    expect(resolveExecutionMode({}, {}, {})).toBe("subprocess");
+  });
+
+  it("settings tier applies when task and agent are silent", () => {
+    expect(resolveExecutionMode({}, {}, { taskExecution: "in-process" })).toBe("in-process");
+  });
+
+  it("agent beats settings", () => {
+    expect(resolveExecutionMode({}, { executionMode: "subprocess" }, { taskExecution: "in-process" })).toBe("subprocess");
+    expect(resolveExecutionMode({}, { executionMode: "in-process" }, { taskExecution: "subprocess" })).toBe("in-process");
+  });
+
+  it("task beats agent and settings", () => {
+    expect(
+      resolveExecutionMode(
+        { executionMode: "in-process" },
+        { executionMode: "subprocess" },
+        { taskExecution: "subprocess" },
+      ),
+    ).toBe("in-process");
+    expect(
+      resolveExecutionMode(
+        { executionMode: "subprocess" },
+        { executionMode: "in-process" },
+        { taskExecution: "in-process" },
+      ),
+    ).toBe("subprocess");
+  });
+
+  it("invalid values fall through to the next tier", () => {
+    expect(resolveExecutionMode({ executionMode: "warp-drive" }, { executionMode: "in-process" })).toBe("in-process");
+    expect(resolveExecutionMode({ executionMode: "" }, {}, { taskExecution: "in-process" })).toBe("in-process");
+    expect(resolveExecutionMode({ executionMode: "warp" }, { executionMode: "nope" }, { taskExecution: "bad" })).toBe("subprocess");
+  });
+});

--- a/packages/core/src/execution-mode.ts
+++ b/packages/core/src/execution-mode.ts
@@ -1,0 +1,33 @@
+/**
+ * Adaptive isolation — resolve WHERE a task run executes.
+ *
+ * Pure function, zero I/O. Precedence (first valid wins):
+ *   1. task.executionMode      — per-task override
+ *   2. agent.executionMode     — per-agent default
+ *   3. settings.taskExecution  — project-wide default
+ *   4. "subprocess"            — the historical behavior
+ *
+ * Invalid values are ignored (fall through to the next tier) so a typo in
+ * config degrades to the safe default instead of failing the spawn.
+ */
+
+import type { ExecutionMode } from "./types/config.js";
+
+const VALID: ReadonlySet<string> = new Set(["subprocess", "in-process"]);
+
+function valid(value: unknown): ExecutionMode | undefined {
+  return typeof value === "string" && VALID.has(value) ? (value as ExecutionMode) : undefined;
+}
+
+export function resolveExecutionMode(
+  task?: { executionMode?: string },
+  agent?: { executionMode?: string },
+  settings?: { taskExecution?: string },
+): ExecutionMode {
+  return (
+    valid(task?.executionMode) ??
+    valid(agent?.executionMode) ??
+    valid(settings?.taskExecution) ??
+    "subprocess"
+  );
+}

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -41,6 +41,7 @@ export interface HookPayloads {
     retryPolicy?: RetryPolicy;
     notifications?: ScopedNotificationRules;
     sideEffects?: boolean;
+    executionMode?: import("./types/config.js").ExecutionMode;
     draft?: boolean;
   };
   "task:spawn": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export type { Shell, ShellOptions, ShellResult } from "./shell.js";
 
 // ── Spawner Abstraction ─────────────────────────────────────────────────
 export type { Spawner, SpawnResult } from "./spawner.js";
+export { resolveExecutionMode } from "./execution-mode.js";
 
 // ── Agent Prompt Builder ────────────────────────────────────────────────
 export {

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -30,6 +30,8 @@ export interface RunRecord {
    * the task with a resume instead of retrying from zero.
    */
   resumeState?: LoopResumeState;
+  /** Execution mode this run was spawned with ("subprocess" | "in-process"). */
+  executionMode?: string;
 }
 
 export interface RunStore {

--- a/packages/core/src/task-manager.ts
+++ b/packages/core/src/task-manager.ts
@@ -25,6 +25,7 @@ export class TaskManager {
     retryPolicy?: RetryPolicy;
     notifications?: ScopedNotificationRules;
     sideEffects?: boolean;
+    executionMode?: import("./types/config.js").ExecutionMode;
     draft?: boolean;
   }): Promise<Task> {
     if (!this.ctx.taskStore) throw new Error("Orchestrator not initialized");
@@ -43,6 +44,7 @@ export class TaskManager {
       retryPolicy: opts.retryPolicy,
       notifications: opts.notifications,
       sideEffects: opts.sideEffects,
+      executionMode: opts.executionMode,
       draft: opts.draft,
     });
     if (hookResult.cancelled) {
@@ -81,6 +83,7 @@ export class TaskManager {
       retryPolicy: hookData.retryPolicy,
       notifications: hookData.notifications,
       sideEffects: hookData.sideEffects,
+      executionMode: hookData.executionMode ?? opts.executionMode,
       status: hookData.draft ? "draft" : undefined,
     });
     this.ctx.emitter.emit("task:created", { task });

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -3,6 +3,7 @@ import type { OrchestratorContext } from "./orchestrator-context.js";
 import { resolveMissionStore, resolveMissionForTask } from "./mission-store.js";
 import type { Task, TaskResult, RunnerConfig } from "./types.js";
 import { agentMemoryScope } from "./memory-store.js";
+import { resolveExecutionMode } from "./execution-mode.js";
 import type { RunRecord } from "./run-store.js";
 import type { LoopResumeState } from "./loop/run-store.js";
 
@@ -515,9 +516,13 @@ export class TaskRunner {
       });
     }
 
+    // Adaptive isolation: resolve WHERE this run executes (task > agent > settings)
+    const executionMode = resolveExecutionMode(task, agent, this.ctx.config.settings);
+
     const runnerConfig: RunnerConfig = {
       runId,
       taskId: task.id,
+      executionMode,
       agent,
       task: taskWithContext,
       polpoDir: this.ctx.polpoDir,
@@ -543,6 +548,7 @@ export class TaskRunner {
         agentName: agent.name,
         status: "running",
         startedAt: now,
+        executionMode,
         updatedAt: now,
         activity: { filesCreated: [], filesEdited: [], toolCalls: 0, totalTokens: 0, lastUpdate: now },
         config: runnerConfig,

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -151,6 +151,8 @@ export interface AgentConfig {
    *  Defaults to agent name. Used with agent-browser's --profile flag.
    *  Profiles stored in .polpo/browser-profiles/<name>/. */
   browserProfile?: string;
+  /** Where this agent's task runs execute. Precedence: task > agent > settings. */
+  executionMode?: import("./config.js").ExecutionMode;
   /** Allowed recipient email domains for email_send (e.g. ["acme.com", "partner.io"]).
    *  When set, emails can only be sent to addresses in these domains.
    *  When omitted, all domains are allowed (backwards compatible). */

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -12,6 +12,8 @@ import type { LoopResumeState } from "../loop/run-store.js";
 // === Runner Config ===
 
 export interface RunnerConfig {
+  /** Resolved execution mode for this run (stamped by the task runner). */
+  executionMode?: ExecutionMode;
   runId: string;
   taskId: string;
   agent: AgentConfig;
@@ -131,6 +133,9 @@ export interface PolpoConfig {
   providers?: Record<string, ProviderConfig>;
 }
 
+/** Where a task run executes: OS subprocess (default) or inside the host process (proxy model). */
+export type ExecutionMode = "subprocess" | "in-process";
+
 export interface PolpoSettings {
   maxRetries: number;
   workDir: string;
@@ -175,7 +180,7 @@ export interface PolpoSettings {
    *  block of the proxy execution model (LLM loop in the server, tools
    *  proxied to the sandbox in later phases). Per-task/per-agent policy
    *  is future work; this is a global opt-in. */
-  taskExecution?: "subprocess" | "in-process";
+  taskExecution?: ExecutionMode;
   /** PostgreSQL connection URL (required when storage is "postgres").
    *  Example: "postgres://user:pass@localhost:5432/polpo" */
   databaseUrl?: string;

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -159,6 +159,8 @@ export interface Task {
    * Propagates from Task → Run for per-user attribution and metering.
    */
   user?: string;
+  /** Execution mode override for this task (wins over agent and settings). */
+  executionMode?: import("./config.js").ExecutionMode;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/drizzle/src/schema/runs.ts
+++ b/packages/drizzle/src/schema/runs.ts
@@ -22,6 +22,7 @@ export const runsSqlite = sqliteTable("runs", {
   user: text("user"),
   /** Durable-turns checkpoint (LoopResumeState JSON) — written once per completed turn. */
   resumeState: text("resume_state"),
+  executionMode: text("execution_mode"),
 }, (table) => [
   index("idx_runs_status").on(table.status),
   index("idx_runs_task_id").on(table.taskId),
@@ -49,6 +50,7 @@ export const runsPg = pgTable("runs", {
   user: pgText("user"),
   /** Durable-turns checkpoint (LoopResumeState JSON) — written once per completed turn. */
   resumeState: jsonb("resume_state"),
+  executionMode: pgText("execution_mode"),
 }, (table) => [
   pgIndex("idx_pg_runs_status").on(table.status),
   pgIndex("idx_pg_runs_task_id").on(table.taskId),

--- a/packages/drizzle/src/stores/run-store.ts
+++ b/packages/drizzle/src/stores/run-store.ts
@@ -37,6 +37,7 @@ export class DrizzleRunStore implements RunStore {
       configPath: row.configPath,
       user: row.user ?? undefined,
       resumeState: deserializeJson<LoopResumeState | undefined>(row.resumeState, undefined, d),
+      executionMode: row.executionMode ?? undefined,
     };
   }
 
@@ -59,6 +60,7 @@ export class DrizzleRunStore implements RunStore {
       configPath: run.configPath,
       user: run.user ?? null,
       resumeState: serializeJson(run.resumeState, d),
+      executionMode: run.executionMode ?? null,
     };
     await this.db.insert(this.runs).values(values)
       .onConflictDoUpdate({

--- a/packages/node/src/__tests__/composite-spawner.test.ts
+++ b/packages/node/src/__tests__/composite-spawner.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { CompositeSpawner } from "../adapters/composite-spawner.js";
+import type { Spawner, SpawnResult } from "@polpo-ai/core/spawner";
+import type { RunnerConfig } from "@polpo-ai/core/types";
+
+function fakeSpawner(pid: number): Spawner & { spawn: ReturnType<typeof vi.fn>; kill: ReturnType<typeof vi.fn> } {
+  return {
+    spawn: vi.fn(async (_c: RunnerConfig): Promise<SpawnResult> => ({ pid, configPath: `fake://${pid}` })),
+    isAlive: vi.fn((p: number) => p === pid),
+    kill: vi.fn(),
+  } as any;
+}
+
+const config = (mode?: string): RunnerConfig =>
+  ({ runId: "r1", taskId: "t1", executionMode: mode, agent: { name: "a" }, task: { id: "t1" } }) as any;
+
+describe("CompositeSpawner — adaptive isolation dispatch", () => {
+  it("routes in-process mode to the in-process backend", async () => {
+    const sub = fakeSpawner(4242);
+    const inp = fakeSpawner(-7);
+    const composite = new CompositeSpawner(sub, inp);
+
+    const r = await composite.spawn(config("in-process"));
+    expect(r.pid).toBe(-7);
+    expect(inp.spawn).toHaveBeenCalledOnce();
+    expect(sub.spawn).not.toHaveBeenCalled();
+  });
+
+  it("routes subprocess mode — and no mode at all — to the subprocess backend", async () => {
+    const sub = fakeSpawner(4242);
+    const inp = fakeSpawner(-7);
+    const composite = new CompositeSpawner(sub, inp);
+
+    await composite.spawn(config("subprocess"));
+    await composite.spawn(config(undefined));
+    expect(sub.spawn).toHaveBeenCalledTimes(2);
+    expect(inp.spawn).not.toHaveBeenCalled();
+  });
+
+  it("isAlive and kill route by pid sign", () => {
+    const sub = fakeSpawner(4242);
+    const inp = fakeSpawner(-7);
+    const composite = new CompositeSpawner(sub, inp);
+
+    expect(composite.isAlive(-7)).toBe(true);
+    expect(composite.isAlive(4242)).toBe(true);
+    expect(composite.isAlive(-99)).toBe(false);
+
+    composite.kill(-7);
+    expect(inp.kill).toHaveBeenCalledWith(-7);
+    expect(sub.kill).not.toHaveBeenCalled();
+
+    composite.kill(4242);
+    expect(sub.kill).toHaveBeenCalledWith(4242);
+  });
+});

--- a/packages/node/src/__tests__/in-process-spawner.test.ts
+++ b/packages/node/src/__tests__/in-process-spawner.test.ts
@@ -55,6 +55,7 @@ vi.mock("@polpo-ai/llm", async (importOriginal) => {
   };
 });
 
+import { CompositeSpawner } from "../adapters/composite-spawner.js";
 import { InProcessSpawner } from "../adapters/in-process-spawner.js";
 import { NodeSpawner } from "../adapters/node-spawner.js";
 import { executeRun } from "../core/run-lifecycle.js";
@@ -468,13 +469,18 @@ describe("settings.taskExecution selection", () => {
     return (orchestrator as unknown as { spawner: unknown }).spawner;
   }
 
-  test("default: no opt-in → subprocess NodeSpawner (zero behavior change)", async () => {
+  test("default: no opt-in → composite routing a default config to the subprocess backend", async () => {
     const dir = await makeProject("sel-default", {});
     const orchestrator = new Orchestrator({ workDir: dir });
     await orchestrator.initInteractive("sel-default", {
       name: "team", agents: [createTestAgent({ name: "worker" })],
     });
-    expect(spawnerOf(orchestrator)).toBeInstanceOf(NodeSpawner);
+    // Adaptive isolation: the orchestrator now always wires the composite;
+    // zero-behavior-change lives in the routing default, pinned here.
+    const composite = spawnerOf(orchestrator) as CompositeSpawner;
+    expect(composite).toBeInstanceOf(CompositeSpawner);
+    expect((composite as unknown as { subprocess: unknown }).subprocess).toBeInstanceOf(NodeSpawner);
+    expect((composite as unknown as { inProcess: unknown }).inProcess).toBeInstanceOf(InProcessSpawner);
   });
 
   test("in-process opt-in: task completes end-to-end without a fork", async () => {
@@ -489,7 +495,7 @@ describe("settings.taskExecution selection", () => {
     await orchestrator.initInteractive("sel-inproc", {
       name: "team", agents: [createTestAgent({ name: "worker" })],
     });
-    expect(spawnerOf(orchestrator)).toBeInstanceOf(InProcessSpawner);
+    expect(spawnerOf(orchestrator)).toBeInstanceOf(CompositeSpawner);
 
     // End-to-end through the orchestrator's OWN (file) stores — proving the
     // lazy deps wiring, not just the instance swap. A forked subprocess

--- a/packages/node/src/adapters/composite-spawner.ts
+++ b/packages/node/src/adapters/composite-spawner.ts
@@ -1,0 +1,34 @@
+/**
+ * CompositeSpawner — adaptive isolation dispatch.
+ *
+ * Holds both execution backends and routes each spawn by the mode the task
+ * runner resolved into RunnerConfig.executionMode (task > agent > settings >
+ * "subprocess"). isAlive/kill route by pid sign — the invariant established
+ * by InProcessSpawner: negative pids are in-process runs, positive pids are
+ * OS subprocesses (0 = sandbox, which never flows through this composite:
+ * an injected spawner always bypasses it).
+ */
+
+import type { Spawner, SpawnResult } from "@polpo-ai/core/spawner";
+import type { RunnerConfig } from "@polpo-ai/core/types";
+
+export class CompositeSpawner implements Spawner {
+  constructor(
+    private subprocess: Spawner,
+    private inProcess: Spawner,
+  ) {}
+
+  async spawn(config: RunnerConfig): Promise<SpawnResult> {
+    const target = config.executionMode === "in-process" ? this.inProcess : this.subprocess;
+    return target.spawn(config);
+  }
+
+  isAlive(pid: number): boolean {
+    return pid < 0 ? this.inProcess.isAlive(pid) : this.subprocess.isAlive(pid);
+  }
+
+  kill(pid: number): void {
+    if (pid < 0) this.inProcess.kill(pid);
+    else this.subprocess.kill(pid);
+  }
+}

--- a/packages/node/src/core/orchestrator.ts
+++ b/packages/node/src/core/orchestrator.ts
@@ -58,6 +58,7 @@ import type { PlaybookStore } from "@polpo-ai/core/playbook-store";
 import { FilePlaybookStore } from "@polpo-ai/file-stores";
 import { NodeSpawner } from "../adapters/node-spawner.js";
 import { InProcessSpawner } from "../adapters/in-process-spawner.js";
+import { CompositeSpawner } from "../adapters/composite-spawner.js";
 import type { Spawner } from "@polpo-ai/core/spawner";
 import type { LogEntry } from "@polpo-ai/core/log-store";
 import { NodeFileSystem } from "../adapters/node-filesystem.js";
@@ -187,10 +188,12 @@ export class Orchestrator extends TypedEmitter {
    */
   private applyTaskExecutionMode(): void {
     if (this.spawnerInjected) return;
-    if (this.config.settings.taskExecution !== "in-process") return;
-    // Deps resolve lazily at spawn() time: the vault store is initialized
-    // after the managers, and hot-reload may swap store instances.
-    this.spawner = new InProcessSpawner(() => {
+    // Adaptive isolation: both backends are always available; each run is
+    // routed by the mode the task runner resolved into RunnerConfig
+    // (task > agent > settings > "subprocess"). Deps resolve lazily at
+    // spawn() time: the vault store is initialized after the managers,
+    // and hot-reload may swap store instances.
+    const inProcess = new InProcessSpawner(() => {
       // A DEDICATED LogStore instance per run over the same DB handle —
       // sharing the orchestrator's log sink would hijack its current
       // session (LogStore keeps the session as instance state). File mode
@@ -211,6 +214,7 @@ export class Orchestrator extends TypedEmitter {
         shell: this.shell,
       };
     });
+    this.spawner = new CompositeSpawner(this.spawner, inProcess);
   }
 
   /** Drizzle store bundle — populated when storage is "sqlite" or "postgres". */

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -11,6 +11,7 @@ export { spawnLoopEngine } from "./adapters/loop-engine.js";
 // Spawners — subprocess (default) and in-process (settings.taskExecution: "in-process")
 export { NodeSpawner } from "./adapters/node-spawner.js";
 export { InProcessSpawner } from "./adapters/in-process-spawner.js";
+export { CompositeSpawner } from "./adapters/composite-spawner.js";
 export type { InProcessSpawnerDeps } from "./adapters/in-process-spawner.js";
 export { executeRun } from "./core/run-lifecycle.js";
 export type { ExecuteRunDeps, ExecuteRunOutcome, TranscriptSession } from "./core/run-lifecycle.js";

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -332,6 +332,7 @@ export function taskRoutes(getDeps: () => {
       retryPolicy: body.retryPolicy,
       notifications: body.notifications,
       sideEffects: body.sideEffects,
+      executionMode: body.executionMode,
       draft: body.draft,
       user: body.user,
     });

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -63,6 +63,7 @@ const ScopedNotificationRulesSchema = z.object({
 // ── Task schemas ──────────────────────────────────────────────────────
 
 export const CreateTaskSchema = z.object({
+  executionMode: z.enum(["subprocess", "in-process"]).optional(),
   title: z.string().min(1),
   description: z.string().min(1),
   assignTo: z.string().min(1),
@@ -523,6 +524,7 @@ const AgentLoopFieldsSchema = z.object({
 });
 
 export const AddAgentSchema = z.object({
+  executionMode: z.enum(["subprocess", "in-process"]).optional(),
   name: z.string().min(1),
   role: z.string().optional(),
   model: z.string().optional(),


### PR DESCRIPTION
Phase C: `executionMode` on Task/Agent/settings with task > agent > settings > default precedence (pure resolver, exhaustively tested), CompositeSpawner routing each run to its backend (pid-sign dispatch for isAlive/kill), resolved mode recorded on run records for observability and the Phase D bench. Defaults unchanged, cloud untouched, all additive. Suite 1968 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)