### PR TITLE
refactor: route chat through executeRun (flag + parity, F1c)

### DIFF
--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { AgentActivity, TaskResult, TaskOutcome, ReasoningLevel } from "@polpo-ai/core/types";
+import type { AgentActivity, TaskResult, TaskOutcome, ReasoningLevel, AgentConfig } from "@polpo-ai/core/types";
 import type { VaultStore } from "@polpo-ai/core/vault-store";
 import type { MemoryStore } from "@polpo-ai/core/memory-store";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
@@ -88,5 +88,50 @@ export interface SpawnContext {
    * additive — background hosts leave it undefined ⇒ no per-delta emission, the
    * historical whole-turn behaviour. Best-effort; must not throw.
    */
-  onDelta?: (delta: { text: string }) => void;
+  onDelta?: (delta: { text: string; kind?: "text" | "reasoning" }) => void;
+  /**
+   * Chat-session injection (migration F1c). When set, the engine runs a CHAT
+   * turn loop using these pre-resolved inputs (model/prompt/tools/messages from
+   * the completions route) INSTEAD of resolving from the AgentConfig — so
+   * chat-via-executeRun is at parity with the inline chat handler by
+   * construction. Absent for task/background runs ⇒ the historical path is
+   * byte-identical.
+   */
+  inject?: ChatSessionInjection;
+}
+
+/**
+ * Pre-resolved inputs for running a chat completion through the shared run
+ * lifecycle (F1c). Built server-side from the completions route's already
+ * resolved model/prompt/tools/messages and threaded down through
+ * ExecuteRunDeps → SpawnContext. AI-SDK types are kept opaque (unknown) so core
+ * takes no dependency on `ai`.
+ */
+export interface ChatSessionInjection {
+  /** Resolved agent config (for the RunnerConfig the driver builds). */
+  agent: AgentConfig;
+  /** Optional session title (first user text). */
+  title?: string;
+  /** Resolved model (the same ResolvedModel the engine's prepareSpawn would build). */
+  model: { aiModel: unknown; contextWindow?: number; maxTokens?: number };
+  /** Full system prompt (conversational preamble + agent prompt + memory). */
+  systemPrompt: string;
+  providerOptions?: Record<string, Record<string, unknown>>;
+  maxTurns: number;
+  /** streamText toolChoice, if the route set one. */
+  toolChoice?: unknown;
+  /** Seed conversation (AI-SDK ModelMessage[]). */
+  seedMessages: unknown[];
+  /** AI-SDK ToolSet (declaration-only) fed to streamText. */
+  toolSet: Record<string, unknown>;
+  /** Executes a tool call, returning the string result ("Error:" prefix on failure). */
+  executor: (name: string, args: Record<string, unknown>) => Promise<string>;
+  /** Client-side tool names that interrupt the loop (returned to the caller). */
+  clientSideToolNames: ReadonlySet<string>;
+  /** Provider-executed tool names to record but not dispatch. */
+  providerToolNames: ReadonlySet<string>;
+  /** Tools value used for compaction token estimation — MUST match the chat path. */
+  compactionTools: unknown[];
+  /** Compaction mode ("chat" mirrors the inline handler). */
+  compactionMode: "chat" | "task";
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,7 +151,7 @@ export { buildFixPrompt, buildRetryPrompt, buildSideEffectFixPrompt, buildSideEf
 export { looksLikeQuestion, classifyAsQuestion } from "./question-detector.js";
 
 // ── Adapter Types ────────────────────────────────────────────────────────
-export type { AgentHandle, SpawnContext } from "./adapter.js";
+export type { AgentHandle, SpawnContext, ChatSessionInjection } from "./adapter.js";
 
 // ── Assessment (pure — no Node.js deps) ─────────────────────────────────
 export { assessTask, runCheck, runMetric, type AssessmentDeps, type CheckProgressEvent as AssessorCheckProgressEvent } from "./assessor.js";

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -181,6 +181,12 @@ export interface PolpoSettings {
    *  proxied to the sandbox in later phases). Per-task/per-agent policy
    *  is future work; this is a global opt-in. */
   taskExecution?: ExecutionMode;
+  /** How chat completions execute. Default: "inline" (the hand-rolled turn
+   *  loop in the completions route). "run" routes chat through the shared
+   *  `executeRun` lifecycle + loop-engine (migration F1c) so chat and task
+   *  share one durable engine — behind this flag until parity is validated.
+   *  A global opt-in; the inline path stays the default. */
+  chatExecution?: "inline" | "run";
   /** PostgreSQL connection URL (required when storage is "postgres").
    *  Example: "postgres://user:pass@localhost:5432/polpo" */
   databaseUrl?: string;

--- a/packages/node/src/__tests__/completions-parity.test.ts
+++ b/packages/node/src/__tests__/completions-parity.test.ts
@@ -1,0 +1,147 @@
+/**
+ * F1c parity: chat completions must produce the SAME OpenAI SSE whether they
+ * run through the inline chat-handler (`chatExecution:"inline"`) or through the
+ * shared executeRun lifecycle + loop-engine (`chatExecution:"run"`).
+ *
+ * Drives identical requests under both modes against a mock model and asserts
+ * the streamed content and tool_call event sequence match. Same harness as
+ * completions.test.ts (real Orchestrator + file stores + createApp).
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MockLanguageModelV3 } from "ai/test";
+import { mockResolvedModel, mockTurnSequenceModel } from "./helpers/mock-llm.js";
+import { Orchestrator } from "../core/orchestrator.js";
+
+let activeMockModel: MockLanguageModelV3;
+vi.mock("@polpo-ai/llm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@polpo-ai/llm")>();
+  return {
+    ...actual,
+    resolveModel: () => mockResolvedModel(activeMockModel),
+    resolveModelSpec: (spec: unknown) => spec ?? "mock:mock-model",
+    resolveApiKeyAsync: async () => "mock-api-key",
+    enforceModelAllowlist: () => {},
+    mapReasoningToProviderOptions: () => undefined,
+  };
+});
+
+const POLPO_CONFIG = JSON.stringify({
+  project: "test-parity",
+  team: { name: "test-team", agents: [{ name: "agent-1", role: "Test agent" }] },
+  settings: { logLevel: "quiet" },
+}, null, 2);
+
+let tmpDir: string;
+let app: any;
+let orchestrator: Orchestrator;
+
+function setMockModel(m: MockLanguageModelV3) { activeMockModel = m; }
+function setChatExecution(mode: "inline" | "run") {
+  const cfg = orchestrator.getConfig() as any;
+  cfg.settings = cfg.settings ?? {};
+  cfg.settings.chatExecution = mode;
+}
+
+async function postStream(body: Record<string, unknown>): Promise<Record<string, unknown>[]> {
+  const res = await app.request("/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ agent: "agent-1", stream: true, ...body }),
+  });
+  const text = await res.text();
+  const chunks: Record<string, unknown>[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const data = line.slice(6);
+    if (data === "[DONE]") break;
+    try { chunks.push(JSON.parse(data)); } catch { /* skip */ }
+  }
+  return chunks;
+}
+
+/** Concatenate delta.content across chunks. */
+function content(chunks: Record<string, unknown>[]): string {
+  return chunks.map((ch) => ((ch.choices as any)?.[0]?.delta?.content ?? "")).join("");
+}
+/** Extract the tool_call event states (calling/completed/error) in order. */
+function toolStates(chunks: Record<string, unknown>[]): string[] {
+  return chunks
+    .map((ch) => (ch.choices as any)?.[0]?.tool_call?.state)
+    .filter((s): s is string => typeof s === "string");
+}
+/** The finish_reason of the terminal chunk, if any. */
+function finishReason(chunks: Record<string, unknown>[]): string | undefined {
+  for (let i = chunks.length - 1; i >= 0; i--) {
+    const fr = (chunks[i].choices as any)?.[0]?.finish_reason;
+    if (fr) return fr;
+  }
+  return undefined;
+}
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "polpo-parity-test-"));
+  await mkdir(join(tmpDir, ".polpo"), { recursive: true });
+  await writeFile(join(tmpDir, ".polpo", "polpo.json"), POLPO_CONFIG);
+
+  const { SSEBridge } = await import("../server/sse-bridge.js");
+  const { createApp } = await import("../server/app.js");
+
+  orchestrator = new Orchestrator(tmpDir);
+  await orchestrator.initInteractive("test-parity", {
+    name: "test-team",
+    agents: [{ name: "agent-1", role: "Test agent" }],
+  });
+  const sseBridge = new SSEBridge(orchestrator);
+  sseBridge.start();
+  app = createApp(orchestrator, sseBridge);
+});
+
+afterAll(async () => {
+  if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("F1c parity: inline vs run", () => {
+  it("pure text: streamed content + finish_reason are identical", async () => {
+    const messages = [{ role: "user", content: "Say hello" }];
+
+    setChatExecution("inline");
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "hello from the agent" }]));
+    const inline = await postStream({ messages });
+
+    setChatExecution("run");
+    setMockModel(mockTurnSequenceModel([{ type: "text", text: "hello from the agent" }]));
+    const viaRun = await postStream({ messages });
+
+    expect(content(viaRun)).toBe("hello from the agent");
+    expect(content(viaRun)).toBe(content(inline));
+    expect(finishReason(viaRun)).toBe("stop");
+    expect(finishReason(viaRun)).toBe(finishReason(inline));
+  });
+
+  it("single tool call: content + tool_call event states are identical", async () => {
+    const messages = [{ role: "user", content: "Use a tool" }];
+    const seq = () => mockTurnSequenceModel([
+      { type: "tool-call", toolName: "definitely_not_a_real_tool", args: { x: 1 } },
+      { type: "text", text: "done after the tool" },
+    ]);
+
+    setChatExecution("inline");
+    setMockModel(seq());
+    const inline = await postStream({ messages });
+
+    setChatExecution("run");
+    setMockModel(seq());
+    const viaRun = await postStream({ messages });
+
+    // Same final text.
+    expect(content(viaRun)).toBe("done after the tool");
+    expect(content(viaRun)).toBe(content(inline));
+    // Same tool_call lifecycle (calling → completed/error), same order.
+    expect(toolStates(viaRun)).toEqual(toolStates(inline));
+    expect(toolStates(viaRun)).toContain("calling");
+    expect(finishReason(viaRun)).toBe(finishReason(inline));
+  });
+});

