### PR TITLE
chore(tools,core): drop AgentTool* fossil aliases + pi-ai comments

### DIFF
--- a/packages/core/src/agent-prompt.ts
+++ b/packages/core/src/agent-prompt.ts
@@ -1,7 +1,7 @@
 /**
  * Build the system prompt for an agent.
  *
- * Pure logic — no runtime dependencies (Node.js, pi-ai, filesystem).
+ * Pure logic — no runtime dependencies (Node.js, filesystem).
  * Used by any runtime (self-hosted or managed).
  *
  * Includes: preamble, identity, responsibilities, tone, personality, hierarchy,

--- a/packages/core/src/context-compactor.ts
+++ b/packages/core/src/context-compactor.ts
@@ -163,7 +163,7 @@ function estimateMessageTokens(msg: any): number {
       if (block.type === "text" && typeof block.text === "string") {
         tokens += estimateTokens(block.text);
       } else if (block.type === "toolCall") {
-        // Legacy (pi-ai) tool call: name + stringified arguments
+        // Legacy tool call: name + stringified arguments
         if (block.name) tokens += estimateTokens(block.name);
         if (block.arguments !== undefined) {
           const args =
@@ -222,7 +222,7 @@ export function pruneToolOutputs(
     blockIndex?: number; // for array content within toolResult messages
     tokens: number;
     toolName: string;
-    /** Message shape: legacy pi-ai "toolResult" text blocks vs AI SDK v6
+    /** Message shape: legacy "toolResult" text blocks vs AI SDK v6
      *  role:"tool" tool-result parts. Determines how pruning is applied. */
     shape: "legacy" | "v6";
   }

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -7,7 +7,7 @@ import type { LoopConfig, LoopToolChoice, Pipeline } from "../loop/types.js";
 
 // === Reasoning / Thinking ===
 
-/** Reasoning level for LLM calls (maps to pi-ai ThinkingLevel). */
+/** Reasoning level for LLM calls (maps to the provider's thinking/reasoning level). */
 export type ReasoningLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
 // === Agent Identity & Vault ===

--- a/packages/node/src/__tests__/helpers/mock-llm.ts
+++ b/packages/node/src/__tests__/helpers/mock-llm.ts
@@ -206,7 +206,7 @@ export function mockResolvedModel(aiModel?: MockLanguageModelV3): ResolvedModel 
 
 // ── Legacy API compatibility ──────────────────────────
 // Keep the same exported function names used by the old tests where possible,
