### PR TITLE
feat(bench): crash_resume scenario + execution-mode comparison

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -19,6 +19,8 @@ costs.
 pnpm build                                        # dist/ must exist
 node bench/run.mjs --label baseline-main-runtime  # full local run
 node bench/run.mjs --only smoke,tool_loop_50      # subset
+node bench/run.mjs --label rel-subprocess --execution-mode subprocess   # both execution
+node bench/run.mjs --label rel-inprocess  --execution-mode in-process   # modes, per release
 node bench/compare.mjs bench/results/<a>.json bench/results/<b>.json
 ```
 
@@ -59,8 +61,12 @@ Every task description embeds a directive that fully scripts the mock model:
 The mock is stateless per request: the current turn is recovered from the
 conversation history itself (bench tool-call ids encode `sid` + turn, and the
 runtime echoes them back). Per-`sid` stats (requests, turns, artificial
-latency applied, tool calls emitted) are exposed at `GET /bench/stats/<sid>`;
-`POST /bench/reset` clears them.
+latency applied, tool calls emitted, per-turn request counts `turnRequests`,
+max call-id turn seen inside incoming requests `maxHistoryTurn`) are exposed
+at `GET /bench/stats/<sid>`; `POST /bench/reset` clears them. The last two
+exist for durable-execution verification: a resumed session must show
+`turnRequests[t] == 1` for every checkpointed turn (no re-execution) and a
+`maxHistoryTurn` proving the seeded checkpoint history reached the model.
 
 The mock speaks **both** wire protocols behind a `baseUrl` override:
 
@@ -98,12 +104,104 @@ history compaction.
 | `outcomes_3`     | `register_outcome` pipeline → `task.outcomes`                      |
 | `timeout_kill`   | `cap=never` + `maxDuration: 8s` — watchdog kill → terminal `failed`|
 | `concurrency_10` | 10 concurrent 5-turn tasks — fan-out + makespan                    |
+| `crash_resume`   | durable turns: SIGKILL server+runner mid-task, restart → resume from checkpoint (see below) |
 
 Add a scenario by appending one object to `bench/scenarios.mjs` (directive
 params + declarative invariants — terminal status, turns served by the mock,
 tool calls emitted, outcomes on the task record).
 
-## Baseline results (current runtime, v0.10.x)
+### Execution modes (`--execution-mode`)
+
+Adaptive isolation (v0.12.x) makes WHERE a task runs a per-run policy:
+`"subprocess"` (historical default, detached runner process) or
+`"in-process"` (the loop runs inside the server — ProxyTool P0). The flag
+runs the SAME scenarios under the chosen backend so every release measures
+both:
+
+- **local mode** writes `settings.taskExecution` into the throwaway project
+  (settings tier of the resolver);
+- **target mode** sends the per-task `executionMode` field on `POST /tasks`
+  (task tier — a remote project's settings can't be rewritten).
+
+Either way the harness verifies the RESOLVED mode as an **invariant, not a
+label**: the live run record (`GET /tasks/:id/activity` → `run.executionMode`,
+sampled mid-run because run records are deleted at collection) must report
+the requested mode, corroborated by the pid sign (negative = in-process
+synthetic pid, positive = OS subprocess). Without the flag nothing is sent or
+asserted, so the suite still runs against runtimes that predate execution
+modes; the observed mode is reported in `metrics.execution_mode` when
+available.
+
+### Durable execution (`crash_resume`)
+
+Verifies and measures Phase A durable turns end-to-end, black-box:
+
+1. a control run of the same directive (8 tool turns × 400ms think time)
+   completes normally — ground truth for wall time and final result text;
+2. the crash run starts on a **dedicated child-hosted server** (own temp
+   project, file storage — run records are JSON files that survive restarts);
+3. once the mock has served turn `killAfterTurn + 1` (the engine awaits the
+   turn-K checkpoint write before requesting K+1, so the turn-4 checkpoint is
+   guaranteed durable), the driver SIGKILLs the server host and the runner
+   (in-process runs die with the host). SIGKILL is the only honest crash:
+   PolpoServer traps SIGTERM/SIGINT into `gracefulStop()`, which deletes run
+   records — destroying the checkpoint;
+4. the server restarts on the same project dir. Startup orphan recovery
+   (`recoverOrphanedTasks`) finds the dead run, harvests `resumeState`, and
+   the respawn seeds the checkpoint history.
+
+Invariants: task terminal `done`; **turns ≤ killAfterTurn requested exactly
+once** (mock `turnRequests` — retry-from-zero fails this immediately); at
+most the un-checkpointed in-flight tail is re-requested, once; the seeded
+history reached the model (`maxHistoryTurn`); final result text
+byte-identical to the control run. Metrics: `wall_ms` (includes downtime),
+`control_wall_ms`, `downtime_ms`, `kill_at_turn`, `resumed_from_turn`,
+`turns_saved`, `duplicated_turns`.
+
+Local mode only — the scenario owns its server lifecycle, so it is skipped
+(with a note) under `--target`.
+
+## Results: subprocess vs in-process (v0.12.x, sha 84875ff)
+
+First measured comparison of the two execution backends — same scenarios,
+same mock, labels `durable-subprocess` / `durable-inprocess` (committed in
+`bench/results/`). Both runs 9/9 green, execution-mode invariant verified on
+every run record.
+
+| scenario       | subprocess wall | in-process wall | Δ wall | ovh sub | ovh in-proc |
+| -------------- | --------------- | --------------- | ------ | ------- | ----------- |
+| smoke          | 538             | 155             | −71%   | 488     | 105         |
+| tool_loop_50   | 3786            | 3520            | −7%    | 1236    | 970         |
+| tool_burst     | 1345            | 1226            | −9%    | 795     | 676         |
+| big_output     | 2658            | 2411            | −9%    | 1108    | 861         |
+| max_turns_cap  | 1440            | 1043            | −28%   | 690     | 293         |
+| outcomes_3     | 826             | 425             | −49%   | 526     | 125         |
+| timeout_kill   | 10089           | 10051           | −0.4%  | 1089    | 751         |
+| concurrency_10 | 2524 (makespan) | 1230 (makespan) | −51%   | —       | —           |
+| crash_resume   | 5883            | 5541            | −6%    | —       | —           |
+
+What the numbers say:
+
+- **In-process removes a ~380–400ms fixed cost per task** (runner Node boot
+  + engine import): decisive for short tasks (smoke −71%, outcomes_3 −49%),
+  marginal for long loops (tool_loop_50 −7%). This is the measured floor of
+  the ProxyTool win before sandbox billing even enters the picture.
+- **Fan-out benefits most**: `concurrency_10` makespan halves (1230ms vs
+  2524ms) — ten subprocess boots vs zero.
+- **The loop itself is slightly slower in-process** on tool-heavy scenarios
+  (`loop_ms` +5% on tool_loop_50, +24% on tool_burst): the engine shares the
+  server's event loop, so parallel tool dispatch contends with API traffic.
+  Wall still wins because the boot saving dominates; worth re-measuring as
+  in-process concurrency grows.
+- `crash_resume` (see invariants above): kill after the turn-4/5 checkpoint,
+  restart, resume — **5 turns saved, zero re-executed**, ~1.3s downtime
+  (child-server restart incl. startup recovery), resumed task ~1.4–1.7s
+  slower than its no-crash control, final result byte-identical. Works
+  identically in both execution modes (synthetic negative pids recover the
+  same way: a fresh process has no live in-process runs, so the checkpoint
+  is harvested).
+
+## Baseline results (historical: v0.10.x runtime, pre-reactive-tick)
 
 All 8 scenarios pass. Headline numbers from the committed baseline run
 (`bench/results/…-baseline-main-runtime.json`, run-to-run variance ~±1%):
@@ -180,6 +278,14 @@ Discovered while building this suite against the current dist runtime:
    reaches that path.
 8. **`agents.json` on disk is not a bare `AgentConfig[]`** — the file store
    format is `[{ "agent": {...}, "teamName": "..." }]`.
+9. **Resume is a hard-crash path only** (verified building `crash_resume`,
+   v0.12.x): `gracefulStop()` (also reached via SIGTERM/SIGINT — PolpoServer
+   traps both) marks active runs killed and DELETES their run records, so no
+   checkpoint survives a graceful shutdown; and a runner that dies while the
+   server stays alive goes through stale-detection → retry-from-zero, not
+   resume. Startup orphan recovery after SIGKILL is the one path that
+   resumes from the checkpoint — which is exactly what the scenario
+   simulates (and what a crash/deploy restart looks like in production).
 
 ## Pricing layer
 

--- a/bench/lib/client.mjs
+++ b/bench/lib/client.mjs
@@ -98,19 +98,53 @@ export class PolpoClient {
   }
 
   /**
+   * GET /tasks/:id/activity — composite task + live run record + transcript.
+   * The run record is the only public surface that exposes the RESOLVED
+   * executionMode and the runner pid (positive = subprocess, negative =
+   * in-process synthetic). It only exists while the run is active (deleted
+   * at collection), so callers sample it DURING polling.
+   */
+  getTaskActivity(taskId) {
+    return this.request("GET", `/tasks/${taskId}/activity`);
+  }
+
+  /** Extract the fields the bench asserts on from a live run record. */
+  static pickRunInfo(run) {
+    if (!run) return null;
+    return { id: run.id, pid: run.pid, executionMode: run.executionMode ?? null };
+  }
+
+  /**
    * Poll a task to a terminal state.
-   * Returns { task, wallMs, spawnMs, timeline, timedOut }.
+   * Returns { task, wallMs, spawnMs, timeline, timedOut, run }.
    *   wallMs  — createdAtMs → terminal state observed
    *   spawnMs — createdAtMs → first observed state past "pending"
+   *   run     — live run record snapshot ({ id, pid, executionMode }) when
+   *             captureRun is set, else null. Sampled while the run is
+   *             active; retried every poll until observed.
+   * tolerateErrors — swallow transient request failures (server restarting
+   *   mid-poll, as in crash_resume) instead of throwing; the deadline still
+   *   bounds the loop.
    */
-  async pollTask(taskId, createdAtMs, { timeoutMs = 120_000, intervalMs = 100 } = {}) {
+  async pollTask(taskId, createdAtMs, { timeoutMs = 120_000, intervalMs = 100, captureRun = false, tolerateErrors = false } = {}) {
     const timeline = [];
     let lastStatus = null;
     let spawnMs = null;
+    let run = null;
     const deadline = createdAtMs + timeoutMs;
 
     for (;;) {
-      const task = await this.getTask(taskId);
+      let task;
+      try {
+        task = await this.getTask(taskId);
+      } catch (err) {
+        if (!tolerateErrors) throw err;
+        if (Date.now() > deadline) {
+          return { task: { id: taskId, status: "unknown" }, wallMs: Date.now() - createdAtMs, spawnMs, timeline, timedOut: true, run };
+        }
+        await new Promise((r) => setTimeout(r, intervalMs * 2));
+        continue;
+      }
       const now = Date.now();
       if (task.status !== lastStatus) {
         timeline.push({ status: task.status, tMs: now - createdAtMs });
@@ -119,11 +153,17 @@ export class PolpoClient {
       if (spawnMs === null && !ACTIVE_PRE_SPAWN.has(task.status)) {
         spawnMs = now - createdAtMs;
       }
+      if (captureRun && run === null && !ACTIVE_PRE_SPAWN.has(task.status)) {
+        try {
+          const activity = await this.getTaskActivity(taskId);
+          run = PolpoClient.pickRunInfo(activity?.run);
+        } catch { /* run record not up yet — retry next poll */ }
+      }
       if (TERMINAL_STATUSES.has(task.status)) {
-        return { task, wallMs: now - createdAtMs, spawnMs, timeline, timedOut: false };
+        return { task, wallMs: now - createdAtMs, spawnMs, timeline, timedOut: false, run };
       }
       if (now > deadline) {
-        return { task, wallMs: now - createdAtMs, spawnMs, timeline, timedOut: true };
+        return { task, wallMs: now - createdAtMs, spawnMs, timeline, timedOut: true, run };
       }
       await new Promise((r) => setTimeout(r, intervalMs));
     }
@@ -134,11 +174,11 @@ export class PolpoClient {
    * interval regardless of task count — keeps concurrency scenarios inside
    * the server's rate limit). Same result shape as pollTask, per task.
    */
-  async pollMany(entries, { timeoutMs = 300_000, intervalMs = 200 } = {}) {
+  async pollMany(entries, { timeoutMs = 300_000, intervalMs = 200, captureRun = false } = {}) {
     const state = new Map(
       entries.map((e) => [
         e.taskId,
-        { createdAtMs: e.createdAtMs, timeline: [], lastStatus: null, spawnMs: null, result: null },
+        { createdAtMs: e.createdAtMs, timeline: [], lastStatus: null, spawnMs: null, run: null, result: null },
       ]),
     );
     const startMs = Math.min(...entries.map((e) => e.createdAtMs));
@@ -159,15 +199,21 @@ export class PolpoClient {
         if (s.spawnMs === null && !ACTIVE_PRE_SPAWN.has(task.status)) {
           s.spawnMs = now - s.createdAtMs;
         }
+        if (captureRun && s.run === null && !ACTIVE_PRE_SPAWN.has(task.status) && !TERMINAL_STATUSES.has(task.status)) {
+          try {
+            const activity = await this.getTaskActivity(taskId);
+            s.run = PolpoClient.pickRunInfo(activity?.run);
+          } catch { /* run record not up yet — retry next poll */ }
+        }
         if (TERMINAL_STATUSES.has(task.status)) {
-          s.result = { task, wallMs: now - s.createdAtMs, spawnMs: s.spawnMs, timeline: s.timeline, timedOut: false };
+          s.result = { task, wallMs: now - s.createdAtMs, spawnMs: s.spawnMs, timeline: s.timeline, timedOut: false, run: s.run };
         }
       }
       if (Date.now() > deadline) {
         for (const [taskId, s] of state) {
           if (s.result) continue;
           const task = byId.get(taskId) ?? { id: taskId, status: "unknown" };
-          s.result = { task, wallMs: Date.now() - s.createdAtMs, spawnMs: s.spawnMs, timeline: s.timeline, timedOut: true };
+          s.result = { task, wallMs: Date.now() - s.createdAtMs, spawnMs: s.spawnMs, timeline: s.timeline, timedOut: true, run: s.run };
         }
         break;
       }

--- a/bench/lib/crash-resume.mjs
+++ b/bench/lib/crash-resume.mjs
@@ -1,0 +1,356 @@
+/**
+ * bench/lib/crash-resume.mjs — durable-execution scenario driver.
+ *
+ * Measures and verifies crash → resume (durable turns, per-turn checkpoints):
+ * a multi-turn task is killed mid-run with SIGKILL — server host AND runner —
+ * then the server is restarted on the same project dir. Startup orphan
+ * recovery (`recoverOrphanedTasks`) must harvest the run record's
+ * `resumeState` checkpoint and respawn the task so it RESUMES at
+ * checkpoint+1 instead of retrying from zero.
+ *
+ * Why a dedicated child-hosted server (instead of the shared local server):
+ *   - recovery is a STARTUP path — the server process must actually die and
+ *     come back (a live orchestrator that sees a dead runner goes through
+ *     the stale/retry path, not resume);
+ *   - PolpoServer traps SIGTERM/SIGINT into gracefulStop(), which marks
+ *     runs killed and DELETES the run records — destroying the checkpoint.
+ *     Only SIGKILL simulates a real crash.
+ *
+ * The kill is timed off mock-side truth: the loop runner awaits the turn-K
+ * checkpoint write before issuing the request for turn K+1, so once the
+ * mock has served turn `killAfterTurn + 1`, the checkpoint for
+ * `killAfterTurn` is durably on disk. Invariants (all from public
+ * contracts: task API + mock stats):
+ *
+ *   (a) the task completes `done` after recovery;
+ *   (b) turns ≤ killAfterTurn are NEVER re-requested
+ *       (mock `turnRequests[t] === 1`) — Temporal semantics: recorded
+ *       turns replay from seeded history, they don't re-execute;
+ *   (c) the final result text is byte-identical to a control run of the
+ *       same directive without a crash;
+ *   (d) the seeded history reached the model: the mock saw call-ids
+ *       ≥ killAfterTurn inside an incoming request (`maxHistoryTurn`).
+ *
+ * Metrics: wall (incl. downtime), control wall, downtime, resumed-from
+ * turn, turns saved by the checkpoint, duplicated turns (in-flight at
+ * crash — at most the un-checkpointed tail).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { writeProject } from "./project.mjs";
+import { buildDirective, genSid } from "./directive.mjs";
+import { PolpoClient } from "./client.mjs";
+
+const LIB_DIR = dirname(fileURLToPath(import.meta.url));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ─── Child server host ────────────────────────────────────────────────────────
+
+function startHost({ serverEntry, port, projectDir }) {
+  const child = spawn(
+    process.execPath,
+    [join(LIB_DIR, "server-host.mjs"), "--entry", serverEntry, "--port", String(port), "--workdir", projectDir],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  let stderrTail = "";
+  child.stderr.on("data", (c) => {
+    stderrTail = (stderrTail + c.toString()).slice(-2000);
+  });
+  return {
+    child,
+    get pid() { return child.pid; },
+    get stderrTail() { return stderrTail; },
+    sigkill() {
+      try { process.kill(child.pid, "SIGKILL"); } catch { /* already dead */ }
+    },
+  };
+}
+
+async function waitForApi(polpo, host, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      return await polpo.probe({ timeoutMs: 2_000 });
+    } catch (err) {
+      if (host.child.exitCode !== null && host.child.exitCode !== undefined && host.child.exitCode !== 0) {
+        throw new Error(`server host died (exit ${host.child.exitCode}): ${host.stderrTail.slice(-500)}`);
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`server host not reachable: ${err.message}; stderr: ${host.stderrTail.slice(-500)}`);
+      }
+    }
+  }
+}
+
+// ─── Task helpers ─────────────────────────────────────────────────────────────
+
+async function createDirectiveTask(polpo, scenario, sid, titleSuffix, taskExecutionMode) {
+  const directive = buildDirective(sid, scenario.directive);
+  const description =
+    `${directive}\n\n` +
+    `Benchmark task — the model behavior is fully scripted by the directive above. ` +
+    `Execute the requested tool calls and finish.`;
+  const createdAtMs = Date.now();
+  const task = await polpo.createTask({
+    title: `bench:${scenario.name}${titleSuffix}`,
+    description,
+    assignTo: scenario.agent,
+    expectations: [],
+    ...(taskExecutionMode ? { executionMode: taskExecutionMode } : {}),
+    ...(scenario.taskOpts ?? {}),
+  });
+  return { sid, taskId: task.id, createdAtMs };
+}
+
+/** turnRequests {turn: count} → sorted list of duplicated turns. */
+function duplicatedTurns(turnRequests) {
+  return Object.entries(turnRequests ?? {})
+    .filter(([, count]) => count > 1)
+    .map(([turn, count]) => ({ turn: Number(turn), count }))
+    .sort((a, b) => a.turn - b.turn);
+}
+
+// ─── Scenario driver ──────────────────────────────────────────────────────────
+
+/**
+ * @param {object} scenario   the crash_resume scenario (directive, killAfterTurn, invariants, ...)
+ * @param {object} opts
+ *   serverEntry        path to dist/server/index.js
+ *   mock               MockClient (already health-checked)
+ *   mockPort           mock LLM port (written into the throwaway project)
+ *   port               dedicated port for the child-hosted server
+ *   executionMode      "subprocess" | "in-process" | null — project-wide
+ *                      settings.taskExecution for the throwaway project
+ *   enforceExecutionMode  when true, assert run records report executionMode
+ *   keep               keep the temp project dir
+ */
+export async function runCrashResume(scenario, opts) {
+  const { serverEntry, mock, mockPort, port, executionMode = null, enforceExecutionMode = false, keep = false } = opts;
+  const startedAt = Date.now();
+  const killAfterTurn = scenario.killAfterTurn;
+  const totalTurns = scenario.directive.turns;
+
+  const checks = [];
+  const push = (name, pass, detail) => checks.push({ name, pass, detail });
+
+  const projectDir = mkdtempSync(join(tmpdir(), "polpo-bench-crash-"));
+  writeProject(projectDir, mockPort, { executionMode });
+
+  const polpo = new PolpoClient(`http://127.0.0.1:${port}`, { xffRotate: true });
+  let host = startHost({ serverEntry, port, projectDir });
+
+  const metrics = {};
+  let crashTaskId = null;
+  let controlTaskId = null;
+
+  try {
+    await waitForApi(polpo, host);
+
+    // ── 1. Control run: same directive, no crash — ground truth ──
+    const control = await createDirectiveTask(polpo, scenario, genSid(), "#control", null);
+    controlTaskId = control.taskId;
+    const controlPolled = await polpo.pollTask(control.taskId, control.createdAtMs, {
+      timeoutMs: scenario.timeoutMs,
+      intervalMs: 100,
+      captureRun: true,
+    });
+    if (controlPolled.timedOut) {
+      push("control_terminal", false, `control run did not finish within ${scenario.timeoutMs}ms (last: ${controlPolled.task?.status})`);
+      return finish();
+    }
+    push("control_terminal", controlPolled.task.status === "done", `control run: ${controlPolled.task.status}`);
+    const controlResultText = controlPolled.task?.result?.stdout ?? null;
+    metrics.control_wall_ms = controlPolled.wallMs;
+
+    // ── 2. Crash run ──
+    const crash = await createDirectiveTask(polpo, scenario, genSid(), "", null);
+    crashTaskId = crash.taskId;
+    const sid = crash.sid;
+
+    // Watch task + mock until the kill window: run record captured AND the
+    // mock has served turn killAfterTurn+1 (⇒ checkpoint for killAfterTurn
+    // is durably written — the engine awaits the checkpoint sink before the
+    // next request).
+    let runInfo = null;
+    let killStats = null;
+    const killDeadline = Date.now() + scenario.timeoutMs;
+    for (;;) {
+      if (Date.now() > killDeadline) {
+        push("kill_window", false, "timed out waiting for the kill window");
+        return finish();
+      }
+      const task = await polpo.getTask(crash.taskId);
+      if (task.status === "done" || task.status === "failed") {
+        push("kill_window", false, `task reached ${task.status} before the kill fired — increase turns/latencyMs`);
+        return finish();
+      }
+      if (runInfo === null && task.status !== "pending") {
+        try {
+          const activity = await polpo.getTaskActivity(crash.taskId);
+          runInfo = PolpoClient.pickRunInfo(activity?.run);
+        } catch { /* not up yet */ }
+      }
+      const s = await mock.stats(sid);
+      if (runInfo !== null && (s?.stats?.turnsServed ?? 0) >= killAfterTurn + 1) {
+        killStats = s.stats;
+        break;
+      }
+      await sleep(40);
+    }
+    push("kill_window", true, `killed at mock turn ${killStats.turnsServed} (threshold ${killAfterTurn + 1})`);
+    metrics.kill_at_turn = killStats.turnsServed;
+    const preKillRequests = killStats.requests;
+
+    // ── 3. CRASH: SIGKILL server host first (nothing left alive to observe
+    // the runner death through the live path), then the runner subprocess.
+    // In-process runs (negative synthetic pid) die with the host. ──
+    const killedAtMs = Date.now();
+    host.sigkill();
+    if (runInfo.pid > 0) {
+      try { process.kill(runInfo.pid, "SIGKILL"); } catch { /* already dead */ }
+    }
+    await sleep(300); // let the OS reap before restart
+
+    // ── 4. Restart on the same project dir/port. PolpoServer runs orphan
+    // recovery inside initInteractive() BEFORE binding HTTP, so a healthy
+    // /health implies recovery already harvested the checkpoint. ──
+    host = startHost({ serverEntry, port, projectDir });
+    await waitForApi(polpo, host);
+    metrics.downtime_ms = Date.now() - killedAtMs;
+
+    // ── 5. Poll to terminal (wall includes crash + downtime + resume) ──
+    const polled = await polpo.pollTask(crash.taskId, crash.createdAtMs, {
+      timeoutMs: scenario.timeoutMs,
+      intervalMs: 100,
+      captureRun: true,
+      tolerateErrors: true,
+    });
+    if (polled.timedOut) {
+      push("terminal_reached", false, `no terminal state within ${scenario.timeoutMs}ms of creation (last: ${polled.task?.status})`);
+      await polpo.killTask(crash.taskId);
+      return finish();
+    }
+    push("terminal_reached", true, polled.task.status);
+    push(
+      "terminal_status",
+      (scenario.invariants?.terminal ?? ["done"]).includes(polled.task.status),
+      `expected one of [${(scenario.invariants?.terminal ?? ["done"]).join(", ")}], got "${polled.task.status}"`,
+    );
+    metrics.wall_ms = polled.wallMs;
+
+    // ── 6. Mock-side verification ──
+    const finalStats = (await mock.stats(sid))?.stats;
+    if (!finalStats) {
+      push("mock_stats", false, `mock has no stats for sid ${sid}`);
+      return finish();
+    }
+    const dups = duplicatedTurns(finalStats.turnRequests);
+    const resumedFromTurn = dups.length > 0 ? dups[0].turn : killStats.turnsServed + 1;
+    const turnsSaved = resumedFromTurn - 1;
+
+    // (b) NON-RE-EXECUTION: every turn whose checkpoint predates the kill
+    // must have been requested exactly once. Retry-from-zero re-requests
+    // turns 1..killAfterTurn and fails here.
+    const reexecuted = dups.filter((d) => d.turn <= killAfterTurn);
+    push(
+      "resume_no_reexecution",
+      reexecuted.length === 0,
+      reexecuted.length === 0
+        ? `turns 1..${killAfterTurn} requested exactly once — resumed from turn ${resumedFromTurn} (${turnsSaved} turns saved)`
+        : `turns re-executed after resume: ${reexecuted.map((d) => `${d.turn}(x${d.count})`).join(", ")} — checkpoint was not used`,
+    );
+    // Only the un-checkpointed in-flight tail may replay, and at most once.
+    push(
+      "resume_duplicates_bounded",
+      dups.length <= 2 && dups.every((d) => d.count === 2),
+      `duplicated turns: ${dups.length ? dups.map((d) => `${d.turn}(x${d.count})`).join(", ") : "none"} (allowed: ≤2 turns, ≤2 requests each)`,
+    );
+    // (d) seeded history reached the model wire-side after the restart.
+    push(
+      "history_seeded",
+      (finalStats.maxHistoryTurn ?? 0) >= killAfterTurn,
+      `max bench call-id turn seen in an incoming request: ${finalStats.maxHistoryTurn} (need ≥ ${killAfterTurn})`,
+    );
+    // All scripted turns served exactly to completion.
+    push(
+      "turns_served",
+      finalStats.turnsServed === totalTurns + 1,
+      `expected ${totalTurns + 1} (=${totalTurns} tool turns + final), mock served ${finalStats.turnsServed}`,
+    );
+    push("finals", finalStats.finals === 1, `expected exactly 1 final response, got ${finalStats.finals}`);
+
+    // (c) result identical to the no-crash control run.
+    const crashResultText = polled.task?.result?.stdout ?? null;
+    push(
+      "final_result_identical",
+      controlResultText !== null && crashResultText === controlResultText,
+      crashResultText === controlResultText
+        ? `result text identical to control (${controlResultText?.length ?? 0} bytes)`
+        : `crash-run result differs from control (control: ${JSON.stringify(controlResultText)?.slice(0, 120)}, crash: ${JSON.stringify(crashResultText)?.slice(0, 120)})`,
+    );
+
+    // Execution-mode invariant (pre-crash run + post-resume run).
+    if (enforceExecutionMode && executionMode) {
+      const runs = [
+        ["pre-crash", runInfo],
+        ["post-resume", polled.run],
+      ];
+      for (const [phase, r] of runs) {
+        const pidOk = r ? (executionMode === "in-process" ? r.pid < 0 : r.pid > 0) : false;
+        push(
+          `execution_mode_${phase.replace("-", "_")}`,
+          r?.executionMode === executionMode && pidOk,
+          r
+            ? `${phase} run: executionMode=${r.executionMode}, pid=${r.pid} (expected ${executionMode})`
+            : `${phase} run record never observed`,
+        );
+      }
+    }
+
+    metrics.resumed_from_turn = resumedFromTurn;
+    metrics.turns_saved = turnsSaved;
+    metrics.duplicated_turns = dups.length;
+    metrics.llm_ms = finalStats.llmBusyMs;
+    metrics.turns = finalStats.turnsServed;
+    metrics.llm_requests = finalStats.requests;
+    metrics.requests_pre_crash = preKillRequests;
+    metrics.requests_post_crash = finalStats.requests - preKillRequests;
+    metrics.tool_calls = finalStats.toolCallsEmitted;
+
+    return finish(polled);
+  } catch (err) {
+    push("execution", false, err.message);
+    return finish();
+  } finally {
+    // Best-effort teardown (host may already be dead).
+    try {
+      if (crashTaskId) await polpo.deleteTask(crashTaskId);
+      if (controlTaskId) await polpo.deleteTask(controlTaskId);
+    } catch { /* server gone */ }
+    host.sigkill();
+    if (!keep) {
+      try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  }
+
+  function finish(polled = null) {
+    return {
+      name: scenario.name,
+      description: scenario.description,
+      params: scenario.directive,
+      killAfterTurn,
+      executionMode,
+      pass: checks.every((c) => c.pass),
+      terminal: polled?.task?.status ?? null,
+      metrics,
+      timeline: polled?.timeline,
+      checks,
+      elapsed_ms: Date.now() - startedAt,
+    };
+  }
+}