--- a/packages/node/src/adapters/loop-engine.ts
+++ b/packages/node/src/adapters/loop-engine.ts
@@ -63,6 +63,7 @@ import {
   buildAgentTools,
   buildPrompt,
   collectOutcome,
+  type SpawnPrep,
 } from "./spawn-helpers.js";
 
 // ─── Helpers (task-flavored ports of the completions loop runtime) ─────
@@ -276,26 +277,52 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
   }): Promise<{ lastText: string; accumText: string }> {
     const { sessionAgent, loopName, loop, contextPrompt } = options;
     const resume = usableResumeState(options.resume, loopName);
+    const inject = ctx?.inject;
 
-    const prep = prepareSpawn(sessionAgent, cwd, ctx);
-    const { model, providerOptions } = prep;
-    const systemPrompt = contextPrompt
-      ? `${prep.systemPrompt}\n\n${contextPrompt}`
-      : prep.systemPrompt;
-    const maxTurns = loop.maxTurns ?? prep.maxTurns;
-
-    const allPolpoTools = await buildAgentTools(sessionAgent, cwd, prep, ctx);
-    const toolByName = new Map(allPolpoTools.map((t) => [t.name, t]));
-    const toolSet = toToolDeclarations(allPolpoTools);
-    const toolDescriptions = allPolpoTools.map((t) => ({ description: t.description ?? "" }));
+    // Inject path (chat-via-executeRun, F1c): use the completions route's
+    // already-resolved model/prompt/tools/messages instead of re-resolving from
+    // the AgentConfig — parity by construction. Every branch below is
+    // inject-gated so the task path stays byte-identical.
+    let model: SpawnPrep["model"];
+    let providerOptions: SpawnPrep["providerOptions"];
+    let systemPrompt: string;
+    let maxTurns: number;
+    let toolSet: ToolSet;
+    let toolByName = new Map<string, PolpoTool>();
+    // Tools value handed to compaction's token estimator (JSON.stringify'd); MUST
+    // match the chat path's shape so the compaction trigger point is identical.
+    let compactionTools: unknown[];
+    const compactionMode: "chat" | "task" = inject?.compactionMode ?? "task";
+    if (inject) {
+      model = inject.model as unknown as SpawnPrep["model"];
+      providerOptions = inject.providerOptions as SpawnPrep["providerOptions"];
+      systemPrompt = inject.systemPrompt;
+      maxTurns = inject.maxTurns;
+      toolSet = inject.toolSet as ToolSet;
+      compactionTools = inject.compactionTools;
+    } else {
+      const prep = prepareSpawn(sessionAgent, cwd, ctx);
+      model = prep.model;
+      providerOptions = prep.providerOptions;
+      systemPrompt = contextPrompt
+        ? `${prep.systemPrompt}\n\n${contextPrompt}`
+        : prep.systemPrompt;
+      maxTurns = loop.maxTurns ?? prep.maxTurns;
+      const allPolpoTools = await buildAgentTools(sessionAgent, cwd, prep, ctx);
+      toolByName = new Map(allPolpoTools.map((t) => [t.name, t]));
+      toolSet = toToolDeclarations(allPolpoTools);
+      compactionTools = allPolpoTools.map((t) => ({ description: t.description ?? "" }));
+    }
 
     // Conversation state owned by the host, exactly like the legacy loop.
     // On resume the recorded history (already containing tool-call and
     // tool-result pairs from completed turns) replaces the fresh prompt —
     // side-effects replay from recorded results, they never re-execute.
-    let messages: ModelMessage[] = resume
-      ? [...(resume.history as ModelMessage[])]
-      : [{ role: "user", content: buildPrompt(task) }];
+    let messages: ModelMessage[] = inject
+      ? [...(inject.seedMessages as ModelMessage[])]
+      : resume
+        ? [...(resume.history as ModelMessage[])]
+        : [{ role: "user", content: buildPrompt(task) }];
     let lastStepText = "";
     let accumText = resume?.accumText ?? "";
 
@@ -324,13 +351,13 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
       const compactionResult = await compactIfNeeded({
         systemPrompt,
         messages,
-        tools: toolDescriptions,
+        tools: compactionTools as { description: string }[],
         config: {
           contextWindow: model.contextWindow ?? 200_000,
           maxOutputTokens: model.maxTokens ?? 8192,
         },
         summarize,
-        mode: "task",
+        mode: compactionMode,
         onCompaction: (event: CompactionEvent) => {
           handle.onTranscript?.({
             type: "compaction",
@@ -355,6 +382,7 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
         system: systemPrompt,
         messages,
         tools: toolSet,
+        ...(inject?.toolChoice ? { toolChoice: inject.toolChoice as any } : {}),
         maxOutputTokens: model.maxTokens,
         abortSignal: abortController.signal,
         providerOptions,
@@ -371,11 +399,21 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
       const toolCalls: LoopToolCall[] = [];
       for await (const part of stream.fullStream) {
         switch (part.type) {
+          case "reasoning-delta": {
+            // Chat parity (F1c): surface model reasoning as a thinking delta.
+            if (inject) { try { ctx?.onDelta?.({ text: part.text, kind: "reasoning" }); } catch { /* subscriber can't sink the run */ } }
+            break;
+          }
           case "text-delta": {
             stepText += part.text;
             // F1b: token-level streaming sink (separate from onTranscript, which
             // stays turn-granularity for persistence). Best-effort.
             try { ctx?.onDelta?.({ text: part.text }); } catch { /* a delta subscriber can't sink the run */ }
+            break;
+          }
+          case "tool-input-start": {
+            // Chat parity (F1c): "preparing" tool state before args stream in.
+            if (inject) handle.onTranscript?.({ type: "tool_input_start", toolId: part.id, tool: part.toolName });
             break;
           }
           case "tool-call": {
@@ -388,6 +426,18 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
               toolId: part.toolCallId,
               input: part.input,
             });
+            // Chat parity (F1c): a client-side tool ends the server loop and is
+            // returned to the caller to execute — never dispatched here. Not
+            // pushing it to toolCalls ⇒ the turn ends with no executable tools.
+            if (inject && inject.clientSideToolNames.has(part.toolName)) {
+              handle.onTranscript?.({
+                type: "client_tool_call",
+                toolId: part.toolCallId,
+                tool: part.toolName,
+                input: part.input,
+              });
+              break;
+            }
             toolCalls.push({
               id: part.toolCallId,
               name: part.toolName,
@@ -423,12 +473,35 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
       const responseMessages = (await stream.response).messages;
       messages.push(...responseMessages);
 
+      // Chat parity (F1c): surface per-turn usage + provider metadata so the
+      // driver can accumulate them for onCompletionFinished, matching chat.
+      if (inject) {
+        handle.onTranscript?.({
+          type: "usage",
+          usage: stepUsage,
+          providerMetadata: await Promise.resolve(stream.providerMetadata).catch(() => undefined),
+        });
+      }
+
       return { text: stepText, toolCalls, usage: stepUsage };
     };
 
     // ── LoopRunner tool executor: dispatch + history append ──
     const executeTool = async (toolCall: LoopToolCall): Promise<string> => {
-      const { llmText, isError } = await performToolCall(toolByName.get(toolCall.name), toolCall);
+      let llmText: string;
+      let isError: boolean;
+      if (inject) {
+        // Chat parity (F1c): dispatch via the route's own executor and emit the
+        // FULL result (no 2000-char task truncation). Provider-executed tools
+        // are recorded upstream (tool_use) and skipped here — their result is
+        // already in the stream's response messages.
+        if (inject.providerToolNames.has(toolCall.name)) return "";
+        llmText = await inject.executor(toolCall.name, toolCall.args);
+        isError = llmText.startsWith("Error:");
+        handle.onTranscript?.({ type: "tool_result", toolId: toolCall.id, tool: toolCall.name, content: llmText, isError });
+      } else {
+        ({ llmText, isError } = await performToolCall(toolByName.get(toolCall.name), toolCall));
+      }
 
       // Append the tool result to conversation history so the next model
       // step sees it (the model stream no longer auto-executes tools).
@@ -642,6 +715,18 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
     }) ?? false;
 
     try {
+      // Chat-via-executeRun (F1c): a chat run has no loop selection/graph — it
+      // is a single default turn-loop over the injected conversation. Short-
+      // circuit the loop-selection machinery entirely.
+      if (ctx?.inject) {
+        const session = await runLoopSession({
+          sessionAgent: agentConfig,
+          loopName: "default",
+          loop: { maxTurns: ctx.inject.maxTurns },
+        });
+        alive = false;
+        return { exitCode: 0, stdout: session.lastText, stderr: "", duration: Date.now() - start };
+      }
       const selection = resolveLoopSelection(agentConfig);
       const assigned = agentConfig.assignedLoops ?? [];
 
@@ -698,8 +783,10 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
         duration: Date.now() - start,
       };
     } finally {
-      // Close agent-browser session (profile data auto-persisted by --profile)
-      if (hasExtendedTools) {
+      // Close agent-browser session (profile data auto-persisted by --profile).
+      // Chat (inject) keeps its session — the server driver owns cleanup via
+      // onResponseFinished, matching the inline chat handler.
+      if (hasExtendedTools && !ctx?.inject) {
         await cleanupAgentBrowserSession(agentConfig.name).catch(() => {});
       }
     }

--- a/packages/node/src/core/run-lifecycle.ts
+++ b/packages/node/src/core/run-lifecycle.ts
@@ -28,7 +28,7 @@ import type { RunStore, RunRecord, RunStatus } from "@polpo-ai/core/run-store";
 import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
 import type { LogEntry } from "@polpo-ai/core/log-store";
 import type { RunnerConfig, TaskResult } from "@polpo-ai/core/types";
-import type { AgentHandle } from "@polpo-ai/core/adapter";
+import type { AgentHandle, ChatSessionInjection } from "@polpo-ai/core/adapter";
 import type { FileSystem } from "@polpo-ai/core/filesystem";
 import type { Shell } from "@polpo-ai/core/shell";
 import { sanitizeTranscriptEntry } from "../server/security.js";
@@ -137,6 +137,12 @@ export interface ExecuteRunDeps {
    * entry); token-by-token deltas are a follow-up (F1b, in loop-engine).
    */
   onEvent?: (entry: Record<string, unknown>) => void;
+  /**
+   * Chat-session injection (F1c). When set, the run executes a chat turn-loop
+   * over the injected model/prompt/tools/messages instead of the task's own
+   * resolution — forwarded to SpawnContext.inject. Undefined for task runs.
+   */
+  inject?: ChatSessionInjection;
 }
 
 export interface ExecuteRunOutcome {
@@ -228,10 +234,15 @@ export async function executeRun(config: RunnerConfig, deps: ExecuteRunDeps): Pr
       // NOT onTranscript, so persistence stays turn-granularity. No-op when no
       // subscriber is attached (background hosts).
       onDelta: deps.onEvent
-        ? (delta: { text: string }) => {
-            try { deps.onEvent?.({ type: "text-delta", text: delta.text }); } catch { /* can't sink the run */ }
+        ? (delta: { text: string; kind?: "text" | "reasoning" }) => {
+            try {
+              deps.onEvent?.({ type: delta.kind === "reasoning" ? "reasoning-delta" : "text-delta", text: delta.text });
+            } catch { /* can't sink the run */ }
           }
         : undefined,
+      // F1c: chat-session injection — makes the engine run a chat turn-loop
+      // over pre-resolved inputs. Undefined for task runs (unchanged path).
+      inject: deps.inject,
     };
     handle = spawnLoopEngine(config.agent, config.task, config.cwd, spawnCtx);
     if (config.resumeState) {

--- a/packages/node/src/server/app.ts
+++ b/packages/node/src/server/app.ts
@@ -158,6 +158,42 @@ export function createApp(orchestrator: Orchestrator, sseBridge: SSEBridge, opts
       const raw = await fs.readFile(path);
       return projectLoopConfigSchema.parse(JSON.parse(raw)) as any;
     },
+    // F1c: run a chat completion through the shared executeRun lifecycle +
+    // loop-engine (behind settings.chatExecution:"run"). Injects the route's
+    // already-resolved model/prompt/tools/messages so the engine runs a chat
+    // turn-loop at parity with the inline handler; keeps the run ephemeral.
+    runChatViaRun: async (inject: any, hooks: { onEvent: (e: Record<string, unknown>) => void; signal?: AbortSignal }) => {
+      const { executeRun } = await import("../core/run-lifecycle.js");
+      const { EphemeralRunStore } = await import("./ephemeral-run-store.js");
+      const { nanoid } = await import("nanoid");
+      const runId = `chat-${nanoid()}`;
+      const task: any = {
+        id: runId, title: inject.title ?? "chat", description: "",
+        assignTo: inject.agent?.name ?? "agent", dependsOn: [], status: "pending",
+        expectations: [], metrics: [], retries: 0, maxRetries: 0,
+      };
+      const outcome = await executeRun(
+        {
+          runId, taskId: runId, agent: inject.agent, task,
+          polpoDir: o.getPolpoDir(), cwd: o.getAgentWorkDir(),
+          outputDir: join(o.getPolpoDir(), "output", runId),
+        } as any,
+        {
+          runStore: new EphemeralRunStore(),
+          pid: -1,
+          configPath: `memory://${runId}`,
+          fs: o.getFs(),
+          shell: o.getShell(),
+          memoryStore: o.getMemoryStore(),
+          vaultStore: o.getVaultStore(),
+          gatewayConfig: o.getGatewayConfig(),
+          signal: hooks.signal,
+          inject,
+          onEvent: hooks.onEvent,
+        },
+      );
+      return { status: outcome.status, result: outcome.result };
+    },
   }), opts?.apiKeys));
 
   // ── Authenticated routes (require initialized orchestrator) ───────────

--- a/packages/node/src/server/ephemeral-run-store.ts
+++ b/packages/node/src/server/ephemeral-run-store.ts
@@ -1,0 +1,68 @@
+/**
+ * In-memory RunStore for chat-via-executeRun runs (migration F1c).
+ *
+ * A chat completion is ephemeral: its durable state lives in sessions/messages,
+ * not in the task `runs` table. This store keeps `executeRun`'s bookkeeping
+ * (upsert/activity/outcomes/resume/complete) entirely in memory for the life of
+ * the request, so chat runs never touch the project's task run store or disk.
+ */
+import type { RunStore, RunRecord, RunStatus } from "@polpo-ai/core/run-store";
+import type { AgentActivity, TaskResult, TaskOutcome } from "@polpo-ai/core/types";
+import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
+
+export class EphemeralRunStore implements RunStore {
+  private readonly runs = new Map<string, RunRecord>();
+
+  async upsertRun(run: RunRecord): Promise<void> {
+    this.runs.set(run.id, { ...run });
+  }
+
+  async updateActivity(runId: string, activity: AgentActivity): Promise<void> {
+    const run = this.runs.get(runId);
+    if (run) run.activity = activity;
+  }
+
+  async updateOutcomes(runId: string, outcomes: TaskOutcome[]): Promise<void> {
+    const run = this.runs.get(runId);
+    if (run) run.outcomes = outcomes;
+  }
+
+  async updateResumeState(runId: string, state: LoopResumeState): Promise<void> {
+    const run = this.runs.get(runId);
+    if (run) run.resumeState = state;
+  }
+
+  async completeRun(runId: string, status: RunStatus, result: TaskResult): Promise<void> {
+    const run = this.runs.get(runId);
+    if (run) {
+      run.status = status;
+      run.result = result;
+      run.updatedAt = new Date().toISOString();
+    }
+  }
+
+  async getRun(runId: string): Promise<RunRecord | undefined> {
+    return this.runs.get(runId);
+  }
+
+  async getRunByTaskId(taskId: string): Promise<RunRecord | undefined> {
+    for (const run of this.runs.values()) if (run.taskId === taskId) return run;
+    return undefined;
+  }
+
+  async getActiveRuns(): Promise<RunRecord[]> {
+    return [...this.runs.values()].filter((r) => r.status === "running");
+  }
+
+  async getTerminalRuns(): Promise<RunRecord[]> {
+    return [...this.runs.values()].filter((r) => r.status !== "running");
+  }
+
+  async deleteRun(runId: string): Promise<void> {
+    this.runs.delete(runId);
+  }
+
+  close(): void {
+    this.runs.clear();
+  }
+}

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -38,6 +38,7 @@ import {
   type ProjectLoopConfig,
 } from "@polpo-ai/core";
 import type { ApprovalStore } from "@polpo-ai/core/approval-store";
+import type { ChatSessionInjection } from "@polpo-ai/core";
 import { chatCompletionsRoute } from "./completions/schemas.js";
 import { convertMessages, extractText } from "./completions/message-mapping.js";
 import { toAIToolChoice } from "./completions/tool-mapping.js";
@@ -48,6 +49,7 @@ import {
   streamChatCompletion,
   type ChatCompletionExecution,
 } from "./completions/chat-handler.js";
+import { streamChatViaRun, runNonStreamingChatViaRun } from "./completions/chat-via-run-handler.js";
 
 export { resumeProjectLoopRun } from "./completions/project-loop-runner.js";
 
@@ -108,6 +110,14 @@ export interface CompletionRouteDeps {
     user?: string;
     providerMetadata?: Record<string, unknown>;
   }) => void;
+  /** F1c: run a chat completion through the shared executeRun lifecycle +
+   *  loop-engine (node-provided). Present ⇒ settings.chatExecution:"run" can
+   *  route chat off the inline handler. `onEvent` receives the run's live event
+   *  stream (text-delta / reasoning-delta / tool_use / tool_result / usage / …). */
+  runChatViaRun?: (
+    inject: ChatSessionInjection,
+    hooks: { onEvent: (e: Record<string, unknown>) => void; signal?: AbortSignal },
+  ) => Promise<{ status: string; result: { exitCode: number; stdout: string; stderr: string } }>;
   /** Orchestrator mode support (optional — returns 501 if not provided). */
   resolveOrchestratorContext?: () => Promise<{
     systemPrompt: string;
@@ -162,6 +172,9 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
      * misbehaving cleanup can't leak the request itself.
      */
     let onResponseFinished: (() => Promise<void>) | undefined;
+    // Resolved agent config captured for the execution object (F1c needs it to
+    // build the RunnerConfig for chat-via-executeRun). Undefined in orchestrator mode.
+    let resolvedAgentConfig: any;
 
     const { aiMessages, extraSystemParts } = convertMessages(body.messages);
 
@@ -175,6 +188,7 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
       try {
         const selection = resolveLoopSelection(agentConfig, body.loop);
         agentConfig = selection.agent;
+        resolvedAgentConfig = agentConfig;
         modelToolChoice = toAIToolChoice(agentConfig.toolChoice);
         c.header("x-loop", selection.name);
         const assignedLoops = Array.isArray(agentConfig.assignedLoops) ? agentConfig.assignedLoops : [];
@@ -306,6 +320,7 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
       deps,
       body,
       completionId,
+      agentConfig: resolvedAgentConfig,
       agentMode,
       fullSystemPrompt,
       m,
@@ -320,6 +335,19 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
       sessionId,
       onResponseFinished,
     };
+
+    // F1c: route chat through the shared executeRun lifecycle + loop-engine when
+    // opted in (settings.chatExecution:"run") and the node host provides the
+    // driver. Agent-direct only; project-loop runs already returned above.
+    const viaRun =
+      deps.getConfig()?.settings?.chatExecution === "run" &&
+      !!deps.runChatViaRun &&
+      !projectLoopRuntime;
+    if (viaRun) {
+      return (body.stream
+        ? await streamChatViaRun(c, execution)
+        : await runNonStreamingChatViaRun(c, execution)) as any;
+    }
 
     if (body.stream) {
       // ── Streaming mode ──

--- a/packages/server/src/routes/completions/chat-handler.ts
+++ b/packages/server/src/routes/completions/chat-handler.ts
@@ -29,6 +29,9 @@ export interface ChatCompletionExecution {
   deps: CompletionRouteDeps;
   body: { stream?: boolean; agent?: string; user?: string };
   completionId: string;
+  /** Resolved agent config (agent-direct mode). Used by chat-via-executeRun
+   *  (F1c) to build the RunnerConfig. Undefined in orchestrator mode. */
+  agentConfig: any;
   agentMode: boolean;
   fullSystemPrompt: string;
   m: ResolvedModelInfo;

--- a/packages/server/src/routes/completions/chat-via-run-handler.ts
+++ b/packages/server/src/routes/completions/chat-via-run-handler.ts
@@ -1,0 +1,272 @@
+/**
+ * chat-via-executeRun driver (migration F1c).
+ *
+ * When `settings.chatExecution:"run"`, a chat completion is executed through the
+ * shared `executeRun` lifecycle + loop-engine (node-provided `runChatViaRun`)
+ * instead of the inline `chat-handler` turn loop. This driver:
+ *   1. packs the route's already-resolved model/prompt/tools/messages into a
+ *      `ChatSessionInjection` (so the engine runs a chat turn-loop at parity),
+ *   2. subscribes to the run's live event stream, and
+ *   3. maps each event to the SAME OpenAI SSE chunks the inline handler emits —
+ *      reusing this package's `sse.ts` / `tool-mapping.ts` helpers so framing,
+ *      persistence, and metering are literally the same code.
+ *
+ * Parity notes (see migration plan): multi-tool-turn tool_call order differs
+ * from the inline handler by construction; `model_not_found` enrichment and
+ * provider-executed (extraAiTools) recording are follow-ups. Dark until the
+ * flag is set.
+ */
+import type { Context } from "hono";
+import { streamSSE } from "hono/streaming";
+import type { ChatSessionInjection } from "@polpo-ai/core";
+import type { ChatCompletionExecution } from "./chat-handler.js";
+import { MAX_TURNS } from "./agent-step-runner.js";
+import { completionResponse, modelNotFoundEnvelope, sseChunk } from "./sse.js";
+import {
+  persistAssistantMessage,
+  emitFileChanged,
+  toAITools,
+  CLIENT_SIDE_TOOLS,
+  CLIENT_SIDE_TOOL_NAMES,
+} from "./tool-mapping.js";
+
+/** Best-effort session title from the first user message. */
+function firstUserText(aiMessages: any[]): string {
+  const u = aiMessages.find((m) => m?.role === "user");
+  if (!u) return "chat";
+  if (typeof u.content === "string") return u.content.slice(0, 60);
+  if (Array.isArray(u.content)) {
+    const t = u.content.find((p: any) => p?.type === "text")?.text;
+    if (typeof t === "string") return t.slice(0, 60);
+  }
+  return "chat";
+}
+
+/** Pack the resolved chat inputs into the engine injection. */
+function buildInjection(execution: ChatCompletionExecution): ChatSessionInjection {
+  const { agentConfig, m, fullSystemPrompt, providerOpts, modelToolChoice, effectiveTools, effectiveToolExecutor, extraAiTools, aiMessages } = execution;
+  return {
+    agent: agentConfig,
+    title: firstUserText(aiMessages),
+    model: m as unknown as ChatSessionInjection["model"],
+    systemPrompt: fullSystemPrompt,
+    providerOptions: providerOpts as ChatSessionInjection["providerOptions"],
+    maxTurns: MAX_TURNS,
+    toolChoice: modelToolChoice,
+    seedMessages: aiMessages,
+    toolSet: { ...toAITools(effectiveTools), ...(extraAiTools ?? {}), ...CLIENT_SIDE_TOOLS },
+    executor: effectiveToolExecutor,
+    clientSideToolNames: CLIENT_SIDE_TOOL_NAMES,
+    providerToolNames: new Set(Object.keys(extraAiTools ?? {})),
+    compactionTools: effectiveTools,
+    compactionMode: "chat",
+  };
+}
+
+/**
+ * Shared accumulator + event→state reducer used by both the streaming and
+ * non-streaming drivers. `write` is called for each SSE chunk in streaming
+ * mode; a no-op in non-streaming mode.
+ */
+interface DriverState {
+  finalText: string;
+  toolCallsAccum: any[];
+  totalUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
+  lastProviderMetadata: Record<string, unknown> | undefined;
+  clientReturn: { id: string; name: string; arguments: unknown } | undefined;
+  errorEvent: Record<string, unknown> | undefined;
+}
+
+function makeOnEvent(
+  execution: ChatCompletionExecution,
+  state: DriverState,
+  write: (data: string) => void,
+) {
+  const { completionId, deps, extraAiTools } = execution;
+  const providerToolNames = new Set(Object.keys(extraAiTools ?? {}));
+  const toolArgsById = new Map<string, Record<string, unknown>>();
+  return (e: Record<string, unknown>) => {
+    switch (e.type) {
+      case "text-delta": {
+        const text = String(e.text ?? "");
+        state.finalText += text;
+        write(sseChunk(completionId, { content: text }));
+        break;
+      }
+      case "reasoning-delta": {
+        write(sseChunk(completionId, {}, null, { thinking: String(e.text ?? "") }));
+        break;
+      }
+      case "tool_input_start": {
+        write(sseChunk(completionId, {}, null, { tool_call: { id: e.toolId, name: e.tool, state: "preparing" } }));
+        break;
+      }
+      case "tool_use": {
+        const name = String(e.tool);
+        const args = (e.input ?? {}) as Record<string, unknown>;
+        toolArgsById.set(String(e.toolId), args);
+        if (providerToolNames.has(name)) break; // provider-executed: no calling chunk
+        write(sseChunk(completionId, {}, null, { tool_call: { id: e.toolId, name, arguments: args, state: "calling" } }));
+        break;
+      }
+      case "tool_result": {
+        const name = String(e.tool);
+        const result = String(e.content ?? "");
+        const isError = !!e.isError;
+        const args = toolArgsById.get(String(e.toolId)) ?? {};
+        emitFileChanged(name, args, result, deps.emit);
+        state.toolCallsAccum.push({ id: e.toolId, name, arguments: args, result, state: isError ? "error" : "completed" });
+        write(sseChunk(completionId, {}, null, { tool_call: { id: e.toolId, name, result, state: isError ? "error" : "completed" } }));
+        break;
+      }
+      case "client_tool_call": {
+        state.clientReturn = { id: String(e.toolId), name: String(e.tool), arguments: e.input };
+        break;
+      }
+      case "usage": {
+        const u = (e.usage ?? {}) as { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+        state.totalUsage.inputTokens += u.inputTokens ?? 0;
+        state.totalUsage.outputTokens += u.outputTokens ?? 0;
+        state.totalUsage.totalTokens += u.totalTokens ?? 0;
+        if (e.providerMetadata) state.lastProviderMetadata = e.providerMetadata as Record<string, unknown>;
+        break;
+      }
+      case "error": {
+        state.errorEvent = e;
+        break;
+      }
+    }
+  };
+}
+
+/** OpenAI `tool_calls` finish chunk for a client-side tool (parity with chat-handler). */
+function clientToolFinishChunk(completionId: string, ret: { id: string; name: string; arguments: unknown }): string {
+  return JSON.stringify({
+    id: completionId,
+    object: "chat.completion.chunk",
+    choices: [{
+      index: 0,
+      delta: {
+        role: "assistant",
+        tool_calls: [{ index: 0, id: ret.id, type: "function", function: { name: ret.name, arguments: JSON.stringify(ret.arguments) } }],
+      },
+      finish_reason: "tool_calls",
+    }],
+  });
+}
+
+function newState(): DriverState {
+  return { finalText: "", toolCallsAccum: [], totalUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, lastProviderMetadata: undefined, clientReturn: undefined, errorEvent: undefined };
+}
+
+async function finishCommon(execution: ChatCompletionExecution, state: DriverState, assistantMsgId: string | null) {
+  const { deps, body, m, sessionStore, sessionId, onResponseFinished } = execution;
+  await persistAssistantMessage(sessionStore, sessionId, assistantMsgId, state.finalText, state.toolCallsAccum);
+  try {
+    deps.onCompletionFinished?.({
+      usage: state.totalUsage,
+      model: m.id ?? m.provider,
+      agent: body.agent,
+      sessionId: sessionId ?? undefined,
+      user: body.user,
+      providerMetadata: state.lastProviderMetadata,
+    });
+  } catch { /* never fail on callback */ }
+  if (onResponseFinished) onResponseFinished().catch(() => {});
+}
+
+/** Streaming chat completion via executeRun. */
+export function streamChatViaRun(c: Context, execution: ChatCompletionExecution) {
+  const { deps, body, completionId, m, sessionStore, sessionId } = execution;
+  const inject = buildInjection(execution);
+
+  return streamSSE(c, async (stream) => {
+    const abortController = new AbortController();
+    stream.onAbort(() => abortController.abort());
+    const heartbeat = setInterval(() => {
+      if (abortController.signal.aborted) { clearInterval(heartbeat); return; }
+      stream.write(": ping\n\n").catch(() => clearInterval(heartbeat));
+    }, 20_000);
+
+    await stream.writeSSE({ data: sseChunk(completionId, { role: "assistant" }) });
+
+    let assistantMsgId: string | null = null;
+    if (sessionStore && sessionId) {
+      const placeholder = await sessionStore.addMessage(sessionId, "assistant", "");
+      assistantMsgId = placeholder.id;
+    }
+
+    const state = newState();
+    let writeChain: Promise<void> = Promise.resolve();
+    const write = (data: string) => { writeChain = writeChain.then(() => stream.writeSSE({ data })).catch(() => {}); };
+    const onEvent = makeOnEvent(execution, state, write);
+
+    try {
+      await deps.runChatViaRun!(inject, { onEvent, signal: abortController.signal });
+      await writeChain;
+
+      if (state.clientReturn) {
+        state.toolCallsAccum.push({ id: state.clientReturn.id, name: state.clientReturn.name, arguments: state.clientReturn.arguments, state: "interrupted" });
+        await stream.writeSSE({ data: clientToolFinishChunk(completionId, state.clientReturn) });
+        await stream.writeSSE({ data: "[DONE]" });
+      } else if (!abortController.signal.aborted) {
+        const notFound = state.errorEvent ? modelNotFoundEnvelope(state.errorEvent, m?.id, body.agent) : null;
+        await stream.writeSSE({ data: sseChunk(completionId, {}, "stop", notFound ? { error: notFound } : undefined) });
+        await stream.writeSSE({ data: "[DONE]" });
+      }
+    } catch (err) {
+      if (!((err instanceof DOMException && err.name === "AbortError") || abortController.signal.aborted)) {
+        const notFound = modelNotFoundEnvelope(err, m?.id, body.agent);
+        if (notFound) {
+          await stream.writeSSE({ data: sseChunk(completionId, {}, "stop", { error: notFound }) });
+          await stream.writeSSE({ data: "[DONE]" });
+        } else {
+          throw err;
+        }
+      }
+    } finally {
+      clearInterval(heartbeat);
+      await finishCommon(execution, state, assistantMsgId);
+    }
+  });
+}
+
+/** Non-streaming chat completion via executeRun. */
+export async function runNonStreamingChatViaRun(c: Context, execution: ChatCompletionExecution) {
+  const { deps, body, completionId, m, sessionStore, sessionId } = execution;
+  const inject = buildInjection(execution);
+
+  let assistantMsgId: string | null = null;
+  if (sessionStore && sessionId) {
+    const placeholder = await sessionStore.addMessage(sessionId, "assistant", "");
+    assistantMsgId = placeholder.id;
+  }
+
+  const state = newState();
+  const onEvent = makeOnEvent(execution, state, () => { /* no SSE in non-streaming mode */ });
+
+  try {
+    await deps.runChatViaRun!(inject, { onEvent, signal: undefined });
+
+    if (state.clientReturn) {
+      return c.json({
+        id: completionId,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "polpo",
+        choices: [{
+          index: 0,
+          message: { role: "assistant", content: null, tool_calls: [{ id: state.clientReturn.id, type: "function", function: { name: state.clientReturn.name, arguments: JSON.stringify(state.clientReturn.arguments) } }] },
+          finish_reason: "tool_calls",
+        }],
+      });
+    }
+    if (state.errorEvent) {
+      const notFound = modelNotFoundEnvelope(state.errorEvent, m?.id, body.agent);
+      if (notFound) return c.json({ error: notFound }, 400 as any);
+    }
+    return c.json(completionResponse(completionId, state.finalText, state.totalUsage as any));
+  } finally {
+    await finishCommon(execution, state, assistantMsgId);
+  }
+}


### PR DESCRIPTION
**F1c** completes the chat+task engine unification: chat completions can run through the shared `executeRun` lifecycle + loop-engine, behind `settings.chatExecution:"run"` (default `inline` — **dark until validated**).

**Parity by construction:** the completions route's already-resolved model/prompt/tools/messages are **injected** into the engine (`ChatSessionInjection`) — no double resolution. Tool reconciliation = inject AI-SDK declarations + the `(name,args)=>string` executor (the bridge `agent-step-runner` already uses).

- **core:** `ChatSessionInjection` + `SpawnContext.inject` + `onDelta` `kind`; `chatExecution` flag.
- **node/loop-engine:** an `if(inject)`-gated path (task path byte-identical) — injected inputs, chat-only events (reasoning/tool-input-start/client-tool/usage), full tool results.
- **node/run-lifecycle:** forward inject + map reasoning deltas.
- **node:** `EphemeralRunStore` + `runChatViaRun` impl.
- **server:** dep interface + flag-gated dispatch + `chat-via-run-handler` driver (onEvent→SSE, **reusing** `sse.ts`/`tool-mapping.ts`).

**Parity test:** identical requests under inline vs run → SSE content + tool_call states + finish_reason match. **core 148 · node 1040 (+2 parity) · server 21/22** (the 1 failure is a pre-existing untracked skills test). Task path unchanged.

Follow-ups behind the flag: multi-tool-turn order, model_not_found enrichment, provider-tool recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)