### PR TITLE
fix(skills): install copies the full bundle via FileSystem (not shell cp -r)

### DIFF
--- a/packages/server/src/routes/skills.test.ts
+++ b/packages/server/src/routes/skills.test.ts
@@ -1,0 +1,135 @@
+import { dirname } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { FileEntry, FileStat, FileSystem } from "@polpo-ai/core";
+import { skillRoutes } from "./skills.js";
+
+class MemoryFileSystem implements FileSystem {
+  private readonly files = new Map<string, Uint8Array>();
+  private readonly dirs = new Set<string>(["/"]);
+
+  async readFile(path: string): Promise<string> {
+    const file = this.files.get(path);
+    if (!file) throw new Error(`File not found: ${path}`);
+    return new TextDecoder().decode(file);
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    await this.writeFileBuffer(path, new TextEncoder().encode(content));
+  }
+
+  async readFileBuffer(path: string): Promise<Uint8Array> {
+    const file = this.files.get(path);
+    if (!file) throw new Error(`File not found: ${path}`);
+    return new Uint8Array(file);
+  }
+
+  async writeFileBuffer(path: string, data: Uint8Array): Promise<void> {
+    await this.mkdir(dirname(path));
+    this.files.set(path, new Uint8Array(data));
+  }
+
+  async exists(path: string): Promise<boolean> {
+    if (this.files.has(path) || this.dirs.has(path)) return true;
+    const prefix = path.endsWith("/") ? path : `${path}/`;
+    return [...this.files.keys()].some((file) => file.startsWith(prefix));
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    return (await this.readdirWithTypes(path)).map((entry) => entry.name);
+  }
+
+  async readdirWithTypes(path: string): Promise<FileEntry[]> {
+    const prefix = path.endsWith("/") ? path : `${path}/`;
+    const entries = new Map<string, FileEntry>();
+    for (const dir of this.dirs) {
+      if (!dir.startsWith(prefix) || dir === path) continue;
+      const rest = dir.slice(prefix.length);
+      if (!rest || rest.includes("/")) continue;
+      entries.set(rest, { name: rest, isDirectory: true, isFile: false });
+    }
+    for (const [file, data] of this.files) {
+      if (!file.startsWith(prefix)) continue;
+      const rest = file.slice(prefix.length);
+      if (!rest || rest.includes("/")) continue;
+      entries.set(rest, { name: rest, isDirectory: false, isFile: true, size: data.byteLength });
+    }
+    return [...entries.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async mkdir(path: string): Promise<void> {
+    const parts = path.split("/").filter(Boolean);
+    let current = "";
+    for (const part of parts) {
+      current += `/${part}`;
+      this.dirs.add(current);
+    }
+  }
+
+  async remove(path: string): Promise<void> {
+    this.files.delete(path);
+    const prefix = path.endsWith("/") ? path : `${path}/`;
+    for (const key of [...this.files.keys()]) {
+      if (key.startsWith(prefix)) this.files.delete(key);
+    }
+    for (const key of [...this.dirs]) {
+      if (key === path || key.startsWith(prefix)) this.dirs.delete(key);
+    }
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    const file = this.files.get(path);
+    if (file) return { size: file.byteLength, isDirectory: false, isFile: true };
+    if (await this.exists(path)) return { size: 0, isDirectory: true, isFile: false };
+    throw new Error(`Not found: ${path}`);
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    const file = this.files.get(oldPath);
+    if (!file) throw new Error(`File not found: ${oldPath}`);
+    await this.writeFileBuffer(newPath, file);
+    this.files.delete(oldPath);
+  }
+}
+
+describe("skillRoutes", () => {
+  it("installs the complete skill bundle, not only SKILL.md", async () => {
+    const sourceFs = new MemoryFileSystem();
+    const targetFs = new MemoryFileSystem();
+    await sourceFs.writeFile(
+      "/repo/skills/full-bundle/SKILL.md",
+      "---\nname: full-bundle\ndescription: Full bundle\n---\n\nUse every file.",
+    );
+    await sourceFs.writeFile("/repo/skills/full-bundle/references/guide.md", "# Guide\n\nDetails.");
+    await sourceFs.writeFile("/repo/skills/full-bundle/scripts/run.sh", "echo ok\n");
+    await sourceFs.writeFileBuffer("/repo/skills/full-bundle/assets/logo.bin", new Uint8Array([0, 1, 2, 255]));
+
+    const app = skillRoutes(() => ({
+      polpoDir: "/project/.polpo",
+      fs: targetFs,
+      installFs: sourceFs,
+      shell: {
+        execute: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      },
+      getAgents: async () => [],
+    }));
+
+    const response = await app.request("/add", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ source: "/repo" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).data.installed).toEqual(["full-bundle"]);
+    expect(await targetFs.readFile("/project/.polpo/skills/full-bundle/SKILL.md")).toContain("Use every file.");
+    expect(await targetFs.readFile("/project/.polpo/skills/full-bundle/references/guide.md")).toContain("Details.");
+    expect(await targetFs.readFile("/project/.polpo/skills/full-bundle/scripts/run.sh")).toBe("echo ok\n");
+    expect([...await targetFs.readFileBuffer("/project/.polpo/skills/full-bundle/assets/logo.bin")]).toEqual([0, 1, 2, 255]);
+    expect(await targetFs.readdir("/project/.polpo/skills/full-bundle")).toEqual(expect.arrayContaining([
+      "assets",
+      "references",
+      "scripts",
+      "SKILL.md",
+    ]));
+  });
+});

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -33,6 +33,33 @@ interface LoadedSkill extends SkillInfo {
   content: string;
 }
 
+/**
+ * Recursively copy a skill bundle from one FileSystem to another using ONLY the
+ * FileSystem abstraction — so install works on any backend (local, sandbox
+ * proxy, cloud object store), never assuming a POSIX shell. Copies every file
+ * and subdirectory (SKILL.md, references/, scripts/, assets/, …), not just
+ * SKILL.md. Binary-safe via readFileBuffer/writeFileBuffer when available.
+ */
+async function copySkillBundle(srcFs: FileSystem, src: string, dstFs: FileSystem, dst: string): Promise<void> {
+  await dstFs.mkdir(dst);
+  const entries = (srcFs as any).readdirWithTypes
+    ? await (srcFs as any).readdirWithTypes(src)
+    : (await srcFs.readdir(src)).map((name: string) => ({ name, isFile: true, isDirectory: false }));
+  for (const entry of entries) {
+    const s = join(src, entry.name);
+    const d = join(dst, entry.name);
+    if (entry.isDirectory) {
+      await copySkillBundle(srcFs, s, dstFs, d);
+    } else {
+      const data = (srcFs as any).readFileBuffer
+        ? await (srcFs as any).readFileBuffer(s)
+        : new TextEncoder().encode(await srcFs.readFile(s));
+      if ((dstFs as any).writeFileBuffer) await (dstFs as any).writeFileBuffer(d, data);
+      else await dstFs.writeFile(d, new TextDecoder().decode(data));
+    }
+  }
+}
+
 type SkillIndex = Record<string, { tags?: string[]; category?: string }>;
 
 // ── Dependencies ──
@@ -488,21 +515,26 @@ export function skillRoutes(getDeps: () => SkillRouteDeps): OpenAPIHono {
           if (!force) { skipped.push(skill.name); continue; }
           await fs.remove(targetDir);
         }
-        // Copy via shell (recursive cp)
-        const cpResult = await shell.execute(`cp -r "${skill.path}" "${targetDir}"`);
-        if (cpResult.exitCode === 0) {
-          installed.push(skill.name);
-          // Mirror to skillStore for fast-path list reads.
-          await skillStore?.upsert({
-            name: skill.name,
-            description: skill.description,
-            source,
-            installedAt: new Date().toISOString(),
-            allowedTools: (skill as any).allowedTools,
-          }).catch(() => { /* best-effort — fs write already succeeded */ });
-        } else {
-          errors.push(`${skill.name}: ${cpResult.stderr}`);
+        // Copy the FULL skill bundle via the FileSystem abstraction — SKILL.md
+        // plus references/ scripts/ assets/ and any nested files. Portable:
+        // works with any FileSystem (cloud object stores included), unlike the
+        // old `shell cp -r` which needed a POSIX shell and both paths on one
+        // real filesystem (and silently no-op'd on a mocked/abstract shell).
+        try {
+          await copySkillBundle(scanFs, skill.path, fs, targetDir);
+        } catch (err) {
+          errors.push(`${skill.name}: ${err instanceof Error ? err.message : String(err)}`);
+          continue;
         }
+        installed.push(skill.name);
+        // Mirror to skillStore for fast-path list reads.
+        await skillStore?.upsert({
+          name: skill.name,
+          description: skill.description,
+          source,
+          installedAt: new Date().toISOString(),
+          allowedTools: (skill as any).allowedTools,
+        }).catch(() => { /* best-effort — fs write already succeeded */ });
       }
 
       // Cleanup cloned repo


### PR DESCRIPTION
Skill install (`POST /skills/add`) copied bundles with `shell.execute('cp -r …')` — which only works with a POSIX shell and both paths on one real filesystem, and **silently no-ops** on an abstract/mocked shell or a non-shell FileSystem backend (cloud object store). Result: on those backends the install dropped everything except SKILL.md.

Replaces it with **`copySkillBundle()`** — a recursive copy using ONLY the FileSystem abstraction (`readdirWithTypes` + `readFileBuffer`/`writeFileBuffer`, binary-safe). The complete bundle (SKILL.md + references/ + scripts/ + assets/ + nested files) now installs on **any** backend. `shell` stays only for the git-clone path.

Includes `skills.test.ts` (was uncommitted) documenting the requirement — it drove the fix. **Server suite green (22).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)