### PR TITLE
feat(node): ShellBackedFileSystem — FileSystem over any Shell (F3)

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -73,8 +73,8 @@ export { createEmailTools, ALL_EMAIL_TOOL_NAMES } from "@polpo-ai/tools";
 export { createVaultTools, ALL_VAULT_TOOL_NAMES } from "@polpo-ai/tools";
 export { createAudioTools, ALL_AUDIO_TOOL_NAMES } from "@polpo-ai/tools";
 export { createImageTools, ALL_IMAGE_TOOL_NAMES } from "@polpo-ai/tools";
-
 // ── SandboxProvider (F1: lease + local provider) ─────────────────────────
 export { SandboxLease, DEFAULT_IDLE_SUSPEND_MS } from "./sandbox/lease.js";
 export type { SandboxLeaseOptions } from "./sandbox/lease.js";
 export { LocalSandboxProvider } from "./sandbox/local-provider.js";
+export { ShellBackedFileSystem } from "./sandbox/shell-backed-fs.js";

--- a/packages/node/src/sandbox/shell-backed-fs.test.ts
+++ b/packages/node/src/sandbox/shell-backed-fs.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ShellBackedFileSystem } from "./shell-backed-fs.js";
+import { NodeShell } from "../adapters/node-shell.js";
+
+// Integration test: drive ShellBackedFileSystem over a real NodeShell in a
+// temp dir. Exercises the actual base64/find/stat/mkdir coreutils path.
+describe("ShellBackedFileSystem (over NodeShell)", () => {
+  let dir: string;
+  let fs: ShellBackedFileSystem;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "polpo-sbfs-"));
+    fs = new ShellBackedFileSystem(new NodeShell());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("round-trips text via writeFile/readFile", async () => {
+    const p = join(dir, "note.txt");
+    await fs.writeFile(p, "hello 'quoted' & $pecial\nlines");
+    expect(await fs.readFile(p)).toBe("hello 'quoted' & $pecial\nlines");
+  });
+
+  it("round-trips binary via writeFileBuffer/readFileBuffer", async () => {
+    const p = join(dir, "blob.bin");
+    const data = new Uint8Array([0, 1, 2, 255, 254, 10, 13, 0]);
+    await fs.writeFileBuffer(p, data);
+    expect(Array.from(await fs.readFileBuffer(p))).toEqual(Array.from(data));
+  });
+
+  it("mkdir + exists", async () => {
+    const sub = join(dir, "a/b/c");
+    expect(await fs.exists(sub)).toBe(false);
+    await fs.mkdir(sub);
+    expect(await fs.exists(sub)).toBe(true);
+  });
+
+  it("readdir + readdirWithTypes report files and dirs", async () => {
+    await fs.writeFile(join(dir, "f1.txt"), "x");
+    await fs.mkdir(join(dir, "d1"));
+    const names = (await fs.readdir(dir)).sort();
+    expect(names).toEqual(["d1", "f1.txt"]);
+
+    const typed = (await fs.readdirWithTypes(dir)).sort((a, b) => a.name.localeCompare(b.name));
+    expect(typed).toEqual([
+      { name: "d1", isDirectory: true, isFile: false },
+      { name: "f1.txt", isDirectory: false, isFile: true },
+    ]);
+  });
+
+  it("stat reports size + type", async () => {
+    const p = join(dir, "sized.txt");
+    await fs.writeFile(p, "12345"); // 5 bytes
+    const s = await fs.stat(p);
+    expect(s.size).toBe(5);
+    expect(s.isFile).toBe(true);
+    expect(s.isDirectory).toBe(false);
+
+    const ds = await fs.stat(dir);
+    expect(ds.isDirectory).toBe(true);
+  });
+
+  it("rename moves a file", async () => {
+    const a = join(dir, "old.txt");
+    const b = join(dir, "new.txt");
+    await fs.writeFile(a, "data");
+    await fs.rename(a, b);
+    expect(await fs.exists(a)).toBe(false);
+    expect(await fs.readFile(b)).toBe("data");
+  });
+
+  it("remove deletes recursively", async () => {
+    const sub = join(dir, "tree");
+    await fs.mkdir(join(sub, "inner"));
+    await fs.writeFile(join(sub, "inner", "f.txt"), "x");
+    await fs.remove(sub);
+    expect(await fs.exists(sub)).toBe(false);
+  });
+
+  it("stat on a missing path throws", async () => {
+    await expect(fs.stat(join(dir, "nope"))).rejects.toThrow();
+  });
+});