--- a/bench/lib/project.mjs
+++ b/bench/lib/project.mjs
@@ -1,0 +1,68 @@
+/**
+ * bench/lib/project.mjs — throwaway bench project scaffolding.
+ *
+ * Shared by run.mjs (local mode) and lib/crash-resume.mjs (which needs its
+ * own project dir + child-hosted server it can SIGKILL). One writer keeps
+ * polpo.json / agents.json conventions in a single place.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Write a minimal bench project into `dir/.polpo`.
+ *
+ * @param {string} dir project root
+ * @param {number} mockPort mock LLM port (provider baseUrl override)
+ * @param {{ executionMode?: "subprocess" | "in-process" | null }} [opts]
+ *   executionMode — when set, written as `settings.taskExecution` so the
+ *   SAME scenarios run under either execution backend (adaptive isolation,
+ *   settings tier). Omitted → runtime default (subprocess).
+ */
+export function writeProject(dir, mockPort, { executionMode = null } = {}) {
+  const polpoDir = join(dir, ".polpo");
+  mkdirSync(polpoDir, { recursive: true });
+  writeFileSync(
+    join(polpoDir, "polpo.json"),
+    JSON.stringify(
+      {
+        project: "polpo-bench",
+        settings: {
+          storage: "file",
+          maxRetries: 0, // failures must be terminal — no silent retries mid-benchmark
+          workDir: ".",
+          logLevel: "quiet",
+          ...(executionMode ? { taskExecution: executionMode } : {}),
+        },
+        // NOTE: the provider is named "openai" (with a baseUrl override) instead
+        // of a dedicated "bench" provider because the runtime's pre-spawn
+        // validation (validateProviderKeys) only accepts providers present in
+        // the static PROVIDER_ENV_MAP — unknown custom providers can never
+        // spawn task agents. See bench/README.md, "Runtime findings".
+        providers: {
+          openai: { baseUrl: `http://127.0.0.1:${mockPort}/v1` },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  // FileAgentStore format: [{ agent: AgentConfig, teamName }]
+  writeFileSync(
+    join(polpoDir, "agents.json"),
+    JSON.stringify(
+      [
+        {
+          agent: { name: "bench-agent", role: "developer", model: "openai/mock-1", maxTurns: 250 },
+          teamName: "bench",
+        },
+        {
+          agent: { name: "bench-capped", role: "developer", model: "openai/mock-1", maxTurns: 15 },
+          teamName: "bench",
+        },
+      ],
+      null,
+      2,
+    ),
+  );
+}

--- a/bench/lib/server-host.mjs
+++ b/bench/lib/server-host.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * bench/lib/server-host.mjs — child-process host for a PolpoServer.
+ *
+ * The crash_resume scenario needs a Polpo server it can KILL -9 (a graceful
+ * stop is useless: gracefulStop() SIGTERMs runners, marks runs killed and
+ * DELETES the run records — no checkpoint survives it). PolpoServer also
+ * traps SIGTERM/SIGINT into a graceful stop, so the only honest "machine
+ * died" simulation is SIGKILL on a dedicated child process.
+ *
+ * Usage (spawned by lib/crash-resume.mjs, not by hand):
+ *   node bench/lib/server-host.mjs --entry <dist/server/index.js> \
+ *        --port <port> --workdir <projectDir>
+ *
+ * Readiness is probed by the parent over HTTP (/api/v1/health) — stdout is
+ * informational only.
+ */
+
+import { pathToFileURL } from "node:url";
+
+function getArg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const entry = getArg("entry", null);
+const port = Number(getArg("port", 8379));
+const workDir = getArg("workdir", null);
+
+if (!entry || !workDir) {
+  console.error("[server-host] usage: node server-host.mjs --entry <server.js> --port <port> --workdir <dir>");
+  process.exit(2);
+}
+
+const { PolpoServer } = await import(pathToFileURL(entry).href);
+const server = new PolpoServer({ port, host: "127.0.0.1", workDir });
+await server.start();
+console.log(`[server-host] up on http://127.0.0.1:${port} (pid ${process.pid})`);

--- a/bench/mock-llm.mjs
+++ b/bench/mock-llm.mjs
@@ -51,6 +51,14 @@ function newStats() {
     llmBusyMs: 0, // sum of artificial latency applied
     firstRequestAt: null,
     lastRequestAt: null,
+    // Durable-execution observability (crash_resume): how many times each
+    // turn was requested. A resumed session must NOT re-request completed
+    // turns — turnRequests[t] > 1 for t ≤ checkpoint means re-execution.
+    turnRequests: {},
+    // Highest bench call-id turn seen INSIDE an incoming request (i.e. in
+    // the conversation history the runtime sent us). After a crash+resume,
+    // this proves the seeded checkpoint history actually reached the model.
+    maxHistoryTurn: 0,
   };
 }
 
@@ -409,6 +417,13 @@ export function createMockLlm({ port = 8377, host = "127.0.0.1", quiet = true } 
       stats.llmBusyMs += params.latencyMs;
     }
 
+    // History observability: highest bench call-id turn present in the
+    // INCOMING request (echoed/seeded conversation history).
+    const scannedHistory = scanCallIds(rawJson);
+    if (scannedHistory && scannedHistory.maxTurn > stats.maxHistoryTurn) {
+      stats.maxHistoryTurn = scannedHistory.maxTurn;
+    }
+
     let decision;
     if (!hasTools(body)) {
       // Tool-less request ⇒ summarize/utility call (e.g. context compaction).
@@ -417,6 +432,7 @@ export function createMockLlm({ port = 8377, host = "127.0.0.1", quiet = true } 
       decision = { kind: "text", text: summarizeText(rawText.match(/\[BENCH[^\]]+\]/)?.[0]) };
     } else {
       const turn = computeTurn(body, rawJson);
+      stats.turnRequests[turn] = (stats.turnRequests[turn] ?? 0) + 1;
       decision = decide(sid, params, turn);
       if (decision.kind === "tools") {
         stats.turnsServed = Math.max(stats.turnsServed, turn);

--- a/bench/results/2026-07-04T23-03-01-154Z-84875ff-durable-subprocess.json
+++ b/bench/results/2026-07-04T23-03-01-154Z-84875ff-durable-subprocess.json
@@ -1,0 +1,708 @@
+{
+  "meta": {
+    "ts": "2026-07-04T23:03:01.154Z",
+    "sha": "84875ff",
+    "label": "durable-subprocess",
+    "node": "v20.20.0",
+    "hostname": "aHp0",
+    "target": "local",
+    "mode": "local",
+    "executionMode": "subprocess"
+  },
+  "scenarios": [
+    {
+      "name": "smoke",
+      "description": "1 assistant turn, no tools — pure spawn + single LLM round-trip",
+      "params": {
+        "turns": 0,
+        "toolsPerTurn": 0,
+        "latencyMs": 50,
+        "finalBytes": 200
+      },
+      "sid": "smr6ywcnyzqr71x",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 538,
+        "spawn_ms": 22,
+        "llm_ms": 50,
+        "overhead_ms": 488,
+        "loop_ms": 0,
+        "loop_overhead_ms": 0,
+        "turns": 1,
+        "llm_requests": 1,
+        "tool_calls": 0,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 19,
+        "execution_mode": "subprocess"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 22
+        },
+        {
+          "status": "done",
+          "tMs": 538
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 1, mock served 1"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 0, mock emitted 0"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=subprocess, pid=480388 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 545
+    },
+    {
+      "name": "tool_loop_50",
+      "description": "50 tool turns x 1 bash — sequential loop throughput",
+      "params": {
+        "turns": 50,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr6ywd33aq5wao",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 3786,
+        "spawn_ms": 10,
+        "llm_ms": 2550,
+        "overhead_ms": 1236,
+        "loop_ms": 3268,
+        "loop_overhead_ms": 718,
+        "turns": 51,
+        "llm_requests": 51,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 8,
+        "execution_mode": "subprocess"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 10
+        },
+        {
+          "status": "done",
+          "tMs": 3786
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 51, mock served 51"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=subprocess, pid=480404 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 3788
+    },
+    {
+      "name": "tool_burst",
+      "description": "10 tool turns x 5 bash/turn — parallel tool dispatch within a turn",
+      "params": {
+        "turns": 10,
+        "toolsPerTurn": 5,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr6ywg0byxgcgq",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 1345,
+        "spawn_ms": 18,
+        "llm_ms": 550,
+        "overhead_ms": 795,
+        "loop_ms": 892,
+        "loop_overhead_ms": 342,
+        "turns": 11,
+        "llm_requests": 11,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 17,
+        "execution_mode": "subprocess"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 18
+        },
+        {
+          "status": "done",
+          "tMs": 1345
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 11, mock served 11"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=subprocess, pid=480646 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 1346
+    },
+    {
+      "name": "big_output",
+      "description": "30 tool turns x 1 bash with 64KB output — context growth / compaction stress",
+      "params": {
+        "turns": 30,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 65536,
+        "finalBytes": 500
+      },
+      "sid": "smr6ywh1p728nsi",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 2658,
+        "spawn_ms": 8,
+        "llm_ms": 1550,
+        "overhead_ms": 1108,
+        "loop_ms": 2160,
+        "loop_overhead_ms": 610,
+        "turns": 31,
+        "llm_requests": 31,
+        "tool_calls": 30,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 7,
+        "execution_mode": "subprocess"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 8
+        },
+        {
+          "status": "done",
+          "tMs": 2658
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 31, mock served 31"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 30, mock emitted 30"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=subprocess, pid=480822 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 2660
+    },
+    {
+      "name": "max_turns_cap",
+      "description": "cap=never on agent with maxTurns=15 — runtime must stop the loop at the ceiling",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "cap": "never"
+      },
+      "sid": "smr6ywj3lejtacx",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 1440,
+        "spawn_ms": 11,
+        "llm_ms": 750,
+        "overhead_ms": 690,
+        "loop_ms": 939,
+        "loop_overhead_ms": 189,
+        "turns": 15,
+        "llm_requests": 15,
+        "tool_calls": 15,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 9,
+        "execution_mode": "subprocess"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 11
+        },
+        {
+          "status": "done",
+          "tMs": 1440
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done, failed], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 15, mock served 15"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 15, mock emitted 15"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=subprocess, pid=480966 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 1442
+    },
+    {
+      "name": "outcomes_3",
+      "description": "5 tool turns + 3 register_outcome on the last turn — outcome pipeline",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "outcomes": 3
+      },
+      "sid": "smr6ywk7nummrnl",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 826,
+        "spawn_ms": 9,
+        "llm_ms": 300,
+        "overhead_ms": 526,
+        "loop_ms": 373,
+        "loop_overhead_ms": 73,
+        "turns": 6,
+        "llm_requests": 6,
+        "tool_calls": 5,
+        "outcome_calls": 3,
+        "summarize_calls": 0,
+        "post_ms": 8,
+        "execution_mode": "subprocess"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 9
+        },
+        {
+          "status": "done",
+          "tMs": 826
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 6, mock served 6"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 5, mock emitted 5"
+        },
+        {
+          "name": "outcomes",
+          "pass": true,
+          "detail": "expected 3, task record has 3"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=subprocess, pid=481064 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 827
+    },
+    {
+      "name": "timeout_kill",
+      "description": "cap=never + task maxDuration=8s — watchdog must kill and fail the task",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 300,
+        "cap": "never"
+      },
+      "sid": "smr6ywkumw0d8kp",
+      "pass": true,
+      "terminal": "failed",
+      "metrics": {
+        "wall_ms": 10089,
+        "spawn_ms": 13,
+        "llm_ms": 9000,
+        "overhead_ms": 1089,
+        "loop_ms": 9447,
+        "loop_overhead_ms": 447,
+        "turns": 30,
+        "llm_requests": 31,
+        "tool_calls": 30,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 12,
+        "execution_mode": "subprocess"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 13
+        },
+        {
+          "status": "failed",
+          "tMs": 10089
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "failed"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [failed], got \"failed\""
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=subprocess, pid=481098 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 10091
+    },
+    {
+      "name": "concurrency_10",
+      "description": "10 concurrent tasks x 5 tool turns — scheduler fan-out + makespan",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "concurrency": 10,
+      "pass": true,
+      "terminal": [
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done"
+      ],
+      "metrics": {
+        "makespan_ms": 2524,
+        "wall_ms_min": 2119,
+        "wall_ms_median": 2321,
+        "wall_ms_max": 2524,
+        "llm_ms_total": 3000,
+        "spawn_ms_min": 173,
+        "spawn_ms_max": 175
+      },
+      "checks": [
+        {
+          "name": "all_tasks_pass",
+          "pass": true,
+          "detail": "10/10 tasks green"
+        }
+      ],
+      "tasks": [
+        {
+          "sid": "smr6ywsmxxeos9v",
+          "wall_ms": 2322,
+          "spawn_ms": 175,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmxqvygmt",
+          "wall_ms": 2120,
+          "spawn_ms": 175,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmy5g128d",
+          "wall_ms": 2321,
+          "spawn_ms": 174,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmy4qze2o",
+          "wall_ms": 2321,
+          "spawn_ms": 174,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmysqjzea",
+          "wall_ms": 2321,
+          "spawn_ms": 174,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmy7s6rxh",
+          "wall_ms": 2321,
+          "spawn_ms": 174,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmyn8jd9j",
+          "wall_ms": 2524,
+          "spawn_ms": 174,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmy1gv4e4",
+          "wall_ms": 2119,
+          "spawn_ms": 174,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmz93zl7t",
+          "wall_ms": 2320,
+          "spawn_ms": 173,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        },
+        {
+          "sid": "smr6ywsmzin8xqr",
+          "wall_ms": 2320,
+          "spawn_ms": 173,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "subprocess"
+        }
+      ],
+      "elapsed_ms": 2738
+    },
+    {
+      "name": "crash_resume",
+      "description": "8 tool turns; SIGKILL server+runner after the turn-4 checkpoint; restart → startup recovery must RESUME from the checkpoint (turns ≤4 never re-executed) and finish with a result identical to a no-crash control run",
+      "params": {
+        "turns": 8,
+        "toolsPerTurn": 1,
+        "latencyMs": 400,
+        "toolOutputBytes": 256,
+        "finalBytes": 300
+      },
+      "killAfterTurn": 4,
+      "executionMode": "subprocess",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "control_wall_ms": 4216,
+        "kill_at_turn": 5,
+        "downtime_ms": 1326,
+        "wall_ms": 5883,
+        "resumed_from_turn": 6,
+        "turns_saved": 5,
+        "duplicated_turns": 1,
+        "llm_ms": 4000,
+        "turns": 9,
+        "llm_requests": 10,
+        "requests_pre_crash": 6,
+        "requests_post_crash": 4,
+        "tool_calls": 9
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 3832
+        },
+        {
+          "status": "done",
+          "tMs": 5883
+        }
+      ],
+      "checks": [
+        {
+          "name": "control_terminal",
+          "pass": true,
+          "detail": "control run: done"
+        },
+        {
+          "name": "kill_window",
+          "pass": true,
+          "detail": "killed at mock turn 5 (threshold 5)"
+        },
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "resume_no_reexecution",
+          "pass": true,
+          "detail": "turns 1..4 requested exactly once — resumed from turn 6 (5 turns saved)"
+        },
+        {
+          "name": "resume_duplicates_bounded",
+          "pass": true,
+          "detail": "duplicated turns: 6(x2) (allowed: ≤2 turns, ≤2 requests each)"
+        },
+        {
+          "name": "history_seeded",
+          "pass": true,
+          "detail": "max bench call-id turn seen in an incoming request: 8 (need ≥ 4)"
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 9 (=8 tool turns + final), mock served 9"
+        },
+        {
+          "name": "finals",
+          "pass": true,
+          "detail": "expected exactly 1 final response, got 1"
+        },
+        {
+          "name": "final_result_identical",
+          "pass": true,
+          "detail": "result text identical to control (300 bytes)"
+        },
+        {
+          "name": "execution_mode_pre_crash",
+          "pass": true,
+          "detail": "pre-crash run: executionMode=subprocess, pid=481856 (expected subprocess)"
+        },
+        {
+          "name": "execution_mode_post_resume",
+          "pass": true,
+          "detail": "post-resume run: executionMode=subprocess, pid=481928 (expected subprocess)"
+        }
+      ],
+      "elapsed_ms": 11124
+    }
+  ]
+}

--- a/bench/results/2026-07-04T23-03-42-991Z-84875ff-durable-inprocess.json
+++ b/bench/results/2026-07-04T23-03-42-991Z-84875ff-durable-inprocess.json
@@ -1,0 +1,708 @@
+{
+  "meta": {
+    "ts": "2026-07-04T23:03:42.991Z",
+    "sha": "84875ff",
+    "label": "durable-inprocess",
+    "node": "v20.20.0",
+    "hostname": "aHp0",
+    "target": "local",
+    "mode": "local",
+    "executionMode": "in-process"
+  },
+  "scenarios": [
+    {
+      "name": "smoke",
+      "description": "1 assistant turn, no tools — pure spawn + single LLM round-trip",
+      "params": {
+        "turns": 0,
+        "toolsPerTurn": 0,
+        "latencyMs": 50,
+        "finalBytes": 200
+      },
+      "sid": "smr6yxboq4idn0k",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 155,
+        "spawn_ms": 30,
+        "llm_ms": 50,
+        "overhead_ms": 105,
+        "loop_ms": 0,
+        "loop_overhead_ms": 0,
+        "turns": 1,
+        "llm_requests": 1,
+        "tool_calls": 0,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 26,
+        "execution_mode": "in-process"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 30
+        },
+        {
+          "status": "done",
+          "tMs": 155
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 1, mock served 1"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 0, mock emitted 0"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=in-process, pid=-1 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 158
+    },
+    {
+      "name": "tool_loop_50",
+      "description": "50 tool turns x 1 bash — sequential loop throughput",
+      "params": {
+        "turns": 50,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr6yxbt4lqboce",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 3520,
+        "spawn_ms": 7,
+        "llm_ms": 2550,
+        "overhead_ms": 970,
+        "loop_ms": 3439,
+        "loop_overhead_ms": 889,
+        "turns": 51,
+        "llm_requests": 51,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 5,
+        "execution_mode": "in-process"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 7
+        },
+        {
+          "status": "done",
+          "tMs": 3520
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 51, mock served 51"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=in-process, pid=-2 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 3522
+    },
+    {
+      "name": "tool_burst",
+      "description": "10 tool turns x 5 bash/turn — parallel tool dispatch within a turn",
+      "params": {
+        "turns": 10,
+        "toolsPerTurn": 5,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "sid": "smr6yxeiyhv99k4",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 1226,
+        "spawn_ms": 6,
+        "llm_ms": 550,
+        "overhead_ms": 676,
+        "loop_ms": 1110,
+        "loop_overhead_ms": 560,
+        "turns": 11,
+        "llm_requests": 11,
+        "tool_calls": 50,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 5,
+        "execution_mode": "in-process"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 6
+        },
+        {
+          "status": "done",
+          "tMs": 1226
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 11, mock served 11"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 50, mock emitted 50"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=in-process, pid=-3 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 1229
+    },
+    {
+      "name": "big_output",
+      "description": "30 tool turns x 1 bash with 64KB output — context growth / compaction stress",
+      "params": {
+        "turns": 30,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 65536,
+        "finalBytes": 500
+      },
+      "sid": "smr6yxfh3s01k98",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 2411,
+        "spawn_ms": 7,
+        "llm_ms": 1550,
+        "overhead_ms": 861,
+        "loop_ms": 2262,
+        "loop_overhead_ms": 712,
+        "turns": 31,
+        "llm_requests": 31,
+        "tool_calls": 30,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 6,
+        "execution_mode": "in-process"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 7
+        },
+        {
+          "status": "done",
+          "tMs": 2411
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 31, mock served 31"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 30, mock emitted 30"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=in-process, pid=-4 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 2412
+    },
+    {
+      "name": "max_turns_cap",
+      "description": "cap=never on agent with maxTurns=15 — runtime must stop the loop at the ceiling",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "cap": "never"
+      },
+      "sid": "smr6yxhc3watqhz",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 1043,
+        "spawn_ms": 9,
+        "llm_ms": 750,
+        "overhead_ms": 293,
+        "loop_ms": 924,
+        "loop_overhead_ms": 174,
+        "turns": 15,
+        "llm_requests": 15,
+        "tool_calls": 15,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 7,
+        "execution_mode": "in-process"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 9
+        },
+        {
+          "status": "done",
+          "tMs": 1043
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done, failed], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 15, mock served 15"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 15, mock emitted 15"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=in-process, pid=-5 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 1044
+    },
+    {
+      "name": "outcomes_3",
+      "description": "5 tool turns + 3 register_outcome on the last turn — outcome pipeline",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "outcomes": 3
+      },
+      "sid": "smr6yxi53g6aill",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "wall_ms": 425,
+        "spawn_ms": 5,
+        "llm_ms": 300,
+        "overhead_ms": 125,
+        "loop_ms": 352,
+        "loop_overhead_ms": 52,
+        "turns": 6,
+        "llm_requests": 6,
+        "tool_calls": 5,
+        "outcome_calls": 3,
+        "summarize_calls": 0,
+        "post_ms": 4,
+        "execution_mode": "in-process"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 5
+        },
+        {
+          "status": "done",
+          "tMs": 425
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 6, mock served 6"
+        },
+        {
+          "name": "tool_calls",
+          "pass": true,
+          "detail": "expected 5, mock emitted 5"
+        },
+        {
+          "name": "outcomes",
+          "pass": true,
+          "detail": "expected 3, task record has 3"
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=in-process, pid=-6 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 428
+    },
+    {
+      "name": "timeout_kill",
+      "description": "cap=never + task maxDuration=8s — watchdog must kill and fail the task",
+      "params": {
+        "turns": 9999,
+        "toolsPerTurn": 1,
+        "latencyMs": 300,
+        "cap": "never"
+      },
+      "sid": "smr6yxigz6ac2h5",
+      "pass": true,
+      "terminal": "failed",
+      "metrics": {
+        "wall_ms": 10051,
+        "spawn_ms": 6,
+        "llm_ms": 9300,
+        "overhead_ms": 751,
+        "loop_ms": 9891,
+        "loop_overhead_ms": 591,
+        "turns": 31,
+        "llm_requests": 32,
+        "tool_calls": 31,
+        "outcome_calls": 0,
+        "summarize_calls": 0,
+        "post_ms": 5,
+        "execution_mode": "in-process"
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 6
+        },
+        {
+          "status": "failed",
+          "tMs": 10051
+        }
+      ],
+      "checks": [
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "failed"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [failed], got \"failed\""
+        },
+        {
+          "name": "execution_mode",
+          "pass": true,
+          "detail": "run record: executionMode=in-process, pid=-7 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 10053
+    },
+    {
+      "name": "concurrency_10",
+      "description": "10 concurrent tasks x 5 tool turns — scheduler fan-out + makespan",
+      "params": {
+        "turns": 5,
+        "toolsPerTurn": 1,
+        "latencyMs": 50,
+        "toolOutputBytes": 256
+      },
+      "concurrency": 10,
+      "pass": true,
+      "terminal": [
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done",
+        "done"
+      ],
+      "metrics": {
+        "makespan_ms": 1230,
+        "wall_ms_min": 1229,
+        "wall_ms_median": 1230,
+        "wall_ms_max": 1230,
+        "llm_ms_total": 3000,
+        "spawn_ms_min": 167,
+        "spawn_ms_max": 168
+      },
+      "checks": [
+        {
+          "name": "all_tasks_pass",
+          "pass": true,
+          "detail": "10/10 tasks green"
+        }
+      ],
+      "tasks": [
+        {
+          "sid": "smr6yxq881cgtrq",
+          "wall_ms": 1230,
+          "spawn_ms": 168,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq89y1kpdc",
+          "wall_ms": 1230,
+          "spawn_ms": 168,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq89e828f3",
+          "wall_ms": 1230,
+          "spawn_ms": 168,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq89mm7ztc",
+          "wall_ms": 1230,
+          "spawn_ms": 168,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq89rhbtxn",
+          "wall_ms": 1230,
+          "spawn_ms": 168,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq8a4k5wte",
+          "wall_ms": 1229,
+          "spawn_ms": 167,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq8af7xb12",
+          "wall_ms": 1229,
+          "spawn_ms": 167,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq8az5v3ah",
+          "wall_ms": 1229,
+          "spawn_ms": 167,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq8aqiq1za",
+          "wall_ms": 1229,
+          "spawn_ms": 167,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        },
+        {
+          "sid": "smr6yxq8ay3v8y7",
+          "wall_ms": 1229,
+          "spawn_ms": 167,
+          "terminal": "done",
+          "llm_ms": 300,
+          "turns": 6,
+          "execution_mode": "in-process"
+        }
+      ],
+      "elapsed_ms": 1452
+    },
+    {
+      "name": "crash_resume",
+      "description": "8 tool turns; SIGKILL server+runner after the turn-4 checkpoint; restart → startup recovery must RESUME from the checkpoint (turns ≤4 never re-executed) and finish with a result identical to a no-crash control run",
+      "params": {
+        "turns": 8,
+        "toolsPerTurn": 1,
+        "latencyMs": 400,
+        "toolOutputBytes": 256,
+        "finalBytes": 300
+      },
+      "killAfterTurn": 4,
+      "executionMode": "in-process",
+      "pass": true,
+      "terminal": "done",
+      "metrics": {
+        "control_wall_ms": 3886,
+        "kill_at_turn": 5,
+        "downtime_ms": 1575,
+        "wall_ms": 5541,
+        "resumed_from_turn": 5,
+        "turns_saved": 4,
+        "duplicated_turns": 1,
+        "llm_ms": 4000,
+        "turns": 9,
+        "llm_requests": 10,
+        "requests_pre_crash": 5,
+        "requests_post_crash": 5,
+        "tool_calls": 9
+      },
+      "timeline": [
+        {
+          "status": "in_progress",
+          "tMs": 3672
+        },
+        {
+          "status": "done",
+          "tMs": 5541
+        }
+      ],
+      "checks": [
+        {
+          "name": "control_terminal",
+          "pass": true,
+          "detail": "control run: done"
+        },
+        {
+          "name": "kill_window",
+          "pass": true,
+          "detail": "killed at mock turn 5 (threshold 5)"
+        },
+        {
+          "name": "terminal_reached",
+          "pass": true,
+          "detail": "done"
+        },
+        {
+          "name": "terminal_status",
+          "pass": true,
+          "detail": "expected one of [done], got \"done\""
+        },
+        {
+          "name": "resume_no_reexecution",
+          "pass": true,
+          "detail": "turns 1..4 requested exactly once — resumed from turn 5 (4 turns saved)"
+        },
+        {
+          "name": "resume_duplicates_bounded",
+          "pass": true,
+          "detail": "duplicated turns: 5(x2) (allowed: ≤2 turns, ≤2 requests each)"
+        },
+        {
+          "name": "history_seeded",
+          "pass": true,
+          "detail": "max bench call-id turn seen in an incoming request: 8 (need ≥ 4)"
+        },
+        {
+          "name": "turns_served",
+          "pass": true,
+          "detail": "expected 9 (=8 tool turns + final), mock served 9"
+        },
+        {
+          "name": "finals",
+          "pass": true,
+          "detail": "expected exactly 1 final response, got 1"
+        },
+        {
+          "name": "final_result_identical",
+          "pass": true,
+          "detail": "result text identical to control (300 bytes)"
+        },
+        {
+          "name": "execution_mode_pre_crash",
+          "pass": true,
+          "detail": "pre-crash run: executionMode=in-process, pid=-2 (expected in-process)"
+        },
+        {
+          "name": "execution_mode_post_resume",
+          "pass": true,
+          "detail": "post-resume run: executionMode=in-process, pid=-1 (expected in-process)"
+        }
+      ],
+      "elapsed_ms": 10711
+    }
+  ]
+}

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -6,6 +6,7 @@
  *   node bench/run.mjs [--label <label>] [--only <names,csv>]
  *                      [--mock-port 8377] [--port 8378]
  *                      [--target <url>] [--mock-url <url>]
