### PR TITLE
fix: ensurePgSchema adds resume_state + execution_mode to runs

### DIFF
--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -106,6 +106,8 @@ export async function ensurePgTables(db: any): Promise<void> {
   )`);
 
   await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS "user" TEXT`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS resume_state JSONB`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS execution_mode TEXT`);
 
   await db.execute(sql`CREATE TABLE IF NOT EXISTS loop_runs (
     id                  TEXT PRIMARY KEY,


### PR DESCRIPTION
The hand-written PG schema path drifted from the Drizzle schema — `resume_state` and `execution_mode` were missing from the `runs` CREATE path, failing every DrizzleRunStore PG test (which only run in the release workflow, not PR CI). Verified against Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)