### PR TITLE
refactor(node): optional onEvent stream hook on executeRun (F1a)

### DIFF
--- a/packages/node/src/__tests__/run-lifecycle.test.ts
+++ b/packages/node/src/__tests__/run-lifecycle.test.ts
@@ -175,6 +175,50 @@ describe("executeRun — shared run lifecycle", () => {
     expect(log[0].pid).toBe(4242);
   });
 
+  test("onEvent (F1a): a streaming host receives each transcript entry live, teed alongside persistence", async () => {
+    setMockModel(mockTurnSequenceModel([
+      { type: "tool-call", toolName: "write", args: { path: "ev-a.txt", content: "hi" } },
+      { type: "text", text: "streamed" },
+    ]));
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+    const events: Record<string, unknown>[] = [];
+
+    const outcome = await executeRun(config, {
+      runStore: store,
+      pid: 7,
+      configPath: `memory://${config.runId}`,
+      onEvent: (entry) => events.push(entry),
+    });
+
+    expect(outcome.status).toBe("completed");
+    // onEvent saw the same entry types the activity log persisted — teed, not replaced.
+    const types = events.map((e) => e.type);
+    expect(types).toContain("tool_use");
+    expect(types).toContain("tool_result");
+    expect(types).toContain("assistant");
+    expect(events.find((e) => e.type === "assistant")?.text).toBe("streamed");
+    // Persistence still happened (tee, not replace).
+    const log = await readActivityLog(config.runId);
+    expect(log.map((e) => e.event ?? e.type)).toContain("assistant");
+  });
+
+  test("onEvent (F1a): a throwing subscriber never sinks the run", async () => {
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "resilient" }]));
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+
+    const outcome = await executeRun(config, {
+      runStore: store,
+      pid: 8,
+      configPath: `memory://${config.runId}`,
+      onEvent: () => { throw new Error("subscriber boom"); },
+    });
+
+    expect(outcome.status).toBe("completed");
+    expect(outcome.result.stdout).toBe("resilient");
+  });
+
   test("engine failure: run marked failed, executeRun resolves (never throws)", async () => {
     setMockModel(new MockLanguageModelV3({
       doStream: () => { throw new Error("model exploded"); },

--- a/packages/node/src/core/run-lifecycle.ts
+++ b/packages/node/src/core/run-lifecycle.ts
@@ -125,6 +125,18 @@ export interface ExecuteRunDeps {
   configPath: string;
   /** Abort = graceful kill (subprocess SIGTERM / in-process spawner.kill). */
   signal?: AbortSignal;
+  /**
+   * Live event subscription. Optional and additive: a STREAMING host
+   * (chat-via-executeRun, migration F1) passes this to receive each transcript
+   * entry — assistant text, tool_use, tool_result, loop_trace, error — as the
+   * engine emits it, and map it to SSE. Background hosts (task/subprocess) leave
+   * it undefined, so behaviour is unchanged: it is teed alongside the existing
+   * activity-log / DB-transcript persistence, never in place of it.
+   *
+   * Granularity note: entries arrive per TURN today (whole assistant text in one
+   * entry); token-by-token deltas are a follow-up (F1b, in loop-engine).
+   */
+  onEvent?: (entry: Record<string, unknown>) => void;
 }
 
 export interface ExecuteRunOutcome {
@@ -229,6 +241,9 @@ export async function executeRun(config: RunnerConfig, deps: ExecuteRunDeps): Pr
     }
     // Wire transcript persistence — every agent message gets written to the run log
     handle.onTranscript = (entry) => {
+      // F1a: live subscription for streaming hosts (chat-via-executeRun). Teed
+      // first, best-effort — it must never break persistence below.
+      try { deps.onEvent?.(entry); } catch { /* a subscriber error can't sink the run */ }
       actLog.logTranscript(entry);
       // Persist transcript to DB when a log session is available
       if (logSession) {


### PR DESCRIPTION
**F1a** of routing chat through `executeRun` — additive, zero behaviour change.

Adds an optional `onEvent` callback to `ExecuteRunDeps`. A streaming host can subscribe to each transcript entry (assistant/tool_use/tool_result/loop_trace/error) live and map it to SSE. **Teed** alongside the existing activity-log + DB-transcript persistence (never replacing it), and wrapped so a throwing subscriber can't sink the run.

Background hosts (task/subprocess) leave it undefined ⇒ unchanged. Per-turn granularity today; token deltas come in F1b (loop-engine). **2 tests; full node suite green (1037).**

Next: **F1b** (per-delta emission in loop-engine), then **F1c** (flag + router branch + `handleChatViaExecuteRun` + parity test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)