### PR TITLE
refactor(core): unified Run vocabulary (chat/task convergence, F0)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,9 @@ export type {
 // ── Store Interfaces ─────────────────────────────────────────────────────
 export type { TaskStore } from "./task-store.js";
 export type { RunStore, RunRecord, RunStatus } from "./run-store.js";
+// Unified Run — convergence target for chat/task/mission (migration plan F0, additive/unused).
+export type { UnifiedRunStatus, UnifiedRunRecord, RunEngine, RunDelivery } from "./unified-run.js";
+export { isTerminalRunStatus, UNIFIED_RUN_TERMINAL_STATUSES } from "./unified-run.js";
 export type { ConfigStore } from "./config-store.js";
 export type { MemoryStore } from "./memory-store.js";
 export { agentMemoryScope } from "./memory-store.js";

--- a/packages/core/src/unified-run.test.ts
+++ b/packages/core/src/unified-run.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  isTerminalRunStatus,
+  UNIFIED_RUN_TERMINAL_STATUSES,
+  type UnifiedRunStatus,
+  type UnifiedRunRecord,
+} from "./unified-run.js";
+import type { RunStatus, RunRecord } from "./run-store.js";
+import type { ProjectLoopRunStatus, LoopRunRecord } from "./loop/run-store.js";
+
+describe("unified run vocabulary (F0)", () => {
+  it("UnifiedRunStatus is a superset of both run-status vocabularies", () => {
+    // Compile-time proof: a value of either source type is assignable to the
+    // unified type without a cast. If it stopped being a superset, this file
+    // would not typecheck.
+    const fromTask: UnifiedRunStatus = "killed" satisfies RunStatus;
+    const fromLoop: UnifiedRunStatus = "awaiting_approval" satisfies ProjectLoopRunStatus;
+    expect([fromTask, fromLoop]).toEqual(["killed", "awaiting_approval"]);
+  });
+
+  it("terminal check covers terminal states from BOTH paths", () => {
+    expect(isTerminalRunStatus("completed")).toBe(true);
+    expect(isTerminalRunStatus("failed")).toBe(true);
+    expect(isTerminalRunStatus("killed")).toBe(true); // task-only terminal
+    expect(isTerminalRunStatus("cancelled")).toBe(true); // loop-only terminal
+    expect(isTerminalRunStatus("approval_rejected")).toBe(true);
+    // non-terminal
+    expect(isTerminalRunStatus("running")).toBe(false);
+    expect(isTerminalRunStatus("awaiting_approval")).toBe(false);
+    expect(isTerminalRunStatus("resuming")).toBe(false);
+    expect(isTerminalRunStatus("approval_approved")).toBe(false);
+  });
+
+  it("every declared terminal status is a valid unified status", () => {
+    expect(UNIFIED_RUN_TERMINAL_STATUSES.every((s) => isTerminalRunStatus(s))).toBe(true);
+  });
+
+  it("a task RunRecord's fields fit UnifiedRunRecord (engine=agent, delivery=background) with no loss", () => {
+    const task = {
+      id: "r1",
+      taskId: "t1",
+      pid: 123,
+      agentName: "coder",
+      status: "running",
+      startedAt: "2026-07-08T00:00:00Z",
+      updatedAt: "2026-07-08T00:00:00Z",
+      configPath: "db://r1",
+    } satisfies Partial<RunRecord>;
+
+    const unified: UnifiedRunRecord = { ...task, engine: "agent", delivery: "background" };
+    expect(unified.taskId).toBe("t1");
+    expect(unified.pid).toBe(123);
+    expect(unified.delivery).toBe("background");
+  });
+
+  it("a loop LoopRunRecord's fields fit UnifiedRunRecord (engine=graph, delivery=stream) with no loss", () => {
+    const loop = {
+      id: "lr1",
+      loopName: "default",
+      agentName: "chat",
+      status: "awaiting_approval",
+      context: {},
+      trace: [],
+      startedAt: "2026-07-08T00:00:00Z",
+      updatedAt: "2026-07-08T00:00:00Z",
+    } satisfies Partial<LoopRunRecord>;
+
+    const unified: UnifiedRunRecord = { ...loop, engine: "graph", delivery: "stream" };
+    expect(unified.loopName).toBe("default");
+    expect(unified.status).toBe("awaiting_approval");
+    expect(unified.engine).toBe("graph");
+  });
+});

