### PR TITLE
feat(core): SandboxProvider port (F0 of sandbox-provider extraction)

### DIFF
--- a/packages/core/src/__tests__/sandbox-provider.test.ts
+++ b/packages/core/src/__tests__/sandbox-provider.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import type {
+  SandboxProvider,
+  SandboxSession,
+  SandboxLifecycle,
+  SandboxUsage,
+} from "../sandbox-provider.js";
+import type { FileSystem } from "../filesystem.js";
+import type { Shell } from "../shell.js";
+
+// Minimal stubs — the port composition is what's under test, not the full
+// FileSystem/Shell surface, so those are cast from empty objects.
+const fs = {} as FileSystem;
+const shell = {} as Shell;
+
+/** A fake provider that exercises every optional capability of the port. */
+function fakeProvider(): { provider: SandboxProvider; disposed: () => boolean } {
+  let ms = 0;
+  let live = true;
+  const lifecycle: SandboxLifecycle = {
+    suspend: vi.fn(async () => {}),
+    resume: vi.fn(async () => {}),
+  };
+  const provider: SandboxProvider = {
+    open(runId): SandboxSession {
+      return {
+        fs,
+        shell,
+        lifecycle,
+        usage(): SandboxUsage {
+          return { runId, projectId: "p1", acquired: 1000, sandboxMs: (ms += 5), sandboxId: "sb-1" };
+        },
+        async dispose() {
+          live = false;
+        },
+      };
+    },
+  };
+  return { provider, disposed: () => !live };
+}
+
+describe("SandboxProvider port", () => {
+  it("opens a session exposing fs + shell", async () => {
+    const { provider } = fakeProvider();
+    const session = await provider.open("run-1");
+    expect(session.fs).toBe(fs);
+    expect(session.shell).toBe(shell);
+  });
+
+  it("supports the optional lifecycle (suspend/resume)", async () => {
+    const { provider } = fakeProvider();
+    const session = await provider.open("run-1");
+    await session.lifecycle?.suspend();
+    await session.lifecycle?.resume();
+    expect(session.lifecycle!.suspend).toHaveBeenCalledOnce();
+    expect(session.lifecycle!.resume).toHaveBeenCalledOnce();
+  });
+
+  it("reports running-time usage with the billable shape", async () => {
+    const { provider } = fakeProvider();
+    const session = await provider.open("run-42");
+    const u = session.usage!();
+    expect(u).toMatchObject({ runId: "run-42", projectId: "p1", sandboxId: "sb-1" });
+    expect(typeof u.sandboxMs).toBe("number");
+    expect(typeof u.acquired).toBe("number");
+  });
+
+  it("disposes the session", async () => {
+    const { provider, disposed } = fakeProvider();
+    const session = await provider.open("run-1");
+    expect(disposed()).toBe(false);
+    await session.dispose();
+    expect(disposed()).toBe(true);
+  });
+
+  it("allows a minimal session without lifecycle/usage (both optional)", async () => {
+    const provider: SandboxProvider = {
+      open: () => ({ fs, shell, dispose: async () => {} }),
+    };
+    const session = await provider.open("run-1");
+    expect(session.lifecycle).toBeUndefined();
+    expect(session.usage).toBeUndefined();
+    await session.dispose();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,14 @@ export type { Shell, ShellOptions, ShellResult } from "./shell.js";
 export type { Spawner, SpawnResult } from "./spawner.js";
 export { resolveExecutionMode } from "./execution-mode.js";
 
+// ── SandboxProvider Abstraction ──────────────────────────────────────────
+export type {
+  SandboxProvider,
+  SandboxSession,
+  SandboxLifecycle,
+  SandboxUsage,
+} from "./sandbox-provider.js";
+
 // ── Agent Prompt Builder ────────────────────────────────────────────────
 export {
   buildAgentSystemPrompt,

--- a/packages/core/src/sandbox-provider.ts
+++ b/packages/core/src/sandbox-provider.ts
@@ -1,0 +1,71 @@
+/**
+ * SandboxProvider — the port that opens an isolated execution environment
+ * (filesystem + shell) for a single run.
+ *
+ * A provider is backed by whatever the host chooses: the local machine, a
+ * Docker container, a Daytona sandbox, a remote microVM, … The proxy
+ * execution model keeps the agent loop in the host process and drives tools
+ * through the session's `fs`/`shell`, so a run is portable across backends
+ * without touching the loop.
+ *
+ * Pure port: types only, no runtime dependencies. Adapters live in the host
+ * packages (node for local/docker, a dedicated package for daytona, the
+ * cloud for proprietary backends).
+ */
+import type { FileSystem } from "./filesystem.js";
+import type { Shell } from "./shell.js";
+
+export interface SandboxProvider {
+  /**
+   * Open a session for `runId`. Returns synchronously or asynchronously
+   * depending on the backend (the local provider is sync; a remote sandbox
+   * resolves after acquisition).
+   */
+  open(runId: string): SandboxSession | Promise<SandboxSession>;
+}
+
+/**
+ * A live execution environment for one run: a {@link FileSystem} + a
+ * {@link Shell}, plus optional suspend/resume ({@link SandboxLifecycle}) and
+ * running-time accounting ({@link SandboxUsage}).
+ *
+ * Callers MUST `dispose()` the session when the run ends.
+ */
+export interface SandboxSession {
+  readonly fs: FileSystem;
+  readonly shell: Shell;
+  /**
+   * Optional suspend/resume. When present, the caller may suspend the
+   * sandbox during idle gaps (e.g. while the model is thinking) and resume
+   * it on demand — the basis of running-time billing. Absent for backends
+   * with no meaningful suspend (e.g. the local machine) or with native
+   * per-call suspend that needs no externally-driven lifecycle.
+   */
+  readonly lifecycle?: SandboxLifecycle;
+  /** Running-time accounting for this session, when the backend meters it. */
+  usage?(): SandboxUsage;
+  /** Release the session's resources. Idempotent. */
+  dispose(): Promise<void>;
+}
+
+/**
+ * Suspend/resume for a sandbox session. `suspend()` frees the hot resources
+ * (CPU/RAM) while keeping the filesystem; `resume()` makes it runnable again.
+ * Maps to Daytona stop/start, Docker pause/unpause, and similar primitives.
+ */
+export interface SandboxLifecycle {
+  suspend(): Promise<void>;
+  resume(): Promise<void>;
+}
+
+/** Running-time accounting for a sandbox session — the billable unit. */
+export interface SandboxUsage {
+  runId: string;
+  projectId?: string;
+  /** When the session was first acquired (epoch ms). */
+  acquired: number;
+  /** Total milliseconds the sandbox was actually running (not suspended). */
+  sandboxMs: number;
+  /** Backend sandbox identifier, when applicable. */
+  sandboxId?: string;
+}


### PR DESCRIPTION
**F0** of the sandbox-provider extraction (portability moat). Adds the `SandboxProvider` port to `@polpo-ai/core`:

- `SandboxProvider.open(runId)` → `SandboxSession` (`fs` + `shell` + optional `lifecycle` suspend/resume + optional `usage()` running-time accounting + `dispose()`).
- Pure types, **zero runtime deps**, **additive / non-breaking** — no consumers yet.
- Adapters (local/docker in node, daytona in a dedicated package, proprietary backends in cloud) land in later phases behind this one port; `lifecycle` is optional so native per-call suspend backends don't have to fake a lease.
- +5 composition tests proving the port is implementable (incl. lifecycle-less minimal session).

Foundation for: same agent-directory runs on any backend = the portability differentiator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)