### PR TITLE
Release v0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/file-stores/package.json
+++ b/packages/file-stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/file-stores",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "File-based store implementations for Polpo — the default zero-dependency persistence backend (JSON/Markdown files)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/node",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Polpo Node.js runtime — orchestrator wiring, adapters, server assembly, runner entry. The composition root behind the polpo-ai package.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps all packages 0.13.1 → **0.14.0**.

**Sandbox-provider extraction** (the portability foundation) + cleanups shipped since 0.13.1:
- `SandboxProvider` port in core (#125)
- `SandboxLease` + `LocalSandboxProvider` in node (#128)
- `ShellBackedFileSystem` in node (#129)
- persistAssistantMessage projection dedup (#124)
- /roots stat N+1 fix (#127)
- AgentTool*/pi-ai fossil cleanup (#126)

All additive / non-breaking (SandboxProvider has no consumers yet). Minor bump.

After merge: `git tag v0.14.0 && git push --tags` → the release workflow publishes to npm. Unblocks the cloud swap (F4) to consume the portable sandbox ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)