--- a/packages/node/src/sandbox/shell-backed-fs.ts
+++ b/packages/node/src/sandbox/shell-backed-fs.ts
@@ -1,0 +1,104 @@
+/**
+ * ShellBackedFileSystem — a {@link FileSystem} implemented entirely over a
+ * {@link Shell}. Metadata ops map to coreutils (`test`, `mkdir`, `rm`, `mv`,
+ * `ls`, `find`, `stat`); data ops move bytes through `base64` so binary content
+ * survives the shell round-trip.
+ *
+ * This is the reusable core of any shell-only sandbox backend (Docker `exec`,
+ * a remote VM's `run`, …): give it a Shell and it becomes a full FileSystem,
+ * no backend-specific file API required. Backends with a native file-transfer
+ * primitive (Daytona `fs.uploadFile`, Arker `sync`) should override the data
+ * ops for efficiency; this class is the portable fallback.
+ *
+ * Assumes GNU coreutils (`find -printf`, `stat -c`) — i.e. a Linux container,
+ * which is the case for every sandbox backend. `base64`-over-argv also caps the
+ * practical single-file size at the shell's ARG_MAX; large binaries want a
+ * native transfer primitive.
+ */
+import type { FileSystem, FileEntry, FileStat, Shell } from "@polpo-ai/core";
+
+/** Single-quote a string for safe interpolation into a shell command. */
+function shq(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+export class ShellBackedFileSystem implements FileSystem {
+  constructor(private readonly shell: Shell) {}
+
+  async readFile(path: string): Promise<string> {
+    return new TextDecoder().decode(await this.readFileBuffer(path));
+  }
+
+  async readFileBuffer(path: string): Promise<Uint8Array> {
+    const r = await this.shell.execute(`base64 ${shq(path)}`);
+    if (r.exitCode !== 0) throw new Error(`readFile ${path}: ${r.stderr.trim() || "failed"}`);
+    return Uint8Array.from(Buffer.from(r.stdout, "base64"));
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    await this.writeFileBuffer(path, new TextEncoder().encode(content));
+  }
+
+  async writeFileBuffer(path: string, data: Uint8Array): Promise<void> {
+    const b64 = Buffer.from(data).toString("base64");
+    const r = await this.shell.execute(`printf '%s' ${shq(b64)} | base64 -d > ${shq(path)}`);
+    if (r.exitCode !== 0) throw new Error(`writeFile ${path}: ${r.stderr.trim() || "failed"}`);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return (await this.shell.execute(`test -e ${shq(path)}`)).exitCode === 0;
+  }
+
+  async mkdir(path: string): Promise<void> {
+    const r = await this.shell.execute(`mkdir -p ${shq(path)}`);
+    if (r.exitCode !== 0) throw new Error(`mkdir ${path}: ${r.stderr.trim() || "failed"}`);
+  }
+
+  async remove(path: string): Promise<void> {
+    await this.shell.execute(`rm -rf ${shq(path)}`);
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    const r = await this.shell.execute(`mv ${shq(oldPath)} ${shq(newPath)}`);
+    if (r.exitCode !== 0) throw new Error(`rename ${oldPath} → ${newPath}: ${r.stderr.trim() || "failed"}`);
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    const r = await this.shell.execute(`ls -1A ${shq(path)}`);
+    return r.exitCode === 0 ? r.stdout.split("\n").filter(Boolean) : [];
+  }
+
+  async readdirWithTypes(path: string): Promise<FileEntry[]> {
+    // `find` one level deep with a type marker: "d\t<name>" or "f\t<name>".
+    const r = await this.shell.execute(
+      `find ${shq(path)} -mindepth 1 -maxdepth 1 -printf '%y\\t%f\\n' 2>/dev/null`,
+    );
+    if (r.exitCode !== 0) return [];
+    return r.stdout.split("\n").filter(Boolean).map((line) => {
+      const [ty, name] = line.split("\t");
+      const isDirectory = ty === "d";
+      return { name: name ?? "", isDirectory, isFile: !isDirectory };
+    });
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    // Numeric size + mtime (locale-independent), then a d/f type marker via
+    // `test -d`. `stat -c`'s `%F` is localized ("regular file" / "file
+    // regolare") and `-c` does not interpret `\n`, so avoid both. The `&&`
+    // makes a missing path fail (stat's non-zero exit propagates).
+    const p = shq(path);
+    const r = await this.shell.execute(
+      `stat --printf='%s %Y ' ${p} && ( [ -d ${p} ] && echo d || echo f )`,
+    );
+    if (r.exitCode !== 0) throw new Error(`stat ${path}: not found`);
+    const [sizeStr, mtimeStr, kind] = r.stdout.trim().split(/\s+/);
+    const isDirectory = kind === "d";
+    const mtime = Number(mtimeStr);
+    return {
+      size: Number(sizeStr) || 0,
+      isDirectory,
+      isFile: !isDirectory,
+      modifiedAt: Number.isFinite(mtime) ? new Date(mtime * 1000) : undefined,
+    };
+  }
+}


### PR DESCRIPTION
**F3** of the sandbox-provider extraction — the reusable core for shell-only backends.

`ShellBackedFileSystem` implements the full `FileSystem` port over just a `Shell`: metadata via coreutils (`test`/`mkdir`/`rm`/`mv`/`ls`/`find`/`stat`), data via `base64` so binary survives the shell round-trip. Give it a Shell (Docker `exec`, a remote VM `run`) and it's a full FileSystem — no backend-specific file API needed.

Extracted from the cloud `ArkerFileSystem`, with a **locale-independent `stat`** (the template's `%F` is localized and `-c` doesn't interpret `\n`). Additive, non-breaking. **+8 integration tests** over a real `NodeShell`.

Independent of F1 (#128) — branches from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)