### PR TITLE
refactor(node): token-level onDelta streaming through executeRun (F1b)

### DIFF
--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -80,4 +80,13 @@ export interface SpawnContext {
    * errors anyway).
    */
   onTurnCheckpoint?: (state: LoopResumeState) => void | Promise<void>;
+  /**
+   * Token-level streaming sink: called for each model text-delta as it arrives,
+   * for hosts that stream token-by-token (chat-via-executeRun, migration F1b).
+   * Kept SEPARATE from onTranscript so per-token deltas reach the live consumer
+   * WITHOUT polluting the turn-granularity transcript persistence. Optional and
+   * additive — background hosts leave it undefined ⇒ no per-delta emission, the
+   * historical whole-turn behaviour. Best-effort; must not throw.
+   */
+  onDelta?: (delta: { text: string }) => void;
 }

--- a/packages/node/src/__tests__/run-lifecycle.test.ts
+++ b/packages/node/src/__tests__/run-lifecycle.test.ts
@@ -219,6 +219,34 @@ describe("executeRun — shared run lifecycle", () => {
     expect(outcome.result.stdout).toBe("resilient");
   });
 
+  test("onDelta (F1b): token deltas reach onEvent as text-delta events, separate from turn transcript & persistence", async () => {
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "hello world" }]));
+    const store = new InMemoryRunStore();
+    const config = makeConfig();
+    const events: Record<string, unknown>[] = [];
+
+    await executeRun(config, {
+      runStore: store,
+      pid: 9,
+      configPath: `memory://${config.runId}`,
+      onEvent: (entry) => events.push(entry),
+    });
+
+    // Token deltas arrived on the same onEvent hook, tagged text-delta.
+    const deltas = events.filter((e) => e.type === "text-delta");
+    expect(deltas.length).toBeGreaterThan(1); // the mock splits text into chunks
+    expect(deltas.map((d) => d.text).join("")).toBe("hello world");
+
+    // The turn-granularity assistant entry is STILL emitted (unchanged path).
+    expect(events.find((e) => e.type === "assistant")?.text).toBe("hello world");
+
+    // Deltas did NOT pollute the persisted activity log — persistence stays
+    // turn-granularity (deltas route via ctx.onDelta, not onTranscript).
+    const log = await readActivityLog(config.runId);
+    expect(log.filter((e) => (e.event ?? e.type) === "text-delta")).toHaveLength(0);
+    expect(log.map((e) => e.event ?? e.type)).toContain("assistant");
+  });
+
   test("engine failure: run marked failed, executeRun resolves (never throws)", async () => {
     setMockModel(new MockLanguageModelV3({
       doStream: () => { throw new Error("model exploded"); },

--- a/packages/node/src/adapters/loop-engine.ts
+++ b/packages/node/src/adapters/loop-engine.ts
@@ -373,6 +373,9 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
         switch (part.type) {
           case "text-delta": {
             stepText += part.text;
+            // F1b: token-level streaming sink (separate from onTranscript, which
+            // stays turn-granularity for persistence). Best-effort.
+            try { ctx?.onDelta?.({ text: part.text }); } catch { /* a delta subscriber can't sink the run */ }
             break;
           }
           case "tool-call": {

--- a/packages/node/src/core/run-lifecycle.ts
+++ b/packages/node/src/core/run-lifecycle.ts
@@ -223,6 +223,15 @@ export async function executeRun(config: RunnerConfig, deps: ExecuteRunDeps): Pr
           await runStore.updateResumeState?.(config.runId, state);
         } catch { /* best effort */ }
       },
+      // F1b: route token deltas to the streaming subscriber as {type:"text-delta"}
+      // events on the SAME onEvent hook as turn events (F1a) — but via ctx.onDelta,
+      // NOT onTranscript, so persistence stays turn-granularity. No-op when no
+      // subscriber is attached (background hosts).
+      onDelta: deps.onEvent
+        ? (delta: { text: string }) => {
+            try { deps.onEvent?.({ type: "text-delta", text: delta.text }); } catch { /* can't sink the run */ }
+          }
+        : undefined,
     };
     handle = spawnLoopEngine(config.agent, config.task, config.cwd, spawnCtx);
     if (config.resumeState) {


### PR DESCRIPTION
**F1b** — per-token streaming through `executeRun`, the prerequisite for chat-via-executeRun (F1c) to match the existing streaming chat handler's token-by-token SSE.

- `core`: optional `SpawnContext.onDelta({ text })` — token sink kept **separate** from `onTranscript` so deltas reach the live consumer without polluting turn-granularity persistence.
- `loop-engine`: emit `ctx.onDelta` on each model `text-delta`.
- `run-lifecycle`: route `ctx.onDelta` → `deps.onEvent` as `{type:'text-delta'}` events on the **same** onEvent hook as F1a — only when a subscriber is attached.

Additive, default-off: no `onEvent` ⇒ no deltas ⇒ unchanged whole-turn behaviour. Test proves deltas reconstruct the text, the turn `assistant` entry still fires, and the persisted log stays delta-free. **Node suite green (1038).**

Next: **F1c** — flag + router branch + `handleChatViaExecuteRun` adapter (maps onEvent → `sseChunk`) + parity test vs chat-handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)