-// but return AI SDK types instead of pi-ai types.
+// but return AI SDK types instead of the legacy types.
 
 /** Create a text response — returns a MockLanguageModelV3. */
 export function mockTextResponse(text: string): MockLanguageModelV3 {

--- a/packages/tools/src/audio-tools.ts
+++ b/packages/tools/src/audio-tools.ts
@@ -17,7 +17,7 @@
 
 import { resolve, dirname, extname } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { PolpoTool, ToolResult as CoreToolResult } from "@polpo-ai/core";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import type { Shell } from "@polpo-ai/core";
 import {
@@ -29,7 +29,7 @@ import {
 import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import { NodeShell } from "./adapters/node-shell.js";
 
-type ToolResult = AgentToolResult<any>;
+type ToolResult = CoreToolResult<any>;
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 import type { ResolvedVault } from "./types.js";
 import {

--- a/packages/tools/src/browser-tools.ts
+++ b/packages/tools/src/browser-tools.ts
@@ -20,7 +20,7 @@
 
 import { resolve, dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { PolpoTool, ToolResult } from "@polpo-ai/core";
 import type { Shell } from "@polpo-ai/core";
 import { NodeShell } from "./adapters/node-shell.js";
 
@@ -95,7 +95,7 @@ async function execBrowserAsync(
   }
 }
 
-function browserResult(result: { success: boolean; data?: any; error?: string; raw: string }): AgentToolResult<any> {
+function browserResult(result: { success: boolean; data?: any; error?: string; raw: string }): ToolResult<any> {
   if (!result.success) {
     return {
       content: [{ type: "text", text: `Browser error: ${result.error ?? result.raw}` }],

--- a/packages/tools/src/docx-tools.ts
+++ b/packages/tools/src/docx-tools.ts
@@ -11,7 +11,7 @@
 
 import { resolve, dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { PolpoTool, ToolResult } from "@polpo-ai/core";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";

--- a/packages/tools/src/excel-tools.ts
+++ b/packages/tools/src/excel-tools.ts
@@ -14,7 +14,7 @@
 
 import { resolve, dirname, extname } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { PolpoTool, ToolResult } from "@polpo-ai/core";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import { NodeFileSystem } from "./adapters/node-filesystem.js";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
@@ -137,7 +137,7 @@ async function readCsvFile(
   delimiter: string,
   hasHeaders: boolean,
   maxRows: number,
-): Promise<AgentToolResult<any>> {
+): Promise<ToolResult<any>> {
   const raw = await fs.readFile(filePath);
   const lines = raw.split("\n").filter(l => l.trim());
 

--- a/packages/tools/src/http-tools.ts
+++ b/packages/tools/src/http-tools.ts
@@ -12,7 +12,7 @@
 
 import { resolve, dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { PolpoTool, ToolResult } from "@polpo-ai/core";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 import { assertUrlAllowed } from "./ssrf-guard.js";

--- a/packages/tools/src/image-tools.ts
+++ b/packages/tools/src/image-tools.ts
@@ -18,7 +18,7 @@
 
 import { resolve, dirname, extname } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { PolpoTool, ToolResult as CoreToolResult } from "@polpo-ai/core";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import {
   parseModelString,
@@ -41,7 +41,7 @@ import {
   type VisionProviderName,
 } from "./lib/provider-resolver.js";
 
-type ToolResult = AgentToolResult<any>;
+type ToolResult = CoreToolResult<any>;
 
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB
 

--- a/packages/tools/src/pdf-tools.ts
+++ b/packages/tools/src/pdf-tools.ts
@@ -16,7 +16,7 @@ import { resolve, dirname } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, ToolResult as AgentToolResult } from "@polpo-ai/core";
+import type { PolpoTool, ToolResult } from "@polpo-ai/core";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import type { Shell } from "@polpo-ai/core";
 import { NodeFileSystem } from "./adapters/node-filesystem.js";

--- a/packages/tools/src/search-tools.ts
+++ b/packages/tools/src/search-tools.ts
@@ -8,7 +8,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, SearchProvider, SearchResult } from "@polpo-ai/core";
+import type { PolpoTool, SearchProvider, SearchResult } from "@polpo-ai/core";
 
 const DEFAULT_NUM_RESULTS = 5;
 

--- a/packages/tools/src/system-tools.ts
+++ b/packages/tools/src/system-tools.ts
@@ -11,7 +11,7 @@ import type { Shell } from "@polpo-ai/core/shell";
 // NodeFileSystem and NodeShell are loaded lazily to avoid pulling in
 // node:fs and execa when the consumer provides their own implementations.
 import { Type } from "@sinclair/typebox";
-import type { PolpoTool as PolpoTool, SearchProvider } from "@polpo-ai/core";
+import type { PolpoTool, SearchProvider } from "@polpo-ai/core";
 import { resolveAllowedPaths, assertPathAllowed } from "./path-sandbox.js";
 import { createOutcomeTools as createOutcomeToolsCore } from "./outcome-tools.js";
 import { createHttpTools as createHttpToolsCore, ALL_HTTP_TOOL_NAMES as CORE_HTTP_TOOL_NAMES } from "./http-tools.js";


### PR DESCRIPTION
Naming cleanup (assessment v2 residue #2), non-breaking:

- Remove redundant `PolpoTool as PolpoTool` self-alias (9 tool files).
- Rename `ToolResult as AgentToolResult` → `ToolResult` (or `CoreToolResult` where a local `type ToolResult` shadows the import).
- Scrub the last stale `pi-ai` / `pi-agent-core` references from comments.

Tools package typechecks clean. Pure cosmetic — one concept, one name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)