### PR TITLE
feat: durable pipeline checkpoints — resume mid-pipeline

### DIFF
--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig, AgentActivity, Task, TaskResult, TaskOutcome, ReasoningLevel } from "@polpo-ai/core/types";
+import type { AgentActivity, TaskResult, TaskOutcome, ReasoningLevel } from "@polpo-ai/core/types";
 import type { VaultStore } from "@polpo-ai/core/vault-store";
 import type { MemoryStore } from "@polpo-ai/core/memory-store";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
@@ -62,18 +62,22 @@ export interface SpawnContext {
   /** LLM gateway configuration — passed per-request for multi-tenant support. */
   gatewayConfig?: unknown;
   /**
-   * Durable-turns checkpoint from a previous interrupted run. The engine
-   * seeds its conversation history from it and continues at turn + 1 —
-   * tools that already ran are replayed from their recorded results in the
-   * history, never re-executed. Only single-session loops resume; pipeline
-   * (project-loop graph) task runs ignore it and start fresh.
+   * Durable-turns checkpoint from a previous interrupted run. Single-session
+   * loops seed their conversation history from it and continue at turn + 1;
+   * pipeline (project-loop graph) runs additionally restore the pipeline
+   * position — completed steps are never re-executed (their outputs replay
+   * from the recorded context bag), an in-flight agent step resumes at its
+   * saved turn. Tools that already ran are replayed from their recorded
+   * results, never re-executed.
    */
   resumeState?: LoopResumeState;
   /**
-   * Durable-turns checkpoint sink: called at most once per completed turn
-   * with the serialized post-compaction history. The runner wires it to
-   * RunStore.updateResumeState. Best-effort — implementations should not
-   * throw (the engine swallows errors anyway).
+   * Durable-turns checkpoint sink: called after every completed turn and —
+   * on pipeline runs — after every completed pipeline step, with ONE
+   * composed LoopResumeState (pipeline position + step-local session
+   * history). The runner wires it to RunStore.updateResumeState.
+   * Best-effort — implementations should not throw (the engine swallows
+   * errors anyway).
    */
   onTurnCheckpoint?: (state: LoopResumeState) => void | Promise<void>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -251,10 +251,12 @@ export { resolveLoopSelection, resolveActiveLoopTools, resolveActiveLoopSkills }
 export type { LoopSelection } from "./loop/selector.js";
 export { PipelineExecutor } from "./loop/pipeline.js";
 export type {
+  PipelineCheckpoint,
   PipelineExecutionResult,
   PipelineExecutorOptions,
   PipelineHumanResult,
   PipelineLoopResult,
+  PipelineStepPosition,
   PipelineToolResult,
   PipelineTraceEvent,
 } from "./loop/pipeline.js";

--- a/packages/core/src/loop/pipeline.test.ts
+++ b/packages/core/src/loop/pipeline.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { LoopHookRegistry } from "./hooks.js";
 import { normalizeProjectLoop } from "./normalize.js";
-import { PipelineExecutor } from "./pipeline.js";
+import { PipelineExecutor, type PipelineCheckpoint, type PipelineStepPosition } from "./pipeline.js";
 import {
   LoopApprovalRequiredError,
   LoopPermissionApprovalRequiredError,
   LoopPermissionDeniedError,
   LoopPolicyDeniedError,
 } from "./run-store.js";
-import type { ProjectLoopConfig } from "./types.js";
+import type { ProjectLoopConfig, Step } from "./types.js";
 
 describe("PipelineExecutor", () => {
   it("runs sequential loop steps and accumulates context by loop name", async () => {
@@ -602,5 +602,324 @@ describe("PipelineExecutor", () => {
       verify: { name: "verify" },
     });
     expect(resumed.events.map((event) => event.type)).toContain("loop.resume");
+  });
+});
+
+// ─── Durable pipeline checkpoints (Phase B) ──────────────────────────────
+//
+// The executor emits a PipelineCheckpoint after every completed step: the
+// composed remaining-steps list (same shape the human-gate resume format
+// already replays), the live context bag, and the last completed node.
+// Resume = re-execute with `pipeline.steps = checkpoint.steps` and
+// `context = checkpoint.context` — completed steps are never in the list,
+// their outputs replay from the bag (Temporal semantics).
+
+describe("PipelineExecutor — durable checkpoints", () => {
+  /** Checkpoints always cross a store boundary — pin JSON fidelity. */
+  function collectInto(checkpoints: PipelineCheckpoint[]) {
+    return async (checkpoint: PipelineCheckpoint) => {
+      checkpoints.push(JSON.parse(JSON.stringify(checkpoint)) as PipelineCheckpoint);
+    };
+  }
+
+  it("emits a checkpoint after every completed step: remaining steps, context, previousNode", async () => {
+    const executor = new PipelineExecutor();
+    const checkpoints: PipelineCheckpoint[] = [];
+
+    await executor.execute({
+      loops: { a: {}, b: {} },
+      pipeline: {
+        steps: [
+          { loop: "a" },
+          { tool: "probe", saveAs: "probe" },
+          { loop: "b" },
+        ],
+      },
+      onCheckpoint: collectInto(checkpoints),
+      runLoop: async (name) => ({ output: { ran: name } }),
+      runTool: async () => ({ output: { ok: true } }),
+    });
+
+    expect(checkpoints).toHaveLength(3);
+
+    // After "a": the tool and "b" are still pending, a's output is in the bag.
+    expect(checkpoints[0].steps).toEqual([
+      { tool: "probe", saveAs: "probe" },
+      { loop: "b" },
+    ]);
+    expect(checkpoints[0].previousNode).toBe("a");
+    expect(checkpoints[0].context).toMatchObject({ a: { ran: "a" } });
+
+    // After the tool step.
+    expect(checkpoints[1].steps).toEqual([{ loop: "b" }]);
+    expect(checkpoints[1].previousNode).toBe("probe");
+    expect(checkpoints[1].context).toMatchObject({ a: { ran: "a" }, probe: { ok: true } });
+
+    // After "b": nothing left to execute.
+    expect(checkpoints[2].steps).toEqual([]);
+    expect(checkpoints[2].previousNode).toBe("b");
+  });
+
+  it("resuming from a boundary checkpoint re-executes only the remaining steps", async () => {
+    const runs: string[] = [];
+    const runLoop = async (name: string) => {
+      runs.push(name);
+      return { output: { ran: name } };
+    };
+
+    const executor = new PipelineExecutor();
+    const checkpoints: PipelineCheckpoint[] = [];
+    await executor.execute({
+      loops: { a: {}, b: {}, c: {} },
+      pipeline: { steps: [{ loop: "a" }, { loop: "b" }, { loop: "c" }] },
+      onCheckpoint: collectInto(checkpoints),
+      runLoop,
+    });
+    expect(runs).toEqual(["a", "b", "c"]);
+
+    // "Crash" between b and c: replay the after-b checkpoint.
+    const afterB = checkpoints[1];
+    runs.length = 0;
+    const resumed = await executor.execute({
+      loops: { a: {}, b: {}, c: {} },
+      pipeline: { steps: afterB.steps },
+      context: afterB.context,
+      resume: { previousNode: afterB.previousNode },
+      onCheckpoint: collectInto(checkpoints),
+      runLoop,
+    });
+
+    expect(runs).toEqual(["c"]);
+    expect(resumed.context).toMatchObject({
+      a: { ran: "a" },
+      b: { ran: "b" },
+      c: { ran: "c" },
+    });
+    expect(resumed.events.map((event) => event.type)).toContain("loop.resume");
+  });
+
+  it("pins the switch choice at selection time: the chosen branch is inlined, the switch step is gone", async () => {
+    const executor = new PipelineExecutor();
+    const checkpoints: PipelineCheckpoint[] = [];
+
+    await executor.execute({
+      loops: { pre: {}, x1: {}, x2: {}, y: {}, post: {} },
+      context: { route: { x: true } },
+      pipeline: {
+        steps: [
+          { loop: "pre" },
+          {
+            switch: {
+              cases: [{ when: "route.x == true", steps: [{ loop: "x1" }, { loop: "x2" }] }],
+              default: { steps: [{ loop: "y" }] },
+            },
+          },
+          { loop: "post" },
+        ],
+      },
+      onCheckpoint: collectInto(checkpoints),
+      runLoop: async (name) => ({ output: { ran: name } }),
+    });
+
+    // The selection checkpoint records the choice as a historical fact:
+    // branch steps inlined ahead of the rest, no switch step to re-evaluate.
+    const selection = checkpoints.find((cp) => (cp.steps[0] as any)?.loop === "x1");
+    expect(selection).toBeDefined();
+    expect(selection!.steps).toEqual([{ loop: "x1" }, { loop: "x2" }, { loop: "post" }]);
+    expect(selection!.previousNode).toBe("pre");
+
+    // From the selection onward no checkpoint ever contains a switch step.
+    const fromSelection = checkpoints.slice(checkpoints.indexOf(selection!));
+    for (const cp of fromSelection) {
+      expect(cp.steps.some((step) => "switch" in step)).toBe(false);
+    }
+
+    // Mid-branch boundary: x2 then post remain.
+    expect(checkpoints.some((cp) => JSON.stringify(cp.steps) === JSON.stringify([{ loop: "x2" }, { loop: "post" }]))).toBe(true);
+  });
+
+  it("while: body checkpoints carry a continuation step with completedIterations", async () => {
+    const executor = new PipelineExecutor();
+    const checkpoints: PipelineCheckpoint[] = [];
+    let attempts = 0;
+
+    await executor.execute({
+      loops: { after: {} },
+      pipeline: {
+        steps: [
+          {
+            while: {
+              until: "build.passed == true",
+              maxIterations: 5,
+              steps: [{ tool: "build_check", saveAs: "build" }],
+            },
+          },
+          { loop: "after" },
+        ],
+      },
+      onCheckpoint: collectInto(checkpoints),
+      runLoop: async (name) => ({ output: { ran: name } }),
+      runTool: async () => {
+        attempts += 1;
+        return { output: { passed: attempts >= 2 } };
+      },
+    });
+
+    // The iteration-1 boundary points at a continuation that has already
+    // done 1 iteration — never back at iteration 0.
+    const iteration1 = checkpoints.find((cp) => (cp.steps[0] as any)?.while?.completedIterations === 1);
+    expect(iteration1).toBeDefined();
+    expect((iteration1!.steps[0] as any).while).toMatchObject({
+      until: "build.passed == true",
+      maxIterations: 5,
+      completedIterations: 1,
+    });
+    expect(iteration1!.steps[1]).toEqual({ loop: "after" });
+    expect(iteration1!.context).toMatchObject({ build: { passed: false } });
+
+    // Iteration-2 boundary exists too (the loop exited after it).
+    expect(checkpoints.some((cp) => (cp.steps[0] as any)?.while?.completedIterations === 2)).toBe(true);
+  });
+
+  it("while: resuming from a continuation restarts at the saved iteration, absolute maxIterations accounting", async () => {
+    const executor = new PipelineExecutor();
+    let attempts = 0;
+
+    // Resume from "2 iterations already done" with maxIterations 4:
+    // only iterations 3 and 4 may run before the guard trips.
+    const continuation: Step = {
+      while: {
+        until: "build.passed == true",
+        maxIterations: 4,
+        completedIterations: 2,
+        steps: [{ tool: "build_check", saveAs: "build" }],
+      },
+    };
+
+    const resumed = await executor.execute({
+      loops: {},
+      pipeline: { steps: [continuation] },
+      context: { build: { passed: false } },
+      resume: { previousNode: "build_check" },
+      runLoop: async () => ({ output: {} }),
+      runTool: async () => {
+        attempts += 1;
+        return { output: { passed: attempts >= 2 } };
+      },
+    });
+
+    // Two more iterations ran (3 and 4), not four.
+    expect(attempts).toBe(2);
+    expect(resumed.trace.filter((event) => event.type === "while" && event.matched).map((event) => event.iteration)).toEqual([3, 4]);
+
+    // Same continuation but the exit condition never satisfies: the
+    // absolute budget (4) trips after 2 more iterations, not after 4.
+    let failedAttempts = 0;
+    await expect(executor.execute({
+      loops: {},
+      pipeline: { steps: [JSON.parse(JSON.stringify(continuation)) as Step] },
+      context: { build: { passed: false } },
+      resume: { previousNode: "build_check" },
+      runLoop: async () => ({ output: {} }),
+      runTool: async () => {
+        failedAttempts += 1;
+        return { output: { passed: false } };
+      },
+    })).rejects.toThrow("maxIterations");
+    expect(failedAttempts).toBe(2);
+  });
+
+  it("parallel: no checkpoints inside the block — one boundary after the whole block (v1 cut)", async () => {
+    const executor = new PipelineExecutor();
+    const checkpoints: PipelineCheckpoint[] = [];
+    const positions: Array<PipelineStepPosition | undefined> = [];
+
+    await executor.execute({
+      loops: { pre: {}, p1: {}, p2: {}, post: {} },
+      pipeline: {
+        steps: [
+          { loop: "pre" },
+          { parallel: [[{ loop: "p1" }, { loop: "p2" }], [{ tool: "t", saveAs: "t" }]] },
+          { loop: "post" },
+        ],
+      },
+      onCheckpoint: collectInto(checkpoints),
+      runLoop: async (name, _loop, _context, position) => {
+        positions.push(position);
+        return { output: { ran: name } };
+      },
+      runTool: async () => ({ output: { ok: true } }),
+    });
+
+    // Exactly three checkpoints: after pre, after the parallel block, after
+    // post. Nothing from inside the branches — a crash mid-parallel resumes
+    // from BEFORE the block and re-executes every branch.
+    expect(checkpoints.map((cp) => cp.steps.length)).toEqual([2, 1, 0]);
+    expect(checkpoints[0].steps[0]).toHaveProperty("parallel");
+    expect(checkpoints[1].steps).toEqual([{ loop: "post" }]);
+    expect(checkpoints[1].previousNode).toBe("parallel");
+    expect(checkpoints[1].context).toMatchObject({
+      p1: { ran: "p1" },
+      p2: { ran: "p2" },
+      t: { ok: true },
+    });
+
+    // Agent steps inside parallel get NO position (turn-level checkpoint
+    // composition is suppressed there too); pre/post do.
+    const byIndex = Object.fromEntries(positions.map((p, i) => [i, p]));
+    expect(positions).toHaveLength(4); // pre, p1, p2, post
+    expect(byIndex[0]).toBeDefined();
+    expect(byIndex[3]).toBeDefined();
+    expect(positions.filter((p) => p === undefined)).toHaveLength(2);
+  });
+
+  it("hands runLoop its position: the in-flight step first, then the composed tail", async () => {
+    const executor = new PipelineExecutor();
+    const positions: Array<PipelineStepPosition | undefined> = [];
+
+    await executor.execute({
+      loops: { a: {}, b: {} },
+      pipeline: { steps: [{ loop: "a" }, { loop: "b" }] },
+      onCheckpoint: async () => {},
+      runLoop: async (_name, _loop, _context, position) => {
+        positions.push(position);
+        return { output: {} };
+      },
+    });
+
+    expect(positions[0]?.steps).toEqual([{ loop: "a" }, { loop: "b" }]);
+    expect(positions[0]?.previousNode).toBeUndefined();
+    expect(positions[1]?.steps).toEqual([{ loop: "b" }]);
+    expect(positions[1]?.previousNode).toBe("a");
+  });
+
+  it("without onCheckpoint nothing changes: no position, no checkpoint machinery", async () => {
+    const executor = new PipelineExecutor();
+    const positions: Array<PipelineStepPosition | undefined> = [];
+
+    await executor.execute({
+      loops: { a: {} },
+      pipeline: { steps: [{ loop: "a" }] },
+      runLoop: async (_name, _loop, _context, position) => {
+        positions.push(position);
+        return { output: {} };
+      },
+    });
+
+    expect(positions).toEqual([undefined]);
+  });
+
+  it("a throwing checkpoint sink never fails the pipeline", async () => {
+    const executor = new PipelineExecutor();
+    const result = await executor.execute({
+      loops: { a: {}, b: {} },
+      pipeline: { steps: [{ loop: "a" }, { loop: "b" }] },
+      onCheckpoint: async () => {
+        throw new Error("store went away");
+      },
+      runLoop: async (name) => ({ output: { ran: name } }),
+    });
+
+    expect(result.context).toMatchObject({ a: { ran: "a" }, b: { ran: "b" } });
   });
 });

--- a/packages/core/src/loop/pipeline.ts
+++ b/packages/core/src/loop/pipeline.ts
@@ -55,6 +55,40 @@ export interface PipelineExecutionResult {
   events: LoopTraceEvent[];
 }
 
+/**
+ * Durable pipeline checkpoint — everything a resumed execution needs.
+ *
+ * Deliberately the SAME shape the human-gate resume format already replays
+ * (LoopResumeState.steps/context/previousNode): resume = execute exactly
+ * `steps` against `context`. Completed steps are never in the list — their
+ * outputs replay from the context bag, they are never re-executed
+ * (Temporal semantics).
+ */
+export interface PipelineCheckpoint {
+  /**
+   * Steps still to execute, composed across nested frames: switch branches
+   * are inlined at selection time (the choice is a historical fact, never
+   * re-evaluated), while iterations re-enter through a continuation step
+   * carrying `completedIterations`.
+   */
+  steps: Step[];
+  /** Live context bag at emit time. */
+  context: ContextBag;
+  /** Last completed node — drives the loop:transition hook on resume. */
+  previousNode?: string;
+}
+
+/**
+ * Pipeline position handed to `runLoop` while checkpointing is active, so
+ * the host can compose per-turn agent-session checkpoints with the pipeline
+ * position. `steps[0]` is the in-flight step itself. Undefined when
+ * checkpointing is off or suppressed (inside parallel branches).
+ */
+export interface PipelineStepPosition {
+  steps: Step[];
+  previousNode?: string;
+}
+
 export interface PipelineExecutorOptions {
   name?: string;
   pipeline: Pipeline;
@@ -69,7 +103,19 @@ export interface PipelineExecutorOptions {
     approvedGates?: LoopApprovedGate[];
   };
   onTrace?: (event: LoopTraceEvent) => void | Promise<void>;
-  runLoop: (name: string, loop: LoopConfig, context: Readonly<ContextBag>) => Promise<PipelineLoopResult>;
+  /**
+   * Durable checkpoint sink — invoked after every completed step, at
+   * switch-branch selection, and at while-iteration boundaries with the
+   * composed remaining-steps continuation. Best-effort by contract: errors
+   * are swallowed so a flaky store can never fail a healthy pipeline.
+   *
+   * v1 cut, deliberate: SUPPRESSED inside parallel branches. One resume
+   * slot cannot honestly represent N concurrent branch positions, so a
+   * crash mid-parallel resumes from the checkpoint BEFORE the block and
+   * re-executes every branch (see the parallel handler below).
+   */
+  onCheckpoint?: (checkpoint: PipelineCheckpoint) => void | Promise<void>;
+  runLoop: (name: string, loop: LoopConfig, context: Readonly<ContextBag>, position?: PipelineStepPosition) => Promise<PipelineLoopResult>;
   runTool?: (name: string, input: unknown, context: Readonly<ContextBag>, step: Extract<Step, { tool: string }>) => Promise<PipelineToolResult>;
   handleHuman?: (name: string, step: Extract<Step, { human: string }>, context: Readonly<ContextBag>) => Promise<PipelineHumanResult>;
 }
@@ -111,7 +157,7 @@ export class PipelineExecutor {
       if (!options.resume) {
         await this.runLifecyclePoint("loop:start", context, options, state, { loop: { name: options.name } });
       }
-      await this.executeSteps(options.pipeline.steps, context, trace, options, state, options.resume?.previousNode);
+      await this.executeSteps(options.pipeline.steps, context, trace, options, state, options.resume?.previousNode, [], !!options.onCheckpoint);
       await this.runLifecyclePoint("loop:end", context, options, state, { loop: { name: options.name }, status: "completed" });
       await state.emit({ type: "loop.end", status: "completed" });
       return { context, trace, events: state.events };
@@ -132,10 +178,26 @@ export class PipelineExecutor {
     options: PipelineExecutorOptions,
     state: PipelineExecutionState,
     previousNode?: string,
+    /** Steps the OUTER frames still have to execute after this frame — the
+     *  durable continuation composed across switch branches and while bodies. */
+    tail: Step[] = [],
+    /** Checkpointing active for this frame (false inside parallel branches). */
+    checkpoints = false,
   ): Promise<string | undefined> {
     let lastNode = previousNode;
+
+    // Best-effort durable checkpoint: remaining steps + live bag + position.
+    const emitCheckpoint = async (remaining: Step[], node: string | undefined): Promise<void> => {
+      if (!checkpoints || !options.onCheckpoint) return;
+      try {
+        await options.onCheckpoint({ steps: remaining, context: { ...context }, previousNode: node });
+      } catch { /* checkpoint persistence is best-effort */ }
+    };
+
     for (let i = 0; i < steps.length; i++) {
       const step = steps[i]!;
+      /** Continuation after the current step completes: this frame's rest + outer tail. */
+      const remainingAfter = (): Step[] => [...steps.slice(i + 1), ...tail];
       try {
         if (!this.matchesWhen(step.when, context)) {
           trace.push({ type: "skip", when: step.when, matched: false });
@@ -150,12 +212,18 @@ export class PipelineExecutor {
           await this.runLifecyclePoint("step:before", context, options, state, { step: { name: step.loop, type: "agent" } });
           await this.runLifecyclePoint("model:before", context, options, state, { step: { name: step.loop, type: "agent" } });
           await state.emit({ type: "step.start", step: step.loop, status: "started", when: step.when });
-          const result = await options.runLoop(step.loop, loop, freezeContext(context));
+          // Position lets the host compose per-turn session checkpoints with
+          // the pipeline position while this agent step is in flight.
+          const position = checkpoints && options.onCheckpoint
+            ? { steps: [step, ...remainingAfter()], previousNode: lastNode }
+            : undefined;
+          const result = await options.runLoop(step.loop, loop, freezeContext(context), position);
           mergeLoopResult(context, step.loop, result);
           trace.push({ type: "loop", name: step.loop, when: step.when, matched: true });
           await this.runLifecyclePoint("step:after", context, options, state, { step: { name: step.loop, type: "agent" }, output: result.output });
           await state.emit({ type: "step.end", step: step.loop, status: "completed", output: result.output });
           lastNode = step.loop;
+          await emitCheckpoint(remainingAfter(), lastNode);
           continue;
         }
 
@@ -173,6 +241,7 @@ export class PipelineExecutor {
           await this.runLifecyclePoint("step:after", context, options, state, { step: { name: stepName, type: "tool" }, tool: { name: step.tool, input: step.input }, output: result.output });
           await state.emit({ type: "tool.result", tool: step.tool, step: step.saveAs ?? step.tool, status: "completed", output: result.output });
           lastNode = step.tool;
+          await emitCheckpoint(remainingAfter(), lastNode);
           continue;
         }
 
@@ -181,15 +250,21 @@ export class PipelineExecutor {
           for (const branch of step.switch.cases) {
             if (this.matchesWhen(branch.when, context)) {
               trace.push({ type: "switch", when: branch.when, matched: true });
-              lastNode = await this.executeSteps(branch.steps, context, trace, options, state, lastNode);
+              // Pin the choice as a historical fact: the selection checkpoint
+              // inlines the chosen branch ahead of the rest — a resume replays
+              // the branch without ever re-evaluating the condition.
+              await emitCheckpoint([...branch.steps, ...remainingAfter()], lastNode);
+              lastNode = await this.executeSteps(branch.steps, context, trace, options, state, lastNode, remainingAfter(), checkpoints);
               matched = true;
               break;
             }
           }
           if (!matched && step.switch.default) {
             trace.push({ type: "switch", matched: false });
-            lastNode = await this.executeSteps(step.switch.default.steps, context, trace, options, state, lastNode);
+            await emitCheckpoint([...step.switch.default.steps, ...remainingAfter()], lastNode);
+            lastNode = await this.executeSteps(step.switch.default.steps, context, trace, options, state, lastNode, remainingAfter(), checkpoints);
           }
+          await emitCheckpoint(remainingAfter(), lastNode);
           continue;
         }
 
@@ -203,7 +278,9 @@ export class PipelineExecutor {
             data: { condition: step.while.condition, until: step.while.until, maxIterations: step.while.maxIterations },
           });
           const maxIterations = step.while.maxIterations ?? 5;
-          let iterations = 0;
+          // Durable resume: continuation steps carry the iterations already
+          // completed by a previous process — the budget stays absolute.
+          let iterations = step.while.completedIterations ?? 0;
           while (this.shouldRunWhile(step.while.condition, step.while.until, context)) {
             if (iterations >= maxIterations) {
               throw new Error(`Loop while step exceeded maxIterations (${maxIterations}) before its exit condition was satisfied`);
@@ -216,18 +293,26 @@ export class PipelineExecutor {
               status: "started",
               data: { iteration: iterations, condition: step.while.condition, until: step.while.until },
             });
-            lastNode = await this.executeSteps(step.while.steps, context, trace, options, state, lastNode);
+            // A crash inside this iteration's body resumes by completing the
+            // body's remaining steps, then re-entering the while with this
+            // iteration already accounted for. The continuation drops the
+            // step's `when` guard — entry already happened, it is history.
+            const continuation: Step = { while: { ...step.while, completedIterations: iterations } };
+            lastNode = await this.executeSteps(step.while.steps, context, trace, options, state, lastNode, [continuation, ...remainingAfter()], checkpoints);
             await state.emit({
               type: "step.end",
               step: "while",
               status: "completed",
               data: { iteration: iterations },
             });
+            // Iteration boundary — even when the body emitted no checkpoint.
+            await emitCheckpoint([continuation, ...remainingAfter()], lastNode);
           }
           trace.push({ type: "while", when: step.while.condition ?? step.while.until, matched: false, iteration: iterations });
           await this.runLifecyclePoint("step:after", context, options, state, { step: { name: "while", type: "while" }, output: { iterations } });
           await state.emit({ type: "step.end", step: "while", status: "completed", output: { iterations } });
           lastNode = "while";
+          await emitCheckpoint(remainingAfter(), lastNode);
           continue;
         }
 
@@ -236,10 +321,17 @@ export class PipelineExecutor {
           await state.emit({ type: "step.start", step: "parallel", status: "started", when: step.when });
           const snapshot = freezeContext(context);
           const branches = normalizeParallelBranches(step.parallel);
+          // Durable v1 cut (deliberate): checkpointing is DISABLED inside the
+          // branches — a single resume slot cannot honestly represent N
+          // concurrent branch positions. A crash mid-parallel resumes from
+          // the checkpoint BEFORE this block and re-executes every branch,
+          // including branches that had already completed. Per-branch
+          // checkpoints (resume only the incomplete branches) are a known
+          // follow-up, not faked here.
           const branchResults = await Promise.all(branches.map(async (branchSteps) => {
             const branchContext = { ...snapshot };
             const branchTrace: PipelineTraceEvent[] = [];
-            await this.executeSteps(branchSteps, branchContext, branchTrace, options, state, lastNode);
+            await this.executeSteps(branchSteps, branchContext, branchTrace, options, state, lastNode, [], false);
             return { branchContext, branchTrace };
           }));
           for (const result of branchResults) {
@@ -250,6 +342,7 @@ export class PipelineExecutor {
           await this.runLifecyclePoint("step:after", context, options, state, { step: { name: "parallel", type: "parallel" } });
           await state.emit({ type: "step.end", step: "parallel", status: "completed" });
           lastNode = "parallel";
+          await emitCheckpoint(remainingAfter(), lastNode);
           continue;
         }
 
@@ -264,6 +357,7 @@ export class PipelineExecutor {
           await this.runLifecyclePoint("step:after", context, options, state, { step: { name: step.human, type: "human" }, output: result.output });
           await state.emit({ type: "human.result", human: step.human, step: step.human, status: "completed", output: result.output });
           lastNode = step.human;
+          await emitCheckpoint(remainingAfter(), lastNode);
         }
       } catch (err) {
         this.attachApprovalResume(err, context, (err as any).resume ? steps.slice(i + 1) : steps.slice(i), lastNode);

--- a/packages/core/src/loop/run-store.ts
+++ b/packages/core/src/loop/run-store.ts
@@ -37,6 +37,16 @@ export interface LoopResumeState {
 
   /** Name of the loop session this checkpoint belongs to (e.g. "default"). */
   loopName?: string;
+  /**
+   * Durable pipelines (task path): name of the project-loop pipeline this
+   * checkpoint belongs to. When set, `steps`/`context`/`previousNode` above
+   * carry the pipeline position — the SAME remaining-steps semantics the
+   * human-gate resume already replays — and the turn fields below, when
+   * present, describe the agent step that was in flight (its loop name in
+   * `loopName`, its session history in `history`). Absent on single-session
+   * checkpoints and on pre-existing gate resume states (compat).
+   */
+  pipelineName?: string;
   /** Index of the last COMPLETED turn (0-based). Resume starts at turn + 1. */
   turn?: number;
   /**

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -240,6 +240,14 @@ export interface WhileBlock {
   condition?: string;
   until?: string;
   maxIterations?: number;
+  /**
+   * Durable-resume marker: iterations already completed by a previous
+   * process. Set only on checkpoint continuation steps emitted by the
+   * PipelineExecutor (never in config files), so a resumed `while`
+   * re-enters at the saved iteration and `maxIterations` stays an
+   * absolute budget across crashes.
+   */
+  completedIterations?: number;
   steps: Step[];
 }
 

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -15,12 +15,19 @@ import type { LoopResumeState } from "./loop/run-store.js";
  */
 export const RESUME_CHECKPOINT_MAX_AGE_MS = 60 * 60 * 1000;
 
-/** A checkpoint is resumable if it has at least one completed turn of
- *  history and is fresh enough to trust. */
+/** A checkpoint is resumable, and fresh enough to trust, when it is either:
+ *   - a session checkpoint: a completed turn (`turn`) with non-empty history, or
+ *   - a pipeline checkpoint: a named pipeline (`pipelineName`) recording the
+ *     step position — an in-flight agent step additionally carries turn/history.
+ *  The completions human-gate format (no `pipelineName`, no `turn`) is neither
+ *  and is deliberately not harvested. */
 function usableCheckpoint(state: LoopResumeState | undefined): LoopResumeState | undefined {
   if (!state) return undefined;
-  if (typeof state.turn !== "number" || state.turn < 0) return undefined;
-  if (!Array.isArray(state.history) || state.history.length === 0) return undefined;
+  const hasSession =
+    typeof state.turn === "number" && state.turn >= 0 &&
+    Array.isArray(state.history) && state.history.length > 0;
+  const hasPipeline = typeof state.pipelineName === "string" && state.pipelineName.length > 0;
+  if (!hasSession && !hasPipeline) return undefined;
   const stamp = state.updatedAt ?? state.createdAt;
   const age = Date.now() - new Date(stamp).getTime();
   if (!Number.isFinite(age) || age > RESUME_CHECKPOINT_MAX_AGE_MS) return undefined;
@@ -510,9 +517,12 @@ export class TaskRunner {
     const resumeState = this.pendingResume.get(task.id);
     if (resumeState) {
       this.pendingResume.delete(task.id);
+      const from = resumeState.pipelineName
+        ? `pipeline "${resumeState.pipelineName}" (${resumeState.steps?.length ?? 0} steps left)`
+        : `turn ${(resumeState.turn ?? -1) + 1}`;
       this.ctx.emitter.emit("log", {
         level: "info",
-        message: `[${task.id}] Resuming from checkpoint (turn ${resumeState.turn! + 1}) instead of retrying from zero`,
+        message: `[${task.id}] Resuming from checkpoint (${from}) instead of retrying from zero`,
       });
     }
 

--- a/packages/node/src/__tests__/loop-engine-pipeline-durable.test.ts
+++ b/packages/node/src/__tests__/loop-engine-pipeline-durable.test.ts
@@ -1,0 +1,578 @@
+/**
+ * Durable turns on PIPELINES — Phase B (task #23).
+ *
+ * Contract under test:
+ * 1. Step boundaries: after every completed pipeline step the engine emits a
+ *    composed checkpoint (pipelineName + remaining steps + context bag). A
+ *    crash between step N and N+1 resumes without EVER re-executing steps
+ *    <= N — their outputs replay from the restored context bag, and the
+ *    result is identical to a run that never crashed.
+ * 2. In-flight agent steps: the Phase A per-turn checkpoints are wrapped
+ *    with the pipeline position — a crash at turn K inside step S resumes
+ *    the SAME step at turn K+1 with the recorded session history.
+ * 3. while: a crash at iteration I resumes from iteration I (continuation
+ *    step carries completedIterations — absolute budget, never restarts
+ *    at 0). switch: the chosen branch is inlined at selection time and is
+ *    replayed WITHOUT re-evaluating the condition (the choice is history).
+ * 4. parallel, deliberate v1 cut: no checkpoints inside the block. A crash
+ *    mid-parallel resumes from before the block and re-executes EVERY
+ *    branch (also the ones that had completed) — pinned here, not hidden.
+ * 5. Compat: pre-existing LoopResumeState formats (human-gate pipeline
+ *    resume, Phase A single-session checkpoints) are never misread by the
+ *    pipeline path, and pipeline checkpoints never leak into single-session
+ *    runs.
+ *
+ * Mock strategy: same as loop-engine-durable-turns.test.ts (vi.mock
+ * @polpo-ai/llm → MockLanguageModelV3); tools and filesystem run for real
+ * against a temp dir.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { mkdtemp, mkdir, rm, readFile, unlink, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedModel } from "@polpo-ai/llm";
+import {
+  MockLanguageModelV3,
+  mockTextModel,
+  mockTurnSequenceModel,
+  mockResolvedModel,
+  type MockResponse,
+} from "./helpers/mock-llm.js";
+
+// ── Mock pi-client BEFORE any imports that pull it in ──
+
+let activeResolvedModel: ResolvedModel = mockResolvedModel(mockTextModel("default"));
+
+vi.mock("@polpo-ai/llm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@polpo-ai/llm")>();
+  return {
+    ...actual,
+    resolveModel: () => activeResolvedModel,
+    enforceModelAllowlist: () => {},
+    mapReasoningToProviderOptions: () => undefined,
+  };
+});
+
+import { spawnLoopEngine } from "../adapters/loop-engine.js";
+import type { AgentConfig, Task } from "@polpo-ai/core/types";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
+import type { Step } from "@polpo-ai/core";
+
+// ── Helpers ─────────────────────────────────────────────
+
+function makeAgent(loopName: string): AgentConfig {
+  return {
+    name: "pipeline-agent",
+    role: "developer",
+    assignedLoops: [loopName],
+    defaultLoop: loopName,
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-pipeline-durable-1",
+    title: "Durable pipeline task",
+    description: "Do the scripted flow.",
+    state: "in_progress",
+    expectations: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    assignedTo: "pipeline-agent",
+    ...overrides,
+  } as Task;
+}
+
+/** Sequence model that also captures every doStream prompt — proves which
+ *  sessions actually hit the LLM and what history they saw. */
+function capturingSequenceModel(responses: MockResponse[], prompts: unknown[][]): MockLanguageModelV3 {
+  const inner = mockTurnSequenceModel(responses);
+  return new MockLanguageModelV3({
+    doGenerate: (opts) => inner.doGenerate(opts),
+    doStream: (opts) => {
+      prompts.push(opts.prompt as unknown[]);
+      return inner.doStream(opts);
+    },
+  });
+}
+
+/** Plays `responses` then throws — simulates a crash mid-pipeline. */
+function crashingAfterModel(responses: MockResponse[], prompts?: unknown[][]): MockLanguageModelV3 {
+  const inner = mockTurnSequenceModel(responses);
+  let calls = 0;
+  return new MockLanguageModelV3({
+    doStream: (opts) => {
+      if (prompts) prompts.push(opts.prompt as unknown[]);
+      if (calls++ >= responses.length) throw new Error("simulated crash");
+      return inner.doStream(opts);
+    },
+  });
+}
+
+/** JSON round-trip — a checkpoint always crosses a store boundary. */
+function throughStore(state: LoopResumeState): LoopResumeState {
+  return JSON.parse(JSON.stringify(state)) as LoopResumeState;
+}
+
+let tmpRoot: string;
+let cwd: string;
+let polpoDir: string;
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "polpo-pipeline-durable-"));
+  cwd = join(tmpRoot, "work");
+  polpoDir = join(tmpRoot, ".polpo");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(join(polpoDir, "loops"), { recursive: true });
+});
+
+afterAll(async () => {
+  if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function writeProjectLoop(name: string, loop: Record<string, unknown>) {
+  await writeFile(join(polpoDir, "loops", `${name}.json`), JSON.stringify(loop, null, 2));
+}
+
+interface RunOptions {
+  agent: AgentConfig;
+  resumeState?: LoopResumeState;
+}
+
+async function runEngine(model: MockLanguageModelV3, options: RunOptions) {
+  activeResolvedModel = mockResolvedModel(model);
+  const checkpoints: LoopResumeState[] = [];
+  const transcript: Array<Record<string, unknown>> = [];
+  const handle = spawnLoopEngine(options.agent, makeTask(), cwd, {
+    polpoDir,
+    resumeState: options.resumeState,
+    onTurnCheckpoint: (state) => {
+      checkpoints.push(throughStore(state));
+    },
+  });
+  handle.onTranscript = (entry) => transcript.push(entry);
+  const result = await handle.done;
+  return { handle, result, checkpoints, transcript };
+}
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("pipeline durable turns — step boundaries", () => {
+  test("kill between step N and N+1: steps <= N never re-execute, result identical to a no-crash control", async () => {
+    await writeProjectLoop("two-step", {
+      name: "two-step",
+      start: "plan",
+      steps: {
+        plan: { next: "build" },
+        build: { next: "end" },
+      },
+    });
+    const agent = makeAgent("two-step");
+    const script: MockResponse[] = [
+      { type: "tool-call", toolName: "write", args: { path: "boundary-a.txt", content: "plan output" } },
+      { type: "text", text: '{"planned": true}' },
+      { type: "text", text: "BUILT" },
+    ];
+
+    // ── Control: same script, no crash ──
+    const control = await runEngine(mockTurnSequenceModel(script), { agent });
+    expect(control.result.exitCode).toBe(0);
+    expect(control.result.stdout).toBe("BUILT");
+    await unlink(join(cwd, "boundary-a.txt"));
+
+    // ── Run 1: plan completes, build's first model call crashes ──
+    const crash = await runEngine(crashingAfterModel(script.slice(0, 2)), { agent });
+    expect(crash.result.exitCode).toBe(1);
+
+    // The last surviving checkpoint is the boundary after "plan": pipeline
+    // position only (no session history), plan's output already in the bag.
+    const checkpoint = crash.checkpoints[crash.checkpoints.length - 1]!;
+    expect(checkpoint.pipelineName).toBe("two-step");
+    expect(checkpoint.steps).toEqual([{ loop: "build" }]);
+    expect(checkpoint.previousNode).toBe("plan");
+    expect(checkpoint.context).toMatchObject({ plan: { planned: true } });
+    expect(checkpoint.history).toBeUndefined();
+
+    // Wipe plan's side-effect so any re-execution would be visible.
+    expect(await readFile(join(cwd, "boundary-a.txt"), "utf-8")).toBe("plan output");
+    await unlink(join(cwd, "boundary-a.txt"));
+
+    // ── Run 2: resume from the boundary checkpoint ──
+    const prompts: unknown[][] = [];
+    const resumed = await runEngine(
+      capturingSequenceModel([{ type: "text", text: "BUILT" }], prompts),
+      { agent, resumeState: checkpoint },
+    );
+
+    expect(resumed.result.exitCode).toBe(0);
+    // Identical to the no-crash control.
+    expect(resumed.result.stdout).toBe(control.result.stdout);
+
+    // Temporal semantics: plan's LLM turns and tool never re-executed…
+    expect(prompts).toHaveLength(1);
+    expect(existsSync(join(cwd, "boundary-a.txt"))).toBe(false);
+    // …and build saw plan's output through the restored context bag.
+    expect(JSON.stringify(prompts[0])).toContain("planned");
+    expect(JSON.stringify(prompts[0])).toContain('Active loop step: build');
+  });
+
+  test("kill after the FINAL step: resume completes without re-executing anything", async () => {
+    await writeProjectLoop("one-step", {
+      name: "one-step",
+      start: "solo",
+      steps: { solo: { next: "end" } },
+    });
+    const agent = makeAgent("one-step");
+
+    // Run 1 "crashes" right after the last boundary checkpoint (we simply
+    // harvest the final checkpoint: steps is empty).
+    const first = await runEngine(mockTurnSequenceModel([{ type: "text", text: '{"solo": "done"}' }]), { agent });
+    expect(first.result.exitCode).toBe(0);
+    const final = first.checkpoints[first.checkpoints.length - 1]!;
+    expect(final.steps).toEqual([]);
+    expect(final.pipelineName).toBe("one-step");
+
+    // Resume: zero steps left — the run completes from the bag alone, the
+    // LLM is never called (documented: stdout falls back to context JSON).
+    const prompts: unknown[][] = [];
+    const resumed = await runEngine(capturingSequenceModel([], prompts), { agent, resumeState: final });
+    expect(resumed.result.exitCode).toBe(0);
+    expect(prompts).toHaveLength(0);
+    expect(resumed.result.stdout).toContain('"solo"');
+  });
+});
+
+describe("pipeline durable turns — in-flight agent step (Phase A composition)", () => {
+  test("kill at turn K inside step S: resume restarts S at turn K+1 with the recorded history", async () => {
+    await writeProjectLoop("two-step-b", {
+      name: "two-step-b",
+      start: "plan",
+      steps: {
+        plan: { next: "build" },
+        build: { next: "end" },
+      },
+    });
+    const agent = makeAgent("two-step-b");
+
+    // Run 1: plan completes in one turn; build does a tool turn (turn 0),
+    // then crashes at turn 1.
+    const crash = await runEngine(
+      crashingAfterModel([
+        { type: "text", text: '{"planned": true}' },
+        { type: "tool-call", toolName: "write", args: { path: "inflight-b.txt", content: "build turn 0" } },
+      ]),
+      { agent },
+    );
+    expect(crash.result.exitCode).toBe(1);
+
+    // Last checkpoint: build in flight — pipeline position AND session state.
+    const checkpoint = crash.checkpoints[crash.checkpoints.length - 1]!;
+    expect(checkpoint.pipelineName).toBe("two-step-b");
+    expect(checkpoint.steps).toEqual([{ loop: "build" }]);
+    expect(checkpoint.loopName).toBe("build");
+    expect(checkpoint.turn).toBe(0);
+    expect(Array.isArray(checkpoint.history)).toBe(true);
+    expect(JSON.stringify(checkpoint.history)).toContain("inflight-b.txt");
+    expect(checkpoint.context).toMatchObject({ plan: { planned: true } });
+
+    // Wipe the side-effect so re-execution would be visible.
+    expect(await readFile(join(cwd, "inflight-b.txt"), "utf-8")).toBe("build turn 0");
+    await unlink(join(cwd, "inflight-b.txt"));
+
+    // Run 2: resume — build continues at turn 1.
+    const prompts: unknown[][] = [];
+    const resumed = await runEngine(
+      capturingSequenceModel([{ type: "text", text: "resumed BUILT" }], prompts),
+      { agent, resumeState: checkpoint },
+    );
+
+    expect(resumed.result.exitCode).toBe(0);
+    expect(resumed.result.stdout).toBe("resumed BUILT");
+
+    // plan never re-ran, build's turn-0 tool never re-executed…
+    expect(prompts).toHaveLength(1);
+    expect(existsSync(join(cwd, "inflight-b.txt"))).toBe(false);
+    // …the model saw build's recorded turn-0 history (tool-call + result).
+    const firstPrompt = JSON.stringify(prompts[0]);
+    expect(firstPrompt).toContain("inflight-b.txt");
+    expect(firstPrompt).toContain("tool-result");
+    expect(firstPrompt).toContain("Active loop step: build");
+
+    // Turn numbering continues inside the resumed step.
+    const inFlight = resumed.checkpoints.find((cp) => typeof cp.turn === "number");
+    expect(inFlight?.turn).toBe(1);
+  });
+});
+
+describe("pipeline durable turns — while and switch", () => {
+  test("while: kill at iteration I resumes from iteration I, not from 0", async () => {
+    await writeProjectLoop("retry-flow", {
+      name: "retry-flow",
+      start: "loop",
+      steps: {
+        loop: { type: "while", until: "worker.done == true", maxIterations: 5, body: "worker", next: "end" },
+        worker: { next: "end" },
+      },
+    });
+    const agent = makeAgent("retry-flow");
+
+    // Run 1: iteration 1 completes (done=false), iteration 2 crashes at its
+    // first model call.
+    const crash = await runEngine(
+      crashingAfterModel([{ type: "text", text: '{"done": false}' }]),
+      { agent },
+    );
+    expect(crash.result.exitCode).toBe(1);
+
+    // Last checkpoint = iteration-1 boundary: a while continuation that has
+    // already done 1 iteration.
+    const checkpoint = crash.checkpoints[crash.checkpoints.length - 1]!;
+    expect(checkpoint.pipelineName).toBe("retry-flow");
+    const continuation = checkpoint.steps[0] as Extract<Step, { while: unknown }>;
+    expect((continuation as any).while.completedIterations).toBe(1);
+    expect(checkpoint.context).toMatchObject({ worker: { done: false } });
+
+    // Run 2: resume — exactly ONE more worker session runs (iteration 2).
+    const prompts: unknown[][] = [];
+    const resumed = await runEngine(
+      capturingSequenceModel([{ type: "text", text: '{"done": true}' }], prompts),
+      { agent, resumeState: checkpoint },
+    );
+
+    expect(resumed.result.exitCode).toBe(0);
+    expect(prompts).toHaveLength(1);
+
+    // The resumed trace runs iteration 2 — never iteration 1 again.
+    const iterations = resumed.transcript
+      .filter((t) => t.type === "loop_trace")
+      .map((t) => (t.trace as { data?: { iteration?: number } }).data?.iteration)
+      .filter((i): i is number => typeof i === "number");
+    expect(iterations).toContain(2);
+    expect(iterations).not.toContain(1);
+  });
+
+  test("switch: the chosen branch replays WITHOUT re-evaluating the condition", async () => {
+    await writeProjectLoop("route-flow", {
+      name: "route-flow",
+      start: "router",
+      steps: {
+        router: { next: [{ when: "router.path == 'x'", to: "x" }, { to: "y" }] },
+        x: { next: "end" },
+        y: { next: "end" },
+      },
+    });
+    const agent = makeAgent("route-flow");
+
+    // Run 1: router picks branch x, then x's first model call crashes.
+    const crash = await runEngine(
+      crashingAfterModel([{ type: "text", text: '{"path": "x"}' }]),
+      { agent },
+    );
+    expect(crash.result.exitCode).toBe(1);
+
+    // The selection checkpoint pinned the choice: branch x inlined, the
+    // switch step GONE — nothing left to re-evaluate.
+    const checkpoint = crash.checkpoints[crash.checkpoints.length - 1]!;
+    expect(checkpoint.steps).toEqual([{ loop: "x" }]);
+    expect(checkpoint.steps.some((step) => "switch" in step)).toBe(false);
+
+    // Tamper the restored bag so a re-evaluation WOULD choose y — the
+    // resume must still run x, because the choice is a recorded fact.
+    const tampered = throughStore(checkpoint);
+    (tampered.context as any).router = { path: "y" };
+
+    const prompts: unknown[][] = [];
+    const resumed = await runEngine(
+      capturingSequenceModel([{ type: "text", text: "X-DONE" }], prompts),
+      { agent, resumeState: tampered },
+    );
+
+    expect(resumed.result.exitCode).toBe(0);
+    expect(resumed.result.stdout).toBe("X-DONE");
+    expect(prompts).toHaveLength(1);
+    expect(JSON.stringify(prompts[0])).toContain("Active loop step: x");
+    expect(JSON.stringify(prompts[0])).not.toContain("Active loop step: y");
+  });
+});
+
+describe("pipeline durable turns — parallel (v1 cut, pinned)", () => {
+  test("crash inside parallel resumes from BEFORE the block: completed branches re-execute, prior steps do not", async () => {
+    await writeProjectLoop("par-flow", {
+      name: "par-flow",
+      start: "pre",
+      steps: {
+        pre: {
+          type: "tool",
+          tool: "bash",
+          input: { command: "echo ran >> par-marker.txt" },
+          saveAs: "pre",
+          next: "fanout",
+        },
+        fanout: { type: "parallel", branches: ["p1", "p2"], join: "all", next: "post" },
+        p1: { next: "end" },
+        p2: { next: "end" },
+        post: { next: "end" },
+      },
+    });
+    const agent = makeAgent("par-flow");
+
+    // Run 1: one parallel branch completes, the other crashes.
+    const crash = await runEngine(
+      crashingAfterModel([{ type: "text", text: '{"branch": "done"}' }]),
+      { agent },
+    );
+    expect(crash.result.exitCode).toBe(1);
+    expect(await readFile(join(cwd, "par-marker.txt"), "utf-8")).toBe("ran\n");
+
+    // No checkpoint from inside the block: the last one is the boundary
+    // after the "pre" tool step (previousNode records the TOOL name — the
+    // pre-existing lastNode semantics), the whole parallel step pending.
+    const checkpoint = crash.checkpoints[crash.checkpoints.length - 1]!;
+    expect(checkpoint.previousNode).toBe("bash");
+    expect(checkpoint.steps[0]).toHaveProperty("parallel");
+    expect(checkpoint.history).toBeUndefined();
+
+    // Run 2: resume. BOTH branches re-execute (v1 cut — also the branch
+    // that had completed), then post runs. The pre tool step does NOT.
+    const prompts: unknown[][] = [];
+    const resumed = await runEngine(
+      capturingSequenceModel(
+        [
+          { type: "text", text: '{"p": 1}' },
+          { type: "text", text: '{"p": 2}' },
+          { type: "text", text: "POST-DONE" },
+        ],
+        prompts,
+      ),
+      { agent, resumeState: checkpoint },
+    );
+
+    expect(resumed.result.exitCode).toBe(0);
+    expect(resumed.result.stdout).toBe("POST-DONE");
+    // Three sessions ran on resume: p1 + p2 (re-executed) + post.
+    expect(prompts).toHaveLength(3);
+    // The tool step before the block was NOT re-executed.
+    expect(await readFile(join(cwd, "par-marker.txt"), "utf-8")).toBe("ran\n");
+  });
+});
+
+describe("pipeline durable turns — format compat", () => {
+  test("a pre-existing human-gate resume state (no pipelineName) is ignored: fresh start, no crash", async () => {
+    await writeProjectLoop("compat-flow", {
+      name: "compat-flow",
+      start: "plan",
+      steps: {
+        plan: { next: "build" },
+        build: { next: "end" },
+      },
+    });
+    const agent = makeAgent("compat-flow");
+
+    // The completions human-gate format: steps + context + previousNode +
+    // approvedGates, NO pipelineName, NO turn fields.
+    const gateFormat: LoopResumeState = {
+      context: { plan: { planned: "stale" } },
+      steps: [{ loop: "build" }],
+      previousNode: "plan",
+      approvedGates: [{ type: "policy", id: "approve-deploy", hook: "tool:before" }],
+      attempts: 1,
+      createdAt: new Date().toISOString(),
+    };
+
+    const prompts: unknown[][] = [];
+    const { result } = await runEngine(
+      capturingSequenceModel(
+        [
+          { type: "text", text: '{"planned": true}' },
+          { type: "text", text: "FRESH-BUILT" },
+        ],
+        prompts,
+      ),
+      { agent, resumeState: gateFormat },
+    );
+
+    // Both steps ran — the gate-format state did not skip "plan".
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("FRESH-BUILT");
+    expect(prompts).toHaveLength(2);
+    expect(JSON.stringify(prompts[1])).not.toContain("stale");
+  });
+
+  test("a Phase A single-session checkpoint never seeds a pipeline run", async () => {
+    await writeProjectLoop("compat-flow-b", {
+      name: "compat-flow-b",
+      start: "solo",
+      steps: { solo: { next: "end" } },
+    });
+    const agent = makeAgent("compat-flow-b");
+
+    const sessionCheckpoint: LoopResumeState = {
+      context: {},
+      steps: [],
+      loopName: "default",
+      turn: 2,
+      history: [{ role: "user", content: "old single-session prompt" }],
+      accumText: "old",
+      createdAt: new Date().toISOString(),
+    };
+
+    const prompts: unknown[][] = [];
+    const { result } = await runEngine(
+      capturingSequenceModel([{ type: "text", text: "SOLO-FRESH" }], prompts),
+      { agent, resumeState: sessionCheckpoint },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("SOLO-FRESH");
+    expect(prompts).toHaveLength(1);
+    expect(JSON.stringify(prompts[0])).not.toContain("old single-session prompt");
+  });
+
+  test("a pipeline checkpoint never seeds a single-session (non-pipeline) run", async () => {
+    const singleAgent: AgentConfig = { name: "pipeline-agent", role: "developer" };
+
+    const pipelineCheckpoint: LoopResumeState = {
+      context: { plan: { planned: true } },
+      steps: [{ loop: "default" }],
+      pipelineName: "two-step",
+      loopName: "default",
+      turn: 0,
+      history: [{ role: "user", content: "pipeline step history" }],
+      createdAt: new Date().toISOString(),
+    };
+
+    const prompts: unknown[][] = [];
+    const { result, checkpoints } = await runEngine(
+      capturingSequenceModel([{ type: "text", text: "SINGLE-FRESH" }], prompts),
+      { agent: singleAgent, resumeState: pipelineCheckpoint },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("SINGLE-FRESH");
+    // History was NOT seeded from the pipeline checkpoint…
+    expect(JSON.stringify(prompts[0])).not.toContain("pipeline step history");
+    // …and single-session checkpointing restarted from turn 0.
+    expect(checkpoints[0]?.turn).toBe(0);
+    expect(checkpoints[0]?.pipelineName).toBeUndefined();
+  });
+
+  test("a throwing checkpoint sink never fails a pipeline run", async () => {
+    await writeProjectLoop("sink-flow", {
+      name: "sink-flow",
+      start: "solo",
+      steps: { solo: { next: "end" } },
+    });
+    activeResolvedModel = mockResolvedModel(mockTurnSequenceModel([{ type: "text", text: "still fine" }]));
+    const handle = spawnLoopEngine(makeAgent("sink-flow"), makeTask(), cwd, {
+      polpoDir,
+      onTurnCheckpoint: () => {
+        throw new Error("store went away");
+      },
+    });
+    const result = await handle.done;
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("still fine");
+  });
+});

--- a/packages/node/src/__tests__/resilience.test.ts
+++ b/packages/node/src/__tests__/resilience.test.ts
@@ -777,4 +777,64 @@ describe("Durable turns recovery", () => {
     expect(spawnedConfigs).toHaveLength(1);
     expect(spawnedConfigs[0].resumeState).toBeUndefined();
   });
+
+  // ── Phase B: pipeline checkpoints (position, no per-turn history) ──
+
+  /** A step-boundary pipeline checkpoint: position only, no session. */
+  function makePipelineCheckpoint(overrides: Partial<LoopResumeState> = {}): LoopResumeState {
+    const now = new Date().toISOString();
+    return {
+      context: { plan: { planned: true } },
+      steps: [{ loop: "build" }],
+      previousNode: "plan",
+      pipelineName: "ship-flow",
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    };
+  }
+
+  it("dead runner with a pipeline boundary checkpoint: respawn carries it (no turn fields required)", async () => {
+    const task = await createOrphanTask("Resumable pipeline task");
+    await runStore.upsertRun(runRecord(task.id, { resumeState: makePipelineCheckpoint() }));
+
+    const recovered = await orchestrator.engine.recoverOrphanedTasks();
+    expect(recovered).toBe(1);
+
+    await respawn(task.id);
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeDefined();
+    expect(spawnedConfigs[0].resumeState!.pipelineName).toBe("ship-flow");
+    expect(spawnedConfigs[0].resumeState!.steps).toEqual([{ loop: "build" }]);
+    expect(spawnedConfigs[0].resumeState!.turn).toBeUndefined();
+  });
+
+  it("stale pipeline checkpoint is ignored like a stale session checkpoint", async () => {
+    const task = await createOrphanTask("Stale pipeline checkpoint");
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    await runStore.upsertRun(runRecord(task.id, {
+      resumeState: makePipelineCheckpoint({ createdAt: twoHoursAgo, updatedAt: twoHoursAgo }),
+    }));
+
+    await orchestrator.engine.recoverOrphanedTasks();
+    await respawn(task.id);
+
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeUndefined();
+  });
+
+  it("a gate-format resume state (no pipelineName, no turn) is not harvested", async () => {
+    // The completions human-gate format must never be mistaken for a
+    // task-path crash checkpoint.
+    const task = await createOrphanTask("Gate-format state");
+    await runStore.upsertRun(runRecord(task.id, {
+      resumeState: makePipelineCheckpoint({ pipelineName: undefined }),
+    }));
+
+    await orchestrator.engine.recoverOrphanedTasks();
+    await respawn(task.id);
+
+    expect(spawnedConfigs).toHaveLength(1);
+    expect(spawnedConfigs[0].resumeState).toBeUndefined();
+  });
 });

--- a/packages/node/src/adapters/loop-engine.ts
+++ b/packages/node/src/adapters/loop-engine.ts
@@ -112,13 +112,28 @@ export const MAX_CHECKPOINT_BYTES = 4 * 1024 * 1024;
  * Validate a resume checkpoint against the session about to start. A
  * checkpoint only applies to the same loop session and must carry actual
  * history and a completed-turn index; anything else falls back to a fresh
- * start (never fails the run).
+ * start (never fails the run). Pipeline checkpoints (pipelineName set)
+ * never seed a single-session run — their loopName is a pipeline STEP.
  */
 function usableResumeState(resume: LoopResumeState | undefined, loopName: string): LoopResumeState | undefined {
   if (!resume) return undefined;
+  if (resume.pipelineName) return undefined;
   if (resume.loopName !== loopName) return undefined;
   if (typeof resume.turn !== "number" || resume.turn < 0) return undefined;
   if (!Array.isArray(resume.history) || resume.history.length === 0) return undefined;
+  return resume;
+}
+
+/**
+ * Validate a resume checkpoint against the pipeline about to start: it must
+ * belong to the SAME project loop and carry a remaining-steps continuation.
+ * Single-session checkpoints (no pipelineName) and human-gate resume states
+ * from the completions path are ignored — fresh start, never a failure.
+ */
+function usablePipelineResumeState(resume: LoopResumeState | undefined, pipelineName: string): LoopResumeState | undefined {
+  if (!resume) return undefined;
+  if (resume.pipelineName !== pipelineName) return undefined;
+  if (!Array.isArray(resume.steps)) return undefined;
   return resume;
 }
 
@@ -471,11 +486,18 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
    * PipelineExecutor: agent steps are independent LLM sessions that share
    * the context bag; tool steps execute deterministically with no LLM turn.
    *
-   * Durable turns (Phase A) does NOT checkpoint pipeline task runs: a
-   * pipeline checkpoint needs pipeline position + per-step session history
-   * (the LoopResumeState pipeline fields cover position, per-step history
-   * does not exist yet) — Phase B. Pipeline runs ignore ctx.resumeState
-   * and start fresh, which is the pre-existing behavior.
+   * Durable pipelines (Phase B): checkpoints at two granularities, one
+   * resume slot, one unified format (LoopResumeState, additive):
+   * (a) at every completed step boundary the executor emits the composed
+   *     remaining-steps continuation + context bag (steps already done are
+   *     NOT in it — their outputs replay from the bag, Temporal semantics);
+   * (b) inside an in-flight agent step, the Phase A per-turn checkpoints
+   *     are wrapped with the pipeline position (steps[0] = the step itself)
+   *     so a crash at turn K resumes the SAME step at turn K+1.
+   * switch choices are pinned at selection (never re-evaluated on resume),
+   * while continuations carry completedIterations (absolute budget).
+   * Deliberate v1 cut: no checkpoints inside parallel branches — a crash
+   * mid-parallel resumes from before the block and re-executes every branch.
    */
   async function runPipeline(projectLoop: ProjectLoopConfig): Promise<string> {
     const normalized = normalizeProjectLoop(projectLoop);
@@ -494,28 +516,93 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
       return baseToolsPromise;
     };
 
+    // A usable checkpoint replaces the pipeline's step list with the
+    // recorded continuation; anything else (absent, other pipeline, old
+    // gate/session formats) starts fresh.
+    const resume = usablePipelineResumeState(ctx?.resumeState, projectLoop.name);
+    // One-shot in-flight session resume: only the FIRST agent step the
+    // resumed pipeline reaches may consume the turn-level fields (it is
+    // steps[0] of the recorded continuation); runLoopSession re-validates
+    // the loop name before seeding history.
+    let pendingSessionResume: LoopResumeState | undefined =
+      resume && typeof resume.turn === "number" && Array.isArray(resume.history) && resume.history.length > 0
+        ? { ...resume, pipelineName: undefined }
+        : undefined;
+
+    // Composed checkpoint sink → ctx.onTurnCheckpoint (the runner wires it
+    // to RunStore.updateResumeState). Same cap and JSON round-trip rules as
+    // the single-session path: an oversized state keeps the previous
+    // checkpoint, a JSON pass pins store fidelity.
+    const checkpointCreatedAt = resume?.createdAt ?? new Date().toISOString();
+    const sink = ctx?.onTurnCheckpoint;
+    const writeCheckpoint = sink
+      ? async (state: LoopResumeState): Promise<void> => {
+          const serialized = JSON.stringify(state);
+          if (serialized.length > MAX_CHECKPOINT_BYTES) return; // keep the previous checkpoint
+          await sink(JSON.parse(serialized) as LoopResumeState);
+        }
+      : undefined;
+    /** Fields every composed checkpoint carries, boundary or in-flight. */
+    const composedBase = () => ({
+      pipelineName: projectLoop.name,
+      approvedGates: resume?.approvedGates,
+      createdAt: checkpointCreatedAt,
+      updatedAt: new Date().toISOString(),
+    });
+
     let finalText = "";
     let toolStepSeq = 0;
     const executor = new PipelineExecutor();
 
     const result = await executor.execute({
       name: projectLoop.name,
-      pipeline: normalized.pipeline,
+      pipeline: resume ? { ...normalized.pipeline, steps: resume.steps } : normalized.pipeline,
       loops: normalized.loops,
-      context: {},
+      context: resume ? { ...resume.context } : {},
       projectHooks: projectLoop.hooks,
       projectPermissions: projectLoop.permissions,
       projectPolicies: projectLoop.policies,
+      resume: resume
+        ? { previousNode: resume.previousNode, approvedGates: resume.approvedGates }
+        : undefined,
+      // (a) Step-boundary checkpoint: pure pipeline position, no session.
+      onCheckpoint: writeCheckpoint
+        ? async (checkpoint) => {
+            await writeCheckpoint({
+              context: checkpoint.context,
+              steps: checkpoint.steps,
+              previousNode: checkpoint.previousNode,
+              ...composedBase(),
+            });
+          }
+        : undefined,
       onTrace: async (event) => {
         handle.onTranscript?.({ type: "loop_trace", trace: event });
       },
-      runLoop: async (name, loop, context) => {
+      runLoop: async (name, loop, context, position) => {
+        const sessionResume = pendingSessionResume;
+        pendingSessionResume = undefined;
         const stepAgent = buildLoopStepAgent(agentConfig, name, loop);
         const session = await runLoopSession({
           sessionAgent: stepAgent,
           loopName: name,
           loop,
           contextPrompt: loopContextPrompt(name, context),
+          resume: sessionResume,
+          // (b) Per-turn checkpoint INSIDE this agent step: the session
+          // state wrapped with the pipeline position. No position = the
+          // step runs inside a parallel branch, checkpointing suppressed.
+          onCheckpoint: writeCheckpoint && position
+            ? async (state) => {
+                await writeCheckpoint({
+                  ...state,
+                  context: { ...context },
+                  steps: position.steps,
+                  previousNode: position.previousNode,
+                  ...composedBase(),
+                });
+              }
+            : undefined,
         });
         if (session.lastText) finalText = session.lastText;
         return { output: maybeParseJson(session.accumText || session.lastText) };


### PR DESCRIPTION
Completes the durable-execution coverage: pipeline task runs (agent/tool/human/parallel/while/switch) now checkpoint and resume, not just single-agent loops.

- One composed `LoopResumeState` (additive on the existing human-gate format): step position + context bag; an in-flight agent step also carries turn/history.
- Completed steps replay their outputs from the context bag and never re-execute (Temporal semantics); `while` resumes at its iteration; `switch` replays the chosen branch without re-evaluating; a pending human gate resumes as pending.
- Orphan recovery harvests pipeline checkpoints (pipelineName + steps) alongside session checkpoints (turn + history); the completions gate-format is still not harvested.
- `parallel`: v1 checkpoints at whole-block completion — incomplete branches re-execute on resume (documented, test-pinned).

+22 tests, suite 1990 green, typecheck clean, all additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)