### PR TITLE
refactor(drizzle): extend runs + engine-scope task queries (F2 PR1)

### DIFF
--- a/packages/drizzle/src/__tests__/stores-pg.test.ts
+++ b/packages/drizzle/src/__tests__/stores-pg.test.ts
@@ -79,6 +79,22 @@ describe.skipIf(!canConnect)("PostgreSQL Drizzle stores", () => {
     stores = createPgStores(db);
   });
 
+  it("ensurePgSchema creates every runs column (F2 migrate.ts drift guard)", async () => {
+    // migrate.ts (ensurePgSchema) is hand-maintained ALTER TABLE lines — a
+    // forgotten column here breaks only the cloud/release PG path (SQLite
+    // auto-derives, so PR CI on SQLite stays green). This asserts parity with
+    // the canonical runsPg schema.
+    const { getTableConfig } = await import("drizzle-orm/pg-core");
+    const { runsPg } = await import("../schema/index.js");
+    const list: any[] = await db.execute(sql.raw(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'runs'`,
+    ));
+    const present = new Set(list.map((r: any) => r.column_name));
+    for (const col of getTableConfig(runsPg).columns.map((c) => c.name)) {
+      expect(present.has(col), `migrate.ts missing runs column: ${col}`).toBe(true);
+    }
+  });
+
   // ═══════════════════════════════════════════════════════════════════════
   // TaskStore
   // ═══════════════════════════════════════════════════════════════════════

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -329,6 +329,26 @@ describe("DrizzleRunStore", () => {
     expect(terminal).toHaveLength(2);
   });
 
+  it("engine-scoped queries exclude project-loop (graph) rows folded into runs (F2)", async () => {
+    // Simulate loop_runs folded into the runs table: rows with engine="graph".
+    // The reaper iterates getActiveRuns/getTerminalRuns and would delete/re-spawn
+    // these if not excluded — the discriminator prevents that.
+    const { runsSqlite } = await import("../schema/runs.js");
+    const graphRow = (id: string, status: string) => ({
+      id, taskId: id, agentName: "chat", adapterType: "loop", configPath: "",
+      status, startedAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", engine: "graph",
+    });
+    await db.insert(runsSqlite).values(graphRow("looprun-running", "running") as any);
+    await db.insert(runsSqlite).values(graphRow("looprun-done", "completed") as any);
+    // Normal task runs — engine defaults to "agent".
+    await stores.runStore.upsertRun(makeRun("r1", "t1") as any);
+    await stores.runStore.upsertRun({ ...makeRun("r2", "t2"), status: "completed" as any } as any);
+
+    expect((await stores.runStore.getActiveRuns()).map((r) => r.id)).toEqual(["r1"]);
+    expect((await stores.runStore.getTerminalRuns()).map((r) => r.id)).toEqual(["r2"]);
+    expect(await stores.runStore.getRunByTaskId("looprun-running")).toBeUndefined();
+  });
+
   it("completeRun guards against overwriting terminal status", async () => {
     await stores.runStore.upsertRun({ ...makeRun("r1", "t1"), status: "completed" as any } as any);
 

--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -108,6 +108,18 @@ export async function ensurePgTables(db: any): Promise<void> {
   await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS "user" TEXT`);
   await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS resume_state JSONB`);
   await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS execution_mode TEXT`);
+  // F2: unified Run — columns folded from loop_runs (additive; hand-maintained
+  // here because cloud/node PG uses ensurePgSchema, not the auto-migrator).
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS loop_name TEXT`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS context JSONB`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS trace JSONB`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS error TEXT`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS approval_request_id TEXT`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS approval JSONB`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS metadata JSONB`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS completed_at TEXT`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS engine TEXT DEFAULT 'agent'`);
+  await db.execute(sql`ALTER TABLE runs ADD COLUMN IF NOT EXISTS delivery TEXT`);
 
   await db.execute(sql`CREATE TABLE IF NOT EXISTS loop_runs (
     id                  TEXT PRIMARY KEY,

--- a/packages/drizzle/src/schema/runs.ts
+++ b/packages/drizzle/src/schema/runs.ts
@@ -23,10 +23,27 @@ export const runsSqlite = sqliteTable("runs", {
   /** Durable-turns checkpoint (LoopResumeState JSON) — written once per completed turn. */
   resumeState: text("resume_state"),
   executionMode: text("execution_mode"),
+  // ── F2: unified Run — columns folded from loop_runs (all nullable/additive) ──
+  loopName: text("loop_name"),
+  context: text("context"),
+  trace: text("trace"),
+  error: text("error"),
+  approvalRequestId: text("approval_request_id"),
+  approval: text("approval"),
+  metadata: text("metadata"),
+  completedAt: text("completed_at"),
+  /** Execution-engine discriminator: "agent" (chat/task turn-loop) | "graph"
+   *  (project-loop). Defaults to "agent" so existing task rows backfill; loop
+   *  rows are written "graph" so task queries (getActiveRuns/getTerminalRuns)
+   *  can exclude them once the tables merge. */
+  engine: text("engine").default("agent"),
+  /** Consumption axis (F3, forward-compat only): "stream" | "background". */
+  delivery: text("delivery"),
 }, (table) => [
   index("idx_runs_status").on(table.status),
   index("idx_runs_task_id").on(table.taskId),
   index("idx_runs_user").on(table.user),
+  index("idx_runs_engine").on(table.engine),
 ]);
 
 // ── PostgreSQL schema ──────────────────────────────────────────────────
@@ -51,8 +68,23 @@ export const runsPg = pgTable("runs", {
   /** Durable-turns checkpoint (LoopResumeState JSON) — written once per completed turn. */
   resumeState: jsonb("resume_state"),
   executionMode: pgText("execution_mode"),
+  // ── F2: unified Run — columns folded from loop_runs (all nullable/additive) ──
+  loopName: pgText("loop_name"),
+  context: jsonb("context"),
+  trace: jsonb("trace"),
+  error: pgText("error"),
+  approvalRequestId: pgText("approval_request_id"),
+  approval: jsonb("approval"),
+  metadata: jsonb("metadata"),
+  completedAt: pgText("completed_at"),
+  /** Execution-engine discriminator: "agent" (chat/task) | "graph" (project-loop).
+   *  Defaults "agent"; loop rows are "graph" so task queries can exclude them. */
+  engine: pgText("engine").default("agent"),
+  /** Consumption axis (F3, forward-compat only): "stream" | "background". */
+  delivery: pgText("delivery"),
 }, (table) => [
   pgIndex("idx_pg_runs_status").on(table.status),
   pgIndex("idx_pg_runs_task_id").on(table.taskId),
   pgIndex("idx_pg_runs_user").on(table.user),
+  pgIndex("idx_pg_runs_engine").on(table.engine),
 ]);

--- a/packages/drizzle/src/stores/run-store.ts
+++ b/packages/drizzle/src/stores/run-store.ts
@@ -1,4 +1,4 @@
-import { eq, desc, inArray } from "drizzle-orm";
+import { eq, desc, inArray, and, ne } from "drizzle-orm";
 import type { RunStore, RunRecord, RunStatus } from "@polpo-ai/core/run-store";
 import type { AgentActivity, TaskResult, TaskOutcome, RunnerConfig } from "@polpo-ai/core/types";
 import type { LoopResumeState } from "@polpo-ai/core/loop-run-store";
@@ -126,22 +126,26 @@ export class DrizzleRunStore implements RunStore {
   }
 
   async getRunByTaskId(taskId: string): Promise<RunRecord | undefined> {
+    // Scope to task rows (engine != "graph"): once loop_runs folds into this
+    // table (F2), loop rows share it but are never task-run results.
     const rows: any[] = await this.db.select().from(this.runs)
-      .where(eq(this.runs.taskId, taskId))
+      .where(and(eq(this.runs.taskId, taskId), ne(this.runs.engine, "graph")))
       .orderBy(desc(this.runs.startedAt))
       .limit(1);
     return rows.length > 0 ? this.rowToRecord(rows[0]) : undefined;
   }
 
   async getActiveRuns(): Promise<RunRecord[]> {
+    // engine-scoped: the orchestrator reaper iterates these — it must never see
+    // (and re-spawn / delete) project-loop rows folded into `runs` (F2).
     const rows: any[] = await this.db.select().from(this.runs)
-      .where(eq(this.runs.status, "running"));
+      .where(and(eq(this.runs.status, "running"), ne(this.runs.engine, "graph")));
     return rows.map((r) => this.rowToRecord(r));
   }
 
   async getTerminalRuns(): Promise<RunRecord[]> {
     const rows: any[] = await this.db.select().from(this.runs)
-      .where(inArray(this.runs.status, TERMINAL_STATUSES));
+      .where(and(inArray(this.runs.status, TERMINAL_STATUSES), ne(this.runs.engine, "graph")));
     return rows.map((r) => this.rowToRecord(r));
   }
 


### PR DESCRIPTION
**F2 PR1** — additive + inert first step of folding `loop_runs` into `runs` (Strategy A: merge table/store, keep the `LoopRunStore` interface).

- **schema/runs.ts** (sqlite+pg): +10 columns (`loop_name, context, trace, error, approval_request_id, approval, metadata, completed_at, engine` default `'agent'`, `delivery`), all nullable/additive; `resume` reuses `resume_state`. +engine index.
- **migrate.ts**: matching `ALTER TABLE runs ADD COLUMN IF NOT EXISTS` lines — cloud/node PG uses `ensurePgSchema`, not the auto-migrator (the documented drift gotcha).
- **run-store.ts**: task queries (`getActiveRuns/getTerminalRuns/getRunByTaskId`) filter `ne(engine,'graph')` so the reaper never sweeps folded loop rows. Task rows default `'agent'` ⇒ unaffected.
- **tests**: collision test (graph rows excluded from task queries) + a PG **drift guard** asserting `ensurePgSchema` creates every `runs` column.

Inert until PR2 (the runs-backed loop store + dual-write). SQLite suite green (114); PG guard runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)