### PR TITLE
fix(files): drop per-file stat N+1 in /roots dirStats

### DIFF
--- a/packages/server/src/routes/files.test.ts
+++ b/packages/server/src/routes/files.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { fileRoutes, type FileRouteDeps } from "./files.js";
+import type { FileSystem, FileEntry } from "@polpo-ai/core";
+
+function makeFs(tree: Record<string, FileEntry[]>) {
+  const stat = vi.fn(async () => ({
+    size: 999, isDirectory: false, isFile: true, modifiedAt: new Date(),
+  }));
+  const fs = {
+    readdirWithTypes: async (p: string) => tree[p] ?? [],
+    readdir: async (p: string) => (tree[p] ?? []).map((e) => e.name),
+    stat,
+  } as unknown as FileSystem;
+  return { fs, stat };
+}
+
+function mount(fs: FileSystem) {
+  const deps: FileRouteDeps = {
+    workDir: "/work",
+    polpoDir: "/polpo",
+    agentWorkDir: "/work",
+    fs,
+    emit: () => {},
+  };
+  return fileRoutes(() => deps);
+}
+
+describe("GET /roots — dirStats size accounting", () => {
+  it("sums sizes from the directory listing without a per-file stat", async () => {
+    const { fs, stat } = makeFs({
+      "/work": [
+        { name: "a.txt", isFile: true, isDirectory: false, size: 10 },
+        { name: "b.txt", isFile: true, isDirectory: false, size: 20 },
+        { name: "sub", isFile: false, isDirectory: true },
+      ],
+      "/work/sub": [{ name: "c.txt", isFile: true, isDirectory: false, size: 5 }],
+      "/polpo": [{ name: "x", isFile: true, isDirectory: false, size: 3 }],
+    });
+
+    const res = await mount(fs).request("/roots");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    const ws = body.data.roots.find((r: any) => r.id === "workspace");
+    const polpo = body.data.roots.find((r: any) => r.id === "polpo");
+
+    expect(ws).toMatchObject({ totalFiles: 3, totalSize: 35 }); // 10 + 20 + 5
+    expect(polpo).toMatchObject({ totalFiles: 1, totalSize: 3 });
+    // The whole point of the fix: no N+1 HeadObject storm.
+    expect(stat).not.toHaveBeenCalled();
+  });
+
+  it("falls back to fs.stat when the listing carries no size", async () => {
+    const { fs, stat } = makeFs({
+      "/work": [{ name: "a.txt", isFile: true, isDirectory: false }], // no size
+      "/polpo": [],
+    });
+
+    const res = await mount(fs).request("/roots");
+    expect(res.status).toBe(200);
+    expect(stat).toHaveBeenCalledTimes(1); // exactly the one file with no listed size
+  });
+});

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -189,7 +189,15 @@ export function fileRoutes(getDeps: () => FileRouteDeps): OpenAPIHono {
             bytes += sub.bytes;
           } else if (e.isFile) {
             files++;
-            try { bytes += (await fs.stat(full)).size; } catch { /* skip */ }
+            // Prefer the size the directory listing already carries
+            // (readdirWithTypes populates it for S3/R2). Only fall back to a
+            // per-file stat/HeadObject when the listing didn't provide one —
+            // this removes an N+1 HeadObject storm across the whole tree.
+            if (typeof e.size === "number") {
+              bytes += e.size;
+            } else {
+              try { bytes += (await fs.stat(full)).size; } catch { /* skip */ }
+            }
           }
         }
       } catch { /* unreadable dir */ }


### PR DESCRIPTION
`GET /roots` recursively walked the tree calling `fs.stat()` on **every file** to sum bytes — an **N+1 HeadObject storm** on S3/R2 backends — even though `readdirWithTypes` already returns each entry's `size`.

Fix: use `FileEntry.size` when the listing provides it; fall back to `fs.stat` only when it doesn't. Behavior-preserving (same totals), just fewer round-trips. +2 regression tests (no stat when sizes present; exactly-one fallback stat when a size is absent).

Shared OSS server package → benefits self-hosters too. Part of the cloud file-handling cheap wins (the rest — cache-layer, presigned — stay cloud-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)