--- a/packages/core/src/unified-run.ts
+++ b/packages/core/src/unified-run.ts
@@ -1,0 +1,100 @@
+/**
+ * Unified Run — the convergence target for chat, task and (later) mission.
+ *
+ * Today the codebase carries three run-shaped records that only overlap by soft
+ * ids: `RunRecord` (task path, run-store.ts), `LoopRunRecord` (chat/loop path,
+ * loop/run-store.ts) and the raw sessions/messages transcript. This module
+ * defines the ONE record they converge onto — the vocabulary for the chat+task
+ * unification (migration plan F0).
+ *
+ * F0 is additive and code-only: nothing consumes these types yet. They pin the
+ * target shape so later phases (route chat through `executeRun`, fold
+ * `loop_runs` into `runs`) migrate toward a single agreed contract instead of
+ * inventing it mid-refactor.
+ *
+ * The chat/task distinction survives as two ORTHOGONAL AXES on one record,
+ * never as two entities:
+ *   - engine:   how a run executes  — "agent" (a trivial single-node loop, i.e.
+ *               plain chat/task) or "graph" (a multi-step project-loop DAG).
+ *   - delivery: how a run is consumed — "stream" (attached over a live SSE, the
+ *               chat surface) or "background" (detached, poll/webhook, the task
+ *               surface).
+ * Every task-only and loop-only field below is OPTIONAL, so a run of either
+ * origin fits without loss — the guarantee that unifying costs no capability.
+ */
+import type { AgentActivity, TaskResult, TaskOutcome, RunnerConfig } from "./types.js";
+import type { RunStatus } from "./run-store.js";
+import type { ContextBag, LoopTraceEvent } from "./loop/types.js";
+import type { LoopResumeState, LoopApprovalSnapshot, ProjectLoopRunStatus } from "./loop/run-store.js";
+
+/**
+ * Superset of both run-status vocabularies. Defined as the union of the two
+ * existing types so it stays in sync automatically: `RunStatus` contributes
+ * "killed", `ProjectLoopRunStatus` contributes the approval/resuming/cancelled
+ * states. A value of either type is assignable to this without a cast.
+ */
+export type UnifiedRunStatus = RunStatus | ProjectLoopRunStatus;
+
+/** How a run executes: a plain turn-loop (chat/task) or a multi-step graph (project loop). */
+export type RunEngine = "agent" | "graph";
+
+/** How a run is consumed: attached over a live stream, or detached in the background. */
+export type RunDelivery = "stream" | "background";
+
+/** Terminal statuses — a run in one of these will not change again. */
+export const UNIFIED_RUN_TERMINAL_STATUSES = [
+  "completed",
+  "failed",
+  "killed",
+  "cancelled",
+  "approval_rejected",
+] as const satisfies readonly UnifiedRunStatus[];
+
+/** True when the status is terminal (covers both the task and loop vocabularies). */
+export function isTerminalRunStatus(status: UnifiedRunStatus): boolean {
+  return (UNIFIED_RUN_TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
+/**
+ * The convergence target for `RunRecord` + `LoopRunRecord`. Common fields are
+ * required; task-origin and loop-origin fields are optional so a run of either
+ * origin fits without loss. Not persisted yet — this is the contract the
+ * migration converges on, not a live store shape.
+ */
+export interface UnifiedRunRecord {
+  // ── identity / common ──
+  id: string;
+  agentName: string;
+  sessionId?: string;
+  user?: string;
+  status: UnifiedRunStatus;
+  startedAt: string;
+  updatedAt: string;
+  completedAt?: string;
+
+  // ── the two axes that replace the chat/task entity split ──
+  engine: RunEngine;
+  delivery: RunDelivery;
+
+  // ── shared durable state (already one format across both paths today) ──
+  resumeState?: LoopResumeState;
+
+  // ── task-origin fields (optional) ──
+  taskId?: string;
+  pid?: number;
+  activity?: AgentActivity;
+  result?: TaskResult;
+  outcomes?: TaskOutcome[];
+  config?: RunnerConfig;
+  configPath?: string;
+  executionMode?: string;
+
+  // ── loop-origin fields (optional) ──
+  loopName?: string;
+  context?: ContextBag;
+  trace?: LoopTraceEvent[];
+  error?: string;
+  approvalRequestId?: string;
+  approval?: LoopApprovalSnapshot;
+  metadata?: Record<string, unknown>;
+}


### PR DESCRIPTION
**F0** of the chat+task run unification — purely additive, code-only, zero behaviour change.

Defines the single record the three run-shaped models (`RunRecord`, `LoopRunRecord`, sessions/messages) converge onto, so later phases migrate toward one agreed contract instead of inventing it mid-refactor:

- `UnifiedRunStatus` = `RunStatus | ProjectLoopRunStatus` (superset, stays in sync automatically)
- `RunEngine` (`agent`|`graph`) + `RunDelivery` (`stream`|`background`) — the two axes that replace the chat/task **entity** split with two **properties**
- `UnifiedRunRecord` — common fields required, every task-/loop-origin field **optional** (zero capability loss)
- `isTerminalRunStatus` + `UNIFIED_RUN_TERMINAL_STATUSES`

Nothing consumes these yet. 5 unit tests, full core suite green (148).

Part of the staged, flag-gated, reversible migration (F0→F3). See migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)