### PR TITLE
refactor(completions): single persistAssistantMessage projection

### DIFF
--- a/packages/server/src/routes/completions/chat-handler.ts
+++ b/packages/server/src/routes/completions/chat-handler.ts
@@ -19,8 +19,8 @@ import {
   CLIENT_SIDE_TOOL_NAMES,
   emitFileChanged,
   indexToolResultsByCallId,
+  persistAssistantMessage,
   recordProviderToolCall,
-  redactVaultToolCalls,
   toAITools,
 } from "./tool-mapping.js";
 
@@ -426,16 +426,8 @@ export function streamChatCompletion(c: any, exec: ChatCompletionExecution): any
     } finally {
       clearInterval(heartbeatInterval);
       // Always persist the assistant response — even on disconnect.
-      // SECURITY: Redact vault credentials before persisting to SQLite
-      const safeToolCalls = redactVaultToolCalls(toolCallsAccum);
-      if (sessionStore && sessionId && assistantMsgId) {
-        if (finalText.trim()) {
-          await sessionStore.updateMessage(sessionId, assistantMsgId, finalText.trim(), safeToolCalls);
-        }
-        else {
-          await sessionStore.updateMessage(sessionId, assistantMsgId, "", safeToolCalls);
-        }
-      }
+      // (Vault credentials are redacted inside persistAssistantMessage.)
+      await persistAssistantMessage(sessionStore, sessionId, assistantMsgId, finalText, toolCallsAccum);
       // Notify consumer (e.g. metering) — fire-and-forget
       try {
         deps.onCompletionFinished?.({
@@ -749,16 +741,11 @@ export async function runNonStreamingChatCompletion(c: any, exec: ChatCompletion
     }
     throw err;
   } finally {
-    // Always persist the final text + tool calls — even on early return (ask_user) or error
-    // SECURITY: Redact vault credentials before persisting to SQLite
-    const safeToolCalls = redactVaultToolCalls(toolCallsAccum);
-    if (sessionStore && sessionId && assistantMsgId) {
-      if (finalText.trim()) {
-        await sessionStore.updateMessage(sessionId, assistantMsgId, finalText.trim(), safeToolCalls);
-      } else {
-        await sessionStore.updateMessage(sessionId, assistantMsgId, "[Response interrupted]", safeToolCalls);
-      }
-    }
+    // Always persist the final text + tool calls — even on early return (ask_user) or error.
+    // (Vault credentials are redacted inside persistAssistantMessage.)
+    await persistAssistantMessage(sessionStore, sessionId, assistantMsgId, finalText, toolCallsAccum, {
+      emptyFallback: "[Response interrupted]",
+    });
     // Notify consumer (e.g. metering) — fire-and-forget
     try {
       deps.onCompletionFinished?.({

--- a/packages/server/src/routes/completions/project-loop-runner.ts
+++ b/packages/server/src/routes/completions/project-loop-runner.ts
@@ -29,7 +29,7 @@ import type { LanguageModelUsage } from "ai";
 import type { CompletionRouteDeps } from "../completions.js";
 import { addUsage, runAgentStepCompletion } from "./agent-step-runner.js";
 import { completionResponse, loopRuntimeErrorEnvelope, modelNotFoundEnvelope, sseChunk } from "./sse.js";
-import { emitFileChanged, redactVaultToolCalls, type LoopRuntimeToolCall } from "./tool-mapping.js";
+import { emitFileChanged, persistAssistantMessage, type LoopRuntimeToolCall } from "./tool-mapping.js";
 
 export interface ProjectLoopRunResult {
   text: string;
@@ -462,10 +462,7 @@ export async function handleProjectLoopCompletion(c: any, options: {
         throw err;
       } finally {
         clearInterval(heartbeatInterval);
-        const safeToolCalls = redactVaultToolCalls(toolCalls);
-        if (sessionStore && sessionId && assistantMsgId) {
-          await sessionStore.updateMessage(sessionId, assistantMsgId, finalText.trim(), safeToolCalls);
-        }
+        await persistAssistantMessage(sessionStore, sessionId, assistantMsgId, finalText, toolCalls);
         try {
           deps.onCompletionFinished?.({
             usage: runUsage,
@@ -517,10 +514,7 @@ export async function handleProjectLoopCompletion(c: any, options: {
     }
     throw err;
   } finally {
-    const safeToolCalls = redactVaultToolCalls(toolCalls);
-    if (sessionStore && sessionId && assistantMsgId) {
-      await sessionStore.updateMessage(sessionId, assistantMsgId, finalText.trim(), safeToolCalls);
-    }
+    await persistAssistantMessage(sessionStore, sessionId, assistantMsgId, finalText, toolCalls);
     try {
       deps.onCompletionFinished?.({
         usage: runUsage,

--- a/packages/server/src/routes/completions/tool-mapping.test.ts
+++ b/packages/server/src/routes/completions/tool-mapping.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { persistAssistantMessage } from "./tool-mapping.js";
+
+function fakeStore() {
+  return { updateMessage: vi.fn().mockResolvedValue(true) };
+}
+
+describe("persistAssistantMessage", () => {
+  it("no-ops when the session is not tracked", async () => {
+    const store = fakeStore();
+    await persistAssistantMessage(undefined, "s1", "m1", "hi", []);
+    await persistAssistantMessage(store, null, "m1", "hi", []);
+    await persistAssistantMessage(store, "s1", undefined, "hi", []);
+    expect(store.updateMessage).not.toHaveBeenCalled();
+  });
+
+  it("persists trimmed final text with the tool calls", async () => {
+    const store = fakeStore();
+    const toolCalls = [{ id: "t1", name: "get_status", arguments: {}, state: "completed" }];
+    await persistAssistantMessage(store, "s1", "m1", "  done  ", toolCalls);
+    expect(store.updateMessage).toHaveBeenCalledWith("s1", "m1", "done", toolCalls);
+  });
+
+  it("falls back to empty string when the model produced no text", async () => {
+    const store = fakeStore();
+    await persistAssistantMessage(store, "s1", "m1", "   ", []);
+    expect(store.updateMessage).toHaveBeenCalledWith("s1", "m1", "", []);
+  });
+
+  it("uses the provided emptyFallback for empty text", async () => {
+    const store = fakeStore();
+    await persistAssistantMessage(store, "s1", "m1", "", [], { emptyFallback: "[Response interrupted]" });
+    expect(store.updateMessage).toHaveBeenCalledWith("s1", "m1", "[Response interrupted]", []);
+  });
+
+  it("redacts vault credentials before persisting", async () => {
+    const store = fakeStore();
+    const toolCalls = [
+      { id: "t1", name: "set_vault_entry", arguments: { service: "smtp", credentials: { password: "s3cret", user: "bob" } } },
+    ];
+    await persistAssistantMessage(store, "s1", "m1", "saved", toolCalls);
+    const persisted = store.updateMessage.mock.calls[0]![3];
+    expect(persisted[0].arguments.credentials).toEqual({ password: "[REDACTED]", user: "[REDACTED]" });
+    // original must not be mutated
+    expect(toolCalls[0]!.arguments.credentials.password).toBe("s3cret");
+  });
+});

--- a/packages/server/src/routes/completions/tool-mapping.ts
+++ b/packages/server/src/routes/completions/tool-mapping.ts
@@ -58,6 +58,30 @@ export function redactVaultToolCalls(toolCalls: any[]): any[] {
   });
 }
 
+/**
+ * Persist a completed assistant turn to the chat session — the single
+ * projection of a finished LLM turn onto `Session.Message`, shared by the
+ * chat handler (streaming + non-streaming) and the project-loop runner
+ * instead of being copy-pasted at each finally block.
+ *
+ * Redacts vault credentials from the tool calls before writing, and falls
+ * back to `emptyFallback` (default "") when the model produced no text.
+ * No-op when the session isn't tracked (no store / sessionId / messageId).
+ */
+export async function persistAssistantMessage(
+  sessionStore: any,
+  sessionId: string | null | undefined,
+  messageId: string | null | undefined,
+  finalText: string,
+  toolCalls: any[],
+  opts?: { emptyFallback?: string },
+): Promise<void> {
+  if (!sessionStore || !sessionId || !messageId) return;
+  const safeToolCalls = redactVaultToolCalls(toolCalls);
+  const content = finalText.trim() || (opts?.emptyFallback ?? "");
+  await sessionStore.updateMessage(sessionId, messageId, content, safeToolCalls);
+}
+
 export function indexToolResultsByCallId(toolResults: any[] | undefined): Map<string, any> {
   const indexed = new Map<string, any>();
   for (const result of toolResults ?? []) {


### PR DESCRIPTION
The `ModelMessage → Session.Message` projection (redact vault tool calls → `updateMessage` with empty-text fallback) was **copy-pasted in 4 finally blocks**: chat-handler streaming + non-streaming, and project-loop-runner (two paths).

Extracted **one `persistAssistantMessage()` helper** in `tool-mapping.ts`, called from all four sites. **Behavior-preserving** — each site keeps its exact trim + empty-text fallback semantics (`""` for streaming/loop, `"[Response interrupted]"` for non-streaming). +5 unit tests.

No schema/DB change. Part of the state-layer cleanup: this is the *code* dedup — the `runs`/`loop_runs` tables stay separate (legitimately different execution shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)