+ *                      [--execution-mode subprocess|in-process]
  *                      [--keep]
  *
  * Local mode (default, no --target):
@@ -21,6 +22,17 @@
  *   http://127.0.0.1:8377). This is how the same suite runs against a sandbox
  *   or a different runtime branch.
  *
+ * Execution mode (--execution-mode, adaptive isolation — Phase C):
+ *   Runs the SAME scenarios under a chosen task-execution backend so every
+ *   release measures BOTH. Local mode writes `settings.taskExecution` into
+ *   the throwaway project (settings tier); target mode sends the per-task
+ *   `executionMode` field on POST /tasks (task tier — remote settings can't
+ *   be rewritten). Either way the RESOLVED mode is verified against the live
+ *   run record (GET /tasks/:id/activity → run.executionMode + pid sign:
+ *   negative = in-process synthetic pid) — an invariant, not just a label.
+ *   Without the flag nothing is sent or asserted (older runtimes stay
+ *   benchmarkable); the observed mode is still reported when available.
+ *
  * Only talks to public contracts: the task REST API + the mock's /bench/stats.
  */
 
@@ -34,6 +46,8 @@ import { createMockLlm } from "./mock-llm.mjs";
 import { scenarios as allScenarios, selectScenarios } from "./scenarios.mjs";
 import { buildDirective, genSid } from "./lib/directive.mjs";
 import { PolpoClient, MockClient } from "./lib/client.mjs";
