### PR TITLE
feat(node): SandboxLease + LocalSandboxProvider (F1 of extraction)

### DIFF
--- a/packages/core/src/__tests__/sandbox-provider.test.ts
+++ b/packages/core/src/__tests__/sandbox-provider.test.ts
@@ -28,7 +28,7 @@ function fakeProvider(): { provider: SandboxProvider; disposed: () => boolean } 
         shell,
         lifecycle,
         usage(): SandboxUsage {
-          return { runId, projectId: "p1", acquired: 1000, sandboxMs: (ms += 5), sandboxId: "sb-1" };
+          return { runId, projectId: "p1", acquired: true, sandboxMs: (ms += 5), sandboxId: "sb-1" };
         },
         async dispose() {
           live = false;
@@ -62,7 +62,7 @@ describe("SandboxProvider port", () => {
     const u = session.usage!();
     expect(u).toMatchObject({ runId: "run-42", projectId: "p1", sandboxId: "sb-1" });
     expect(typeof u.sandboxMs).toBe("number");
-    expect(typeof u.acquired).toBe("number");
+    expect(u.acquired).toBe(true);
   });
 
   it("disposes the session", async () => {

--- a/packages/core/src/sandbox-provider.ts
+++ b/packages/core/src/sandbox-provider.ts
@@ -62,9 +62,17 @@ export interface SandboxLifecycle {
 export interface SandboxUsage {
   runId: string;
   projectId?: string;
-  /** When the session was first acquired (epoch ms). */
-  acquired: number;
-  /** Total milliseconds the sandbox was actually running (not suspended). */
+  /**
+   * True when the run actually acquired a sandbox (touched fs/shell). A run
+   * whose loop only reasons/talks never opens a session, so this is false and
+   * `sandboxMs` is 0 — the resource saving the proxy model is built on.
+   */
+  acquired: boolean;
+  /**
+   * Total milliseconds the sandbox was actually RUNNING (not suspended). With
+   * a {@link SandboxLifecycle}, idle gaps (the model thinking) are subtracted;
+   * without one it equals the acquire→release hold. 0 when never acquired.
+   */
   sandboxMs: number;
   /** Backend sandbox identifier, when applicable. */
   sandboxId?: string;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -73,3 +73,8 @@ export { createEmailTools, ALL_EMAIL_TOOL_NAMES } from "@polpo-ai/tools";
 export { createVaultTools, ALL_VAULT_TOOL_NAMES } from "@polpo-ai/tools";
 export { createAudioTools, ALL_AUDIO_TOOL_NAMES } from "@polpo-ai/tools";
 export { createImageTools, ALL_IMAGE_TOOL_NAMES } from "@polpo-ai/tools";
+
+// ── SandboxProvider (F1: lease + local provider) ─────────────────────────
+export { SandboxLease, DEFAULT_IDLE_SUSPEND_MS } from "./sandbox/lease.js";
+export type { SandboxLeaseOptions } from "./sandbox/lease.js";
+export { LocalSandboxProvider } from "./sandbox/local-provider.js";

--- a/packages/node/src/sandbox/lease.test.ts
+++ b/packages/node/src/sandbox/lease.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { SandboxProvider, SandboxSession, SandboxUsage } from "@polpo-ai/core";
+import { SandboxLease } from "./lease.js";
+import { LocalSandboxProvider } from "./local-provider.js";
+
+function fakeProvider(opts: { withLifecycle?: boolean; omitOptional?: boolean } = {}) {
+  const suspend = vi.fn(async () => {});
+  const resume = vi.fn(async () => {});
+  const dispose = vi.fn(async () => {});
+  const readFile = vi.fn(async (p: string) => `content:${p}`);
+  const readdir = vi.fn(async (_p: string) => ["a", "b"]);
+  let opens = 0;
+
+  const fs: any = {
+    readFile,
+    writeFile: vi.fn(async () => {}),
+    exists: vi.fn(async () => true),
+    readdir,
+    mkdir: vi.fn(async () => {}),
+    remove: vi.fn(async () => {}),
+    stat: vi.fn(async () => ({ size: 1, isDirectory: false, isFile: true, modifiedAt: undefined })),
+    rename: vi.fn(async () => {}),
+  };
+  if (!opts.omitOptional) {
+    fs.readdirWithTypes = vi.fn(async () => [{ name: "a", isDirectory: false, isFile: true, size: 3 }]);
+    fs.readFileBuffer = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    fs.writeFileBuffer = vi.fn(async () => {});
+  }
+
+  const provider: SandboxProvider = {
+    open(): SandboxSession {
+      opens++;
+      return {
+        fs,
+        shell: { execute: vi.fn(async () => ({ stdout: "ok", stderr: "", exitCode: 0 })) },
+        lifecycle: opts.withLifecycle ? { suspend, resume } : undefined,
+        dispose,
+      };
+    },
+  };
+  return { provider, suspend, resume, dispose, readFile, readdir, fs, opens: () => opens };
+}
+
+describe("SandboxLease", () => {
+  it("never opens a session when fs/shell are untouched (lazy acquire)", async () => {
+    const onUsage = vi.fn();
+    const { provider, opens } = fakeProvider();
+    const lease = new SandboxLease(provider, "r1", { onUsage, projectId: "p1" });
+    await lease.dispose();
+    expect(opens()).toBe(0);
+    expect(lease.wasAcquired).toBe(false);
+    expect(onUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "r1", projectId: "p1", acquired: false, sandboxMs: 0 }),
+    );
+  });
+
+  it("opens once and delegates fs ops", async () => {
+    const { provider, readFile, opens } = fakeProvider();
+    const lease = new SandboxLease(provider, "r1");
+    expect(await lease.fs.readFile("/x")).toBe("content:/x");
+    expect(await lease.fs.readFile("/y")).toBe("content:/y");
+    expect(opens()).toBe(1); // acquired once, shared
+    expect(readFile).toHaveBeenCalledTimes(2);
+    expect(lease.wasAcquired).toBe(true);
+  });
+
+  it("shares one session + one resume across parallel ops", async () => {
+    const { provider, resume, opens } = fakeProvider({ withLifecycle: true });
+    const lease = new SandboxLease(provider, "r1");
+    await Promise.all([lease.fs.readFile("/a"), lease.fs.readFile("/b"), lease.fs.readFile("/c")]);
+    expect(opens()).toBe(1);
+    expect(resume).not.toHaveBeenCalled(); // already running from acquire
+  });
+
+  it("meters sandboxMs as the acquire→release hold when there is no lifecycle", async () => {
+    const onUsage = vi.fn();
+    let t = 0;
+    const { provider } = fakeProvider(); // no lifecycle
+    const lease = new SandboxLease(provider, "r1", { now: () => t, onUsage });
+    t = 100;
+    await lease.fs.readFile("/a"); // acquires at t=100
+    t = 400;
+    await lease.dispose(); // releases at t=400
+    const usage = onUsage.mock.calls[0]![0] as SandboxUsage;
+    expect(usage.acquired).toBe(true);
+    expect(usage.sandboxMs).toBe(300);
+  });
+
+  it("disposes the underlying session and is idempotent", async () => {
+    const onUsage = vi.fn();
+    const { provider, dispose } = fakeProvider();
+    const lease = new SandboxLease(provider, "r1", { onUsage });
+    await lease.fs.readFile("/a");
+    await lease.dispose();
+    await lease.dispose(); // second call = no-op
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(onUsage).toHaveBeenCalledTimes(1);
+  });
+
+  describe("optional method fallbacks (backend without them)", () => {
+    it("falls back readdirWithTypes → readdir, buffers → string", async () => {
+      const { provider, readdir } = fakeProvider({ omitOptional: true });
+      const lease = new SandboxLease(provider, "r1");
+      const entries = await lease.fs.readdirWithTypes!("/d");
+      expect(readdir).toHaveBeenCalled();
+      expect(entries).toEqual([
+        { name: "a", isDirectory: false, isFile: true },
+        { name: "b", isDirectory: false, isFile: true },
+      ]);
+      const buf = await lease.fs.readFileBuffer!("/f");
+      expect(new TextDecoder().decode(buf)).toBe("content:/f");
+    });
+  });
+
+  describe("idle suspend/resume", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("suspends after idle, resumes on next op, and excludes the idle gap from sandboxMs", async () => {
+      const onUsage = vi.fn();
+      let t = 0;
+      const { provider, suspend, resume } = fakeProvider({ withLifecycle: true });
+      const lease = new SandboxLease(provider, "r1", { now: () => t, onUsage, idleSuspendMs: 1000 });
+
+      await lease.fs.readFile("/a"); // acquires + runs at t=0; op ends → idle armed
+      t = 200; // it ran 200ms of active work
+      await vi.advanceTimersByTimeAsync(1000); // idle fires → suspend at t=200
+      expect(suspend).toHaveBeenCalledTimes(1);
+
+      t = 5000; // 4800ms of "model thinking" while suspended
+      await lease.fs.readFile("/b"); // resumes at t=5000
+      expect(resume).toHaveBeenCalledTimes(1);
+      t = 5100; // 100ms more active work
+      await lease.dispose();
+
+      const usage = onUsage.mock.calls[0]![0] as SandboxUsage;
+      // 200ms (before suspend) + 100ms (after resume) = 300ms; the 4800ms gap excluded
+      expect(usage.sandboxMs).toBe(300);
+    });
+  });
+});
+
+describe("LocalSandboxProvider", () => {
+  it("opens a session with a real fs + shell, no lifecycle, no-op dispose", async () => {
+    const session = new LocalSandboxProvider().open("r1");
+    expect(typeof session.fs.readFile).toBe("function");
+    expect(typeof session.shell.execute).toBe("function");
+    expect(session.lifecycle).toBeUndefined();
+    await session.dispose(); // must not throw
+  });
+
+  it("under a lease never suspends (behaves like today's local execution)", async () => {
+    const onUsage = vi.fn();
+    const lease = new SandboxLease(new LocalSandboxProvider(), "r1", { onUsage });
+    // A real shell op — the local machine actually runs it.
+    const res = await lease.shell.execute("echo hi");
+    expect(res.stdout.trim()).toBe("hi");
+    await lease.dispose();
+    expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({ acquired: true }));
+  });
+});

--- a/packages/node/src/sandbox/lease.ts
+++ b/packages/node/src/sandbox/lease.ts
@@ -1,0 +1,229 @@
+/**
+ * SandboxLease — a per-run lease over a {@link SandboxProvider} that adds the
+ * three things the proxy execution model needs on top of a raw session:
+ *
+ *  - LAZY ACQUIRE: the session opens on the first fs/shell operation, so a run
+ *    whose loop only reasons/talks never opens one (nothing to bill).
+ *  - INTRA-RUN SUSPEND: a refcount tracks in-flight fs/shell ops; when it hits
+ *    zero the compute is suspended after `idleSuspendMs` (the model is
+ *    thinking), and resumed on the next op. Parallel ops share one sandbox and
+ *    one resume, and it is never suspended mid-operation. No-op when the
+ *    session has no {@link SandboxLifecycle} (e.g. the local machine).
+ *  - METERING: the acquire→release window minus suspended gaps is the run's
+ *    real sandbox-milliseconds, emitted once via `onUsage` on dispose.
+ *
+ * This generalises the cloud's Sandbox-object lease to the {@link FileSystem}
+ * and {@link Shell} ports, so any backend (local, docker, daytona, remote)
+ * gets the same behaviour behind one port.
+ */
+import type {
+  FileSystem,
+  Shell,
+  FileEntry,
+  SandboxProvider,
+  SandboxSession,
+  SandboxLifecycle,
+  SandboxUsage,
+} from "@polpo-ai/core";
+
+/** Default idle window before an unused sandbox's compute is suspended. */
+export const DEFAULT_IDLE_SUSPEND_MS = 1500;
+
+export interface SandboxLeaseOptions {
+  /** Clock injection for testing. */
+  now?: () => number;
+  /** Called once on dispose with the run's sandbox usage. */
+  onUsage?: (usage: SandboxUsage) => void;
+  /** Idle window (ms) before suspending compute. Default 1500. */
+  idleSuspendMs?: number;
+  /** Project id propagated into the emitted usage. */
+  projectId?: string;
+}
+
+export class SandboxLease {
+  private sessionPromise: Promise<SandboxSession> | null = null;
+  private session: SandboxSession | null = null;
+  private lifecycle?: SandboxLifecycle;
+  private acquired = false;
+
+  private inFlight = 0;
+  private running = false;
+  private runningSince = 0;
+  private runningMs = 0;
+
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private resumeLock: Promise<void> | null = null;
+  private released = false;
+
+  private readonly now: () => number;
+  private readonly onUsage?: (usage: SandboxUsage) => void;
+  private readonly idleSuspendMs: number;
+  private readonly projectId?: string;
+
+  /** Activity-wrapped filesystem — hand this to the in-process tool ports. */
+  readonly fs: FileSystem;
+  /** Activity-wrapped shell — hand this to the in-process tool ports. */
+  readonly shell: Shell;
+
+  constructor(
+    private readonly provider: SandboxProvider,
+    private readonly runId: string,
+    opts: SandboxLeaseOptions = {},
+  ) {
+    this.now = opts.now ?? (() => Date.now());
+    this.onUsage = opts.onUsage;
+    this.idleSuspendMs = opts.idleSuspendMs ?? DEFAULT_IDLE_SUSPEND_MS;
+    this.projectId = opts.projectId;
+    this.fs = this.makeFs();
+    this.shell = this.makeShell();
+  }
+
+  /** Whether the run ever opened a session. */
+  get wasAcquired(): boolean {
+    return this.acquired;
+  }
+
+  // ── session lifecycle ──────────────────────────────────────────────────
+
+  private ensureSession(): Promise<SandboxSession> {
+    if (!this.sessionPromise) {
+      this.sessionPromise = Promise.resolve(this.provider.open(this.runId)).then((s) => {
+        this.session = s;
+        this.lifecycle = s.lifecycle;
+        this.acquired = true;
+        this.running = true;
+        this.runningSince = this.now();
+        return s;
+      });
+    }
+    return this.sessionPromise;
+  }
+
+  /** Release the sandbox and emit usage. Idempotent. */
+  async dispose(): Promise<void> {
+    if (this.released) return;
+    this.released = true;
+    this.clearIdle();
+    if (this.running) {
+      this.runningMs += this.now() - this.runningSince;
+      this.running = false;
+    }
+    let sandboxId: string | undefined;
+    if (this.session) {
+      try { sandboxId = this.session.usage?.().sandboxId; } catch { /* ignore */ }
+      try { await this.session.dispose(); } catch { /* best-effort */ }
+    }
+    this.onUsage?.({
+      runId: this.runId,
+      projectId: this.projectId,
+      acquired: this.acquired,
+      sandboxMs: this.acquired ? Math.max(0, this.runningMs) : 0,
+      sandboxId,
+    });
+  }
+
+  // ── activity tracking ──────────────────────────────────────────────────
+
+  private async activityStart(): Promise<void> {
+    this.clearIdle();
+    this.inFlight++;
+    if (!this.running) await this.ensureRunning();
+  }
+
+  private activityEnd(): void {
+    this.inFlight = Math.max(0, this.inFlight - 1);
+    if (this.inFlight === 0) this.armIdle();
+  }
+
+  /** Resume the compute on demand; a single resume is shared by parallel ops. */
+  private async ensureRunning(): Promise<void> {
+    if (this.running || !this.lifecycle) return;
+    if (!this.resumeLock) {
+      const lc = this.lifecycle;
+      this.resumeLock = lc.resume().then(() => {
+        this.running = true;
+        this.runningSince = this.now();
+        this.resumeLock = null;
+      });
+    }
+    await this.resumeLock;
+  }
+
+  private armIdle(): void {
+    if (!this.lifecycle || this.released) return;
+    this.clearIdle();
+    this.idleTimer = setTimeout(() => { void this.suspend(); }, this.idleSuspendMs);
+    // Never keep the process alive just to suspend an idle sandbox.
+    (this.idleTimer as { unref?: () => void }).unref?.();
+  }
+
+  private clearIdle(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  private async suspend(): Promise<void> {
+    if (this.inFlight > 0 || !this.running || !this.lifecycle || this.released) return;
+    this.running = false;
+    this.runningMs += this.now() - this.runningSince;
+    try {
+      await this.lifecycle.suspend();
+    } catch {
+      // Suspend failed — treat as still running so metering stays honest and
+      // the next op doesn't try to resume an already-running sandbox.
+      this.running = true;
+      this.runningSince = this.now();
+    }
+  }
+
+  /** Open (lazily), bracket a fs/shell op with the refcount, and run it. */
+  private async bracket<T>(op: (s: SandboxSession) => Promise<T>): Promise<T> {
+    const session = await this.ensureSession();
+    await this.activityStart();
+    try {
+      return await op(session);
+    } finally {
+      this.activityEnd();
+    }
+  }
+
+  // ── activity-wrapped ports ──────────────────────────────────────────────
+  // The optional FileSystem methods are always present on the lease (callers
+  // may feature-detect them) and fall back to the required methods when the
+  // backend doesn't implement them — same fallbacks the file routes use.
+
+  private makeFs(): FileSystem {
+    const enc = new TextEncoder();
+    const dec = new TextDecoder();
+    return {
+      readFile: (p) => this.bracket((s) => s.fs.readFile(p)),
+      writeFile: (p, c) => this.bracket((s) => s.fs.writeFile(p, c)),
+      exists: (p) => this.bracket((s) => s.fs.exists(p)),
+      readdir: (p) => this.bracket((s) => s.fs.readdir(p)),
+      mkdir: (p) => this.bracket((s) => s.fs.mkdir(p)),
+      remove: (p) => this.bracket((s) => s.fs.remove(p)),
+      stat: (p) => this.bracket((s) => s.fs.stat(p)),
+      rename: (o, n) => this.bracket((s) => s.fs.rename(o, n)),
+      readdirWithTypes: (p) => this.bracket((s) =>
+        s.fs.readdirWithTypes
+          ? s.fs.readdirWithTypes(p)
+          : s.fs.readdir(p).then((names: string[]): FileEntry[] =>
+              names.map((name: string) => ({ name, isDirectory: false, isFile: true }))),
+      ),
+      readFileBuffer: (p) => this.bracket((s) =>
+        s.fs.readFileBuffer ? s.fs.readFileBuffer(p) : s.fs.readFile(p).then((t: string) => enc.encode(t)),
+      ),
+      writeFileBuffer: (p, d) => this.bracket((s) =>
+        s.fs.writeFileBuffer ? s.fs.writeFileBuffer(p, d) : s.fs.writeFile(p, dec.decode(d)),
+      ),
+    };
+  }
+
+  private makeShell(): Shell {
+    return {
+      execute: (cmd, opts) => this.bracket((s) => s.shell.execute(cmd, opts)),
+    };
+  }
+}

--- a/packages/node/src/sandbox/local-provider.ts
+++ b/packages/node/src/sandbox/local-provider.ts
@@ -1,0 +1,26 @@
+/**
+ * LocalSandboxProvider — runs a session directly on the host machine.
+ *
+ * The default provider for self-hosted mode: a session is just the real
+ * {@link NodeFileSystem} + {@link NodeShell}, with NO lifecycle (the local
+ * machine has no meaningful suspend) and NO metering. Under a
+ * {@link SandboxLease} this means the lease never suspends and behaves exactly
+ * as running the tools directly — i.e. identical to today's local execution.
+ */
+import type { SandboxProvider, SandboxSession } from "@polpo-ai/core";
+import { NodeFileSystem } from "../adapters/node-filesystem.js";
+import { NodeShell } from "../adapters/node-shell.js";
+
+export class LocalSandboxProvider implements SandboxProvider {
+  open(_runId: string): SandboxSession {
+    return {
+      fs: new NodeFileSystem(),
+      shell: new NodeShell(),
+      // no lifecycle → the lease never suspends (nothing to suspend locally)
+      // no usage()   → nothing metered locally
+      async dispose() {
+        /* nothing to release on the local machine */
+      },
+    };
+  }
+}


### PR DESCRIPTION
**F1** of the sandbox-provider extraction — the delicate phase, but `default=local` keeps it **functionally identical to today**.

Generalises the cloud's Sandbox-object lease to the `FileSystem`/`Shell` ports:

- **`SandboxLease`** — per-run lease over a `SandboxProvider`:
  - **lazy acquire**: a run that never touches fs/shell never opens a session (nothing to bill),
  - **refcount**: parallel tool ops share one sandbox + one resume, never suspended mid-op,
  - **idle-suspend** via the session's optional `SandboxLifecycle` (no lifecycle ⇒ never suspends),
  - **metering**: acquire→release minus idle gaps = real sandbox-ms, emitted once on `dispose`,
  - optional fs methods (`readdirWithTypes`/`*Buffer`) always present, falling back to the required ones.
- **`LocalSandboxProvider`** — `NodeFileSystem` + `NodeShell`, no lifecycle ⇒ **identical to today's local execution**.
- Align `SandboxUsage.acquired` → `boolean` (matches cloud usage semantics).

Additive, **non-breaking** (no consumers wired yet — selection wiring lands with later phases). **+9 tests** incl. idle suspend/resume with an injected clock (verifies the idle gap is excluded from sandbox-ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)