### PR TITLE
feat(node): thread per-tenant gatewayConfig through in-process execution

### DIFF
--- a/packages/node/src/__tests__/in-process-spawner.test.ts
+++ b/packages/node/src/__tests__/in-process-spawner.test.ts
@@ -44,12 +44,13 @@ import {
 // ── Mock the LLM module BEFORE any imports that pull it in ──
 
 let activeResolvedModel: ResolvedModel = mockResolvedModel(mockTextModel("default"));
+let capturedResolveOpts: unknown;
 
 vi.mock("@polpo-ai/llm", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@polpo-ai/llm")>();
   return {
     ...actual,
-    resolveModel: () => activeResolvedModel,
+    resolveModel: (_model: unknown, opts?: unknown) => { capturedResolveOpts = opts; return activeResolvedModel; },
     enforceModelAllowlist: () => {},
     mapReasoningToProviderOptions: () => undefined,
   };
@@ -167,6 +168,22 @@ describe("InProcessSpawner", () => {
     expect(shape).toContain("assistant");
     // Output dir was created (NodeSpawner parity).
     expect(existsSync(config.outputDir)).toBe(true);
+  });
+
+  test("per-tenant gatewayConfig from deps reaches the loop's model resolution", async () => {
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "gw ok" }]));
+    capturedResolveOpts = undefined;
+    const gatewayConfig = { url: "https://tenant-gw.example/v1", apiKey: "tenant-key" };
+    const store = new InMemoryRunStore();
+    const spawner = new InProcessSpawner(() => ({ runStore: store, gatewayConfig }));
+
+    const spawnResult = await spawner.spawn(makeConfig());
+    await onExitPromise(spawnResult);
+
+    // resolveModel(model, { gateway }) — the in-process host must thread the
+    // per-tenant gateway through, since the shared server process has no
+    // per-tenant env (unlike the sandbox).
+    expect((capturedResolveOpts as { gateway?: unknown })?.gateway).toEqual(gatewayConfig);
   });
 
   test("lifecycle: isAlive during the run, false after; kill() → run killed", async () => {

--- a/packages/node/src/adapters/in-process-spawner.ts
+++ b/packages/node/src/adapters/in-process-spawner.ts
@@ -49,6 +49,9 @@ export interface InProcessSpawnerDeps {
   memoryStore?: MemoryStore;
   fs?: FileSystem;
   shell?: Shell;
+  /** Per-tenant LLM gateway config — the in-process loop runs in a shared
+   *  process with no per-tenant env, so the host must inject it here. */
+  gatewayConfig?: unknown;
 }
 
 export class InProcessSpawner implements Spawner {

--- a/packages/node/src/core/run-lifecycle.ts
+++ b/packages/node/src/core/run-lifecycle.ts
@@ -112,6 +112,13 @@ export interface ExecuteRunDeps {
   fs?: FileSystem;
   /** Shell for tools. Default: a fresh NodeShell. */
   shell?: Shell;
+  /**
+   * LLM gateway configuration for the loop's model resolution. The subprocess
+   * host leaves this undefined and relies on gateway/provider env vars inside
+   * the sandbox; an in-process host (proxy execution) must pass the per-tenant
+   * gateway here — the loop runs in a shared process with no per-tenant env.
+   */
+  gatewayConfig?: unknown;
   /** Pid recorded on the run record: process.pid (subprocess) or a synthetic negative id (in-process). */
   pid: number;
   /** Where the config was persisted ("file:///path", "db://runId", "memory://…"). */
@@ -188,6 +195,9 @@ export async function executeRun(config: RunnerConfig, deps: ExecuteRunDeps): Pr
       reasoning: config.reasoning,
       vaultStore,
       memoryStore,
+      // Per-tenant gateway for the in-process host (undefined for subprocess,
+      // which resolves the gateway from sandbox env).
+      gatewayConfig: deps.gatewayConfig,
       // Subprocess hosts create their own fs/shell; the in-process host
       // injects the orchestrator's instances.
       fs: deps.fs ?? new NodeFileSystem(),


### PR DESCRIPTION
Proxy execution (in-process) runs the loop in a shared server process — the subprocess trick of injecting gateway keys as sandbox env doesn't apply. Adds `gatewayConfig` to `ExecuteRunDeps` and `InProcessSpawnerDeps`, threaded into the spawnCtx so `resolveModel` gets the correct tenant's gateway. Subprocess path unchanged. Prereq for the cloud proxy-execution branch to route per-tenant BYOK correctly. +1 test, suite 1991 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)