+import { writeProject } from "./lib/project.mjs";
+import { runCrashResume } from "./lib/crash-resume.mjs";
 
 const BENCH_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(BENCH_DIR, "..");
@@ -41,7 +55,7 @@ const REPO_ROOT = resolve(BENCH_DIR, "..");
 // ─── Args ─────────────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { label: "run", mockPort: 8377, port: 8378, target: null, mockUrl: null, only: null, keep: false };
+  const args = { label: "run", mockPort: 8377, port: 8378, target: null, mockUrl: null, only: null, keep: false, executionMode: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--label") args.label = argv[++i];
@@ -51,61 +65,20 @@ function parseArgs(argv) {
     else if (a === "--mock-url") args.mockUrl = argv[++i];
     else if (a === "--only") args.only = argv[++i];
     else if (a === "--keep") args.keep = true;
-    else if (a === "--help" || a === "-h") {
-      console.log("Usage: node bench/run.mjs [--label <label>] [--target <url>] [--mock-port 8377] [--port 8378] [--only <names,csv>] [--keep]");
+    else if (a === "--execution-mode") {
+      args.executionMode = argv[++i];
+      if (!["subprocess", "in-process"].includes(args.executionMode)) {
+        console.error(`--execution-mode must be "subprocess" or "in-process", got "${args.executionMode}"`);
+        process.exit(1);
+      }
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: node bench/run.mjs [--label <label>] [--target <url>] [--mock-port 8377] [--port 8378] [--only <names,csv>] [--execution-mode subprocess|in-process] [--keep]",
+      );
       process.exit(0);
     }
   }
   return args;
-}
-
-// ─── Local environment setup ──────────────────────────────────────────────────
-
-function writeProject(dir, mockPort) {
-  const polpoDir = join(dir, ".polpo");
-  mkdirSync(polpoDir, { recursive: true });
-  writeFileSync(
-    join(polpoDir, "polpo.json"),
-    JSON.stringify(
-      {
-        project: "polpo-bench",
-        settings: {
-          storage: "file",
-          maxRetries: 0, // failures must be terminal — no silent retries mid-benchmark
-          workDir: ".",
-          logLevel: "quiet",
-        },
-        // NOTE: the provider is named "openai" (with a baseUrl override) instead
-        // of a dedicated "bench" provider because the runtime's pre-spawn
-        // validation (validateProviderKeys) only accepts providers present in
-        // the static PROVIDER_ENV_MAP — unknown custom providers can never
-        // spawn task agents. See bench/README.md, "Runtime findings".
-        providers: {
-          openai: { baseUrl: `http://127.0.0.1:${mockPort}/v1` },
-        },
-      },
-      null,
-      2,
-    ),
-  );
-  // FileAgentStore format: [{ agent: AgentConfig, teamName }]
-  writeFileSync(
-    join(polpoDir, "agents.json"),
-    JSON.stringify(
-      [
-        {
-          agent: { name: "bench-agent", role: "developer", model: "openai/mock-1", maxTurns: 250 },
-          teamName: "bench",
-        },
-        {
-          agent: { name: "bench-capped", role: "developer", model: "openai/mock-1", maxTurns: 15 },
-          teamName: "bench",
-        },
-      ],
-      null,
-      2,
-    ),
-  );
 }
 
 /**
@@ -164,21 +137,36 @@ function checkInvariants(scenario, outcome) {
   if (inv.maxWallMs !== undefined) {
     push("max_wall", outcome.wallMs <= inv.maxWallMs, `wall ${outcome.wallMs}ms vs max ${inv.maxWallMs}ms`);
   }
+  // Adaptive isolation: the RESOLVED mode on the live run record must match
+  // the requested one — pid sign is the independent corroboration (negative
+  // = in-process synthetic pid, positive = OS subprocess).
+  if (inv.executionMode !== undefined) {
+    const run = outcome.run;
+    const pidOk = run ? (inv.executionMode === "in-process" ? run.pid < 0 : run.pid > 0) : false;
+    push(
+      "execution_mode",
+      run?.executionMode === inv.executionMode && pidOk,
+      run
+        ? `run record: executionMode=${run.executionMode}, pid=${run.pid} (expected ${inv.executionMode})`
+        : "live run record never observed (cannot verify execution mode)",
+    );
+  }
   return checks;
 }
 
-async function runSingleTask(polpo, mock, scenario, sid, pollIntervalMs) {
-  const created = await createScenarioTask(polpo, scenario, sid);
+async function runSingleTask(polpo, mock, scenario, sid, pollIntervalMs, runOpts) {
+  const created = await createScenarioTask(polpo, scenario, sid, 0, runOpts);
   const polled = await polpo.pollTask(created.taskId, created.createdAtMs, {
     timeoutMs: scenario.timeoutMs,
     intervalMs: pollIntervalMs,
+    captureRun: true,
   });
   if (polled.timedOut) await polpo.killTask(created.taskId);
   const mockStats = await mock.stats(sid);
   return { ...created, mockStats, ...polled };
 }
 
-async function createScenarioTask(polpo, scenario, sid, taskIndex = 0) {
+async function createScenarioTask(polpo, scenario, sid, taskIndex = 0, runOpts = {}) {
   const directive = buildDirective(sid, scenario.directive);
   const description =
     `${directive}\n\n` +
@@ -190,21 +178,23 @@ async function createScenarioTask(polpo, scenario, sid, taskIndex = 0) {
     description,
     assignTo: scenario.agent,
     expectations: [],
+    // Target mode: per-task executionMode override (task > agent > settings).
+    ...(runOpts.taskExecutionMode ? { executionMode: runOpts.taskExecutionMode } : {}),
     ...(scenario.taskOpts ?? {}),
   });
   return { sid, taskId: task.id, createdAtMs, postMs: Date.now() - createdAtMs };
 }
 
-async function runScenario(polpo, mock, scenario, pollIntervalMs) {
+async function runScenario(polpo, mock, scenario, pollIntervalMs, runOpts = {}) {
   const startedAt = Date.now();
 
   if (scenario.concurrency && scenario.concurrency > 1) {
     // Fire all creations together, then poll them all with ONE shared
     // GET /tasks loop (rate-limit friendly, identical precision).
     const created = await Promise.all(
-      Array.from({ length: scenario.concurrency }, (_, i) => createScenarioTask(polpo, scenario, genSid(), i)),
+      Array.from({ length: scenario.concurrency }, (_, i) => createScenarioTask(polpo, scenario, genSid(), i, runOpts)),
     );
-    const polled = await polpo.pollMany(created, { timeoutMs: scenario.timeoutMs, intervalMs: pollIntervalMs * 2 });
+    const polled = await polpo.pollMany(created, { timeoutMs: scenario.timeoutMs, intervalMs: pollIntervalMs * 2, captureRun: true });
     const runs = [];
     for (let i = 0; i < created.length; i++) {
       const c = created[i];
@@ -246,12 +236,13 @@ async function runScenario(polpo, mock, scenario, pollIntervalMs) {
         terminal: r.task?.status,
         llm_ms: r.mockStats?.stats?.llmBusyMs ?? null,
         turns: r.mockStats?.stats?.turnsServed ?? null,
+        execution_mode: r.run?.executionMode ?? null,
       })),
       elapsed_ms: Date.now() - startedAt,
     };
   }
 
-  const run = await runSingleTask(polpo, mock, scenario, genSid(), pollIntervalMs);
+  const run = await runSingleTask(polpo, mock, scenario, genSid(), pollIntervalMs, runOpts);
   const checks = checkInvariants(scenario, run);
   const stats = run.mockStats?.stats;
   const llmMs = stats?.llmBusyMs ?? null;
@@ -284,6 +275,7 @@ async function runScenario(polpo, mock, scenario, pollIntervalMs) {
       outcome_calls: stats?.outcomeCallsEmitted ?? null,
       summarize_calls: stats?.summarizeCalls ?? null,
       post_ms: run.postMs,
+      execution_mode: run.run?.executionMode ?? null,
     },
     timeline: run.timeline,
     checks,
@@ -336,7 +328,24 @@ function printTable(results) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const selected = selectScenarios(args.only);
+  let selected = selectScenarios(args.only);
+
+  // crash_resume drives its own server lifecycle (SIGKILL + restart) — it
+  // cannot run against a --target server the harness doesn't own.
+  if (args.target && selected.some((s) => s.special === "crash_resume")) {
+    if (args.only && args.only.split(",").map((s) => s.trim()).includes("crash_resume")) {
+      console.error("[bench] crash_resume requires local mode (it SIGKILLs and restarts its own server) — remove --target or drop it from --only");
+      process.exit(1);
+    }
+    console.log("[bench] crash_resume skipped in target mode (needs local server lifecycle control)");
+    selected = selected.filter((s) => s.special !== "crash_resume");
+  }
+
+  // Adaptive isolation: when a mode is requested, verifying it on the live
+  // run record becomes an invariant of EVERY scenario, not a label.
+  if (args.executionMode) {
+    selected = selected.map((s) => ({ ...s, invariants: { ...s.invariants, executionMode: args.executionMode } }));
+  }
 
   let mockHandle = null;
   let polpoServer = null;
@@ -367,7 +376,9 @@ async function main() {
         throw new Error(`dist not built: ${serverEntry} missing. Run pnpm build first.`);
       }
       projectDir = mkdtempSync(join(tmpdir(), "polpo-bench-"));
-      writeProject(projectDir, args.mockPort);
+      // Local mode carries the requested execution mode through the settings
+      // tier (settings.taskExecution) — the same scenarios, different backend.
+      writeProject(projectDir, args.mockPort, { executionMode: args.executionMode });
       injectRunnerEnv(args.mockPort);
 
       mockHandle = createMockLlm({ port: args.mockPort, quiet: true });
@@ -397,11 +408,28 @@ async function main() {
     const prefix = await polpo.probe();
     console.log(`[bench] api:     ${targetUrl}${prefix}`);
 
+    // Target mode: settings can't be rewritten remotely — request the mode
+    // per task instead (task tier of the same resolver). Local mode already
+    // carries it via settings; sending it per task too would only re-test
+    // precedence, which is unit-tested in the runtime.
+    const runOpts = { taskExecutionMode: args.target ? args.executionMode : null };
+
     const results = [];
     for (const scenario of selected) {
       process.stdout.write(`[bench] ${scenario.name} ... `);
       try {
-        const result = await runScenario(polpo, mock, scenario, pollIntervalMs);
+        const result =
+          scenario.special === "crash_resume"
+            ? await runCrashResume(scenario, {
+                serverEntry: join(REPO_ROOT, "dist", "server", "index.js"),
+                mock,
+                mockPort: args.mockPort,
+                port: args.port + 1, // own child-hosted server, own port
+                executionMode: args.executionMode,
+                enforceExecutionMode: !!args.executionMode,
+                keep: args.keep,
+              })
+            : await runScenario(polpo, mock, scenario, pollIntervalMs, runOpts);
         results.push(result);
         console.log(`${result.pass ? "PASS" : "FAIL"} (${Math.round(result.elapsed_ms / 1000)}s)`);
       } catch (err) {
@@ -428,6 +456,9 @@ async function main() {
       hostname: hostname(),
       target: args.target ?? "local",
       mode: args.target ? "target" : "local",
+      // Task-execution backend requested for this run (null = runtime default,
+      // i.e. subprocess, with no invariant enforced).
+      executionMode: args.executionMode,
     };
     const resultsDir = join(BENCH_DIR, "results");
     mkdirSync(resultsDir, { recursive: true });

--- a/bench/scenarios.mjs
+++ b/bench/scenarios.mjs
@@ -94,6 +94,26 @@ export const scenarios = [
     timeoutMs: 300_000,
     invariants: { terminal: ["done"], turnsServed: 6, toolCalls: 5 },
   },
+  {
+    name: "crash_resume",
+    description:
+      "8 tool turns; SIGKILL server+runner after the turn-4 checkpoint; restart → startup recovery must RESUME from the checkpoint (turns ≤4 never re-executed) and finish with a result identical to a no-crash control run",
+    agent: "bench-agent",
+    // Driven by lib/crash-resume.mjs, NOT the generic single-task runner: it
+    // needs its own child-hosted server it can SIGKILL and restart (recovery
+    // is a startup-only path; graceful stop deletes the checkpoint). Local
+    // mode only — a --target server's lifecycle can't be controlled.
+    special: "crash_resume",
+    // 400ms think-time per turn ⇒ a ~3.5s loop: a wide, race-free window to
+    // observe the run record and land the kill between turn checkpoints.
+    directive: { turns: 8, toolsPerTurn: 1, latencyMs: 400, toolOutputBytes: 256, finalBytes: 300 },
+    // Kill fires once the mock has served turn killAfterTurn+1 — the engine
+    // awaits the turn-K checkpoint write before requesting turn K+1, so the
+    // checkpoint for this turn is guaranteed durable at kill time.
+    killAfterTurn: 4,
+    timeoutMs: 240_000,
+    invariants: { terminal: ["done"] },
+  },
 ];
 
 export function selectScenarios(only) {


### PR DESCRIPTION
Phase D closes the v2 execution chapter — the bench suite now covers durable execution and both execution modes:

- **crash_resume scenario**: server+runner SIGKILLed mid-task, restarted, recovery resumes from the turn-K checkpoint. Invariants asserted black-box: completed turns requested exactly once (retry-from-zero would fail instantly), final result byte-identical to a no-crash control, seeded history observed on the wire. Works in both modes.
- **--execution-mode subprocess|in-process** on the same 8 scenarios, with the resolved mode asserted on the live run record (not just a label).

First real numbers (committed per-sha): in-process removes ~380–400ms of fixed per-task cost — smoke −71%, concurrency_10 makespan −51%; honest counterpoint documented (+5–24% loop_ms on tool-heavy loops from event-loop contention). crash_resume: 5 turns saved, ~1.3s downtime, zero re-execution.

Finding #9 documented: resume exists only on the hard-crash path (graceful stop deletes run records; live stale-detection still retries from zero) — matches the known Phase A leftovers, now verified black-box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)