### PR TITLE
refactor(drizzle): runs-backed loop store + dual-write (F2 PR2)

### DIFF
--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -424,6 +424,61 @@ describe("DrizzleRunStore", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════
+// LoopRunStore — F2 dual-write + runs-backed shadow
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("DrizzleLoopRunStore — dual-write + runs-backed (F2)", () => {
+  const loopInput = (id: string) => ({ id, loop: { name: "review" }, agentName: "chat", sessionId: "s1" });
+
+  it("dual-write: createRun round-trips (reads legacy) and shadows into runs with engine='graph'", async () => {
+    const created = await stores.loopRunStore.createRun(loopInput("looprun-a") as any);
+    expect(created.loopName).toBe("review");
+    expect((await stores.loopRunStore.getRun("looprun-a"))?.id).toBe("looprun-a");
+
+    // Shadow: the runs table has the same record, tagged engine="graph".
+    const { runsSqlite } = await import("../schema/runs.js");
+    const { eq } = await import("drizzle-orm");
+    const shadow: any[] = await db.select().from(runsSqlite).where(eq(runsSqlite.id, "looprun-a"));
+    expect(shadow).toHaveLength(1);
+    expect(shadow[0].engine).toBe("graph");
+    expect(shadow[0].loopName).toBe("review");
+    expect(shadow[0].adapterType).toBe("loop");
+
+    // Invisible to task-run queries.
+    expect((await stores.runStore.getActiveRuns()).map((r) => r.id)).not.toContain("looprun-a");
+  });
+
+  it("runs-backed store: resume round-trips via resume_state; listRuns excludes task rows", async () => {
+    const { DrizzleLoopRunStore } = await import("../stores/loop-run-store.js");
+    const { runsSqlite } = await import("../schema/runs.js");
+    const runsBacked = new DrizzleLoopRunStore(db, runsSqlite, "sqlite", true);
+
+    await runsBacked.createRun(loopInput("looprun-b") as any);
+    await runsBacked.updateRun("looprun-b", { resume: { context: {}, steps: [], createdAt: "2026-01-01T00:00:00Z", accumText: "hi" } as any });
+    expect(((await runsBacked.getRun("looprun-b"))?.resume as any)?.accumText).toBe("hi");
+
+    await stores.runStore.upsertRun({
+      id: "task-x", taskId: "tx", pid: 0, agentName: "a", status: "running",
+      startedAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z",
+      activity: { filesCreated: [], filesEdited: [], toolCalls: 0, totalTokens: 0, lastUpdate: "" },
+      configPath: "/tmp/c.json",
+    } as any);
+    const list = await runsBacked.listRuns();
+    expect(list.map((r) => r.id)).toContain("looprun-b");
+    expect(list.map((r) => r.id)).not.toContain("task-x");
+  });
+
+  it("dual-write appendTrace + updateRun sync the read side", async () => {
+    await stores.loopRunStore.createRun(loopInput("looprun-c") as any);
+    await stores.loopRunStore.appendTrace("looprun-c", { type: "loop:start" } as any);
+    await stores.loopRunStore.updateRun("looprun-c", { status: "completed" as any });
+    const fetched = await stores.loopRunStore.getRun("looprun-c");
+    expect(fetched?.status).toBe("completed");
+    expect(fetched?.trace).toHaveLength(1);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
 // SessionStore
 // ═══════════════════════════════════════════════════════════════════════
 

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -46,7 +46,7 @@ import { skillsPg, skillsSqlite } from "./schema/skills.js";
 
 import { DrizzleTaskStore } from "./stores/task-store.js";
 import { DrizzleRunStore } from "./stores/run-store.js";
-import { DrizzleLoopRunStore } from "./stores/loop-run-store.js";
+import { DrizzleLoopRunStore, DualWriteLoopRunStore } from "./stores/loop-run-store.js";
 import { DrizzleSessionStore } from "./stores/session-store.js";
 import { DrizzleLogStore } from "./stores/log-store.js";
 import { DrizzleApprovalStore } from "./stores/approval-store.js";
@@ -124,7 +124,14 @@ export function createPgStores(db: any): DrizzleStores {
     // Same instance: the Drizzle task store also implements the mission block.
     missionStore: taskStore as unknown as MissionStore,
     runStore: new DrizzleRunStore(db, runsPg, "pg"),
-    loopRunStore: new DrizzleLoopRunStore(db, loopRunsPg, "pg"),
+    // F2: dual-write loop runs to both loop_runs (legacy) and runs (shadow,
+    // engine="graph"); read from legacy until backfill+flip. Drops to the plain
+    // runs-backed store at PR5.
+    loopRunStore: new DualWriteLoopRunStore(
+      new DrizzleLoopRunStore(db, loopRunsPg, "pg"),
+      new DrizzleLoopRunStore(db, runsPg, "pg", true),
+      "legacy",
+    ),
     sessionStore: new DrizzleSessionStore(db, sessionsPg, messagesPg, "pg"),
     logStore: new DrizzleLogStore(db, logSessionsPg, logEntriesPg, "pg"),
     createLogStore: () => new DrizzleLogStore(db, logSessionsPg, logEntriesPg, "pg"),
@@ -157,7 +164,12 @@ export function createSqliteStores(db: any): DrizzleStores {
     // Same instance: the Drizzle task store also implements the mission block.
     missionStore: taskStore as unknown as MissionStore,
     runStore: new DrizzleRunStore(db, runsSqlite, "sqlite"),
-    loopRunStore: new DrizzleLoopRunStore(db, loopRunsSqlite, "sqlite"),
+    // F2: dual-write (see pg factory above).
+    loopRunStore: new DualWriteLoopRunStore(
+      new DrizzleLoopRunStore(db, loopRunsSqlite, "sqlite"),
+      new DrizzleLoopRunStore(db, runsSqlite, "sqlite", true),
+      "legacy",
+    ),
     sessionStore: new DrizzleSessionStore(db, sessionsSqlite, messagesSqlite, "sqlite"),
     logStore: new DrizzleLogStore(db, logSessionsSqlite, logEntriesSqlite, "sqlite"),
     createLogStore: () => new DrizzleLogStore(db, logSessionsSqlite, logEntriesSqlite, "sqlite"),

--- a/packages/drizzle/src/stores/loop-run-store.ts
+++ b/packages/drizzle/src/stores/loop-run-store.ts
@@ -16,6 +16,11 @@ export class DrizzleLoopRunStore implements LoopRunStore {
     private db: any,
     private loopRuns: AnyTable,
     private dialect: Dialect,
+    /** When true, `loopRuns` is actually the unified `runs` table (F2 fold):
+     *  records are written with engine="graph" + task-column sentinels, `resume`
+     *  maps to the `resume_state` column, and reads/lists scope to engine="graph"
+     *  so task rows in the same table are never returned. */
+    private targetsRuns: boolean = false,
   ) {}
 
   private rowToRecord(row: any): LoopRunRecord {
@@ -31,7 +36,7 @@ export class DrizzleLoopRunStore implements LoopRunStore {
       error: row.error ?? undefined,
       approvalRequestId: row.approvalRequestId ?? undefined,
       approval: deserializeJson(row.approval, undefined, this.dialect),
-      resume: deserializeJson(row.resume, undefined, this.dialect),
+      resume: deserializeJson(this.targetsRuns ? row.resumeState : row.resume, undefined, this.dialect),
       metadata: deserializeJson(row.metadata, undefined, this.dialect),
       startedAt: row.startedAt,
       updatedAt: row.updatedAt,
@@ -66,12 +71,16 @@ export class DrizzleLoopRunStore implements LoopRunStore {
   }
 
   async getRun(id: string): Promise<LoopRunRecord | undefined> {
-    const rows: any[] = await this.db.select().from(this.loopRuns).where(eq(this.loopRuns.id, id)).limit(1);
+    const where = this.targetsRuns
+      ? and(eq(this.loopRuns.id, id), eq(this.loopRuns.engine, "graph"))
+      : eq(this.loopRuns.id, id);
+    const rows: any[] = await this.db.select().from(this.loopRuns).where(where).limit(1);
     return rows[0] ? this.rowToRecord(rows[0]) : undefined;
   }
 
   async listRuns(filter: LoopRunListFilter = {}): Promise<LoopRunRecord[]> {
     const clauses = [];
+    if (this.targetsRuns) clauses.push(eq(this.loopRuns.engine, "graph"));
     if (filter.loopName) clauses.push(eq(this.loopRuns.loopName, filter.loopName));
     if (filter.agentName) clauses.push(eq(this.loopRuns.agentName, filter.agentName));
     if (filter.sessionId) clauses.push(eq(this.loopRuns.sessionId, filter.sessionId));
@@ -111,10 +120,9 @@ export class DrizzleLoopRunStore implements LoopRunStore {
   }
 
   private recordToValues(run: LoopRunRecord): Record<string, unknown> {
-    return {
+    const base: Record<string, unknown> = {
       id: run.id,
       loopName: run.loopName,
-      agentName: run.agentName ?? null,
       sessionId: run.sessionId ?? null,
       user: run.user ?? null,
       status: run.status,
@@ -123,11 +131,79 @@ export class DrizzleLoopRunStore implements LoopRunStore {
       error: run.error ?? null,
       approvalRequestId: run.approvalRequestId ?? null,
       approval: serializeJson(run.approval, this.dialect),
-      resume: serializeJson(run.resume, this.dialect),
       metadata: serializeJson(run.metadata, this.dialect),
       startedAt: run.startedAt,
       updatedAt: run.updatedAt,
       completedAt: run.completedAt ?? null,
     };
+    if (this.targetsRuns) {
+      // Writing a loop record into the unified `runs` table: fill the NOT-NULL
+      // task columns with sentinels, tag engine="graph", and map resume →
+      // resume_state (the column `runs` already has).
+      return {
+        ...base,
+        agentName: run.agentName ?? "", // runs.agent_name is NOT NULL
+        taskId: run.id,
+        adapterType: "loop",
+        configPath: "",
+        engine: "graph",
+        resumeState: serializeJson(run.resume, this.dialect),
+      };
+    }
+    return {
+      ...base,
+      agentName: run.agentName ?? null,
+      resume: serializeJson(run.resume, this.dialect),
+    };
+  }
+}
+
+/**
+ * Dual-write LoopRunStore for the F2 transition. Writes go to BOTH the legacy
+ * `loop_runs` store and the shadow `runs`-backed store; the shadow write is
+ * best-effort (a shadow failure never fails the request). Reads come from
+ * `readFrom` — "legacy" during dual-write, flipped to "shadow" once loop_runs
+ * is backfilled into `runs`. When the shadow is the sole source, this wrapper
+ * is dropped and the plain runs-backed store is used directly (PR5).
+ */
+export class DualWriteLoopRunStore implements LoopRunStore {
+  constructor(
+    private legacy: LoopRunStore,
+    private shadow: LoopRunStore,
+    private readFrom: "legacy" | "shadow" = "legacy",
+  ) {}
+
+  private async shadowBestEffort(op: () => Promise<unknown>): Promise<void> {
+    try { await op(); } catch { /* shadow write must never fail the request */ }
+  }
+
+  async createRun(input: CreateLoopRunInput): Promise<LoopRunRecord> {
+    const run = await this.legacy.createRun(input);
+    await this.shadowBestEffort(() => this.shadow.createRun(input));
+    return run;
+  }
+
+  async appendTrace(runId: string, event: LoopTraceEvent): Promise<void> {
+    await this.legacy.appendTrace(runId, event);
+    await this.shadowBestEffort(() => this.shadow.appendTrace(runId, event));
+  }
+
+  async updateRun(runId: string, patch: Partial<Omit<LoopRunRecord, "id" | "startedAt">>): Promise<LoopRunRecord | undefined> {
+    const updated = await this.legacy.updateRun(runId, patch);
+    await this.shadowBestEffort(() => this.shadow.updateRun(runId, patch));
+    return updated;
+  }
+
+  getRun(id: string): Promise<LoopRunRecord | undefined> {
+    return (this.readFrom === "shadow" ? this.shadow : this.legacy).getRun(id);
+  }
+
+  listRuns(filter?: LoopRunListFilter): Promise<LoopRunRecord[]> {
+    return (this.readFrom === "shadow" ? this.shadow : this.legacy).listRuns(filter);
+  }
+
+  async close(): Promise<void> {
+    await this.legacy.close?.();
+    await this.shadow.close?.();
   }
 }


### PR DESCRIPTION
**F2 PR2** — the loop run store can now write into the unified `runs` table, and the factory dual-writes during the transition.

- **DrizzleLoopRunStore** `targetsRuns` mode: writes loop records into `runs` with `engine='graph'` + NOT-NULL task sentinels, maps `resume`↔`resume_state`, scopes `getRun`/`listRuns` to `engine='graph'`.
- **DualWriteLoopRunStore**: writes legacy (`loop_runs`) + shadow (`runs`, best-effort); **reads from legacy** until backfill+flip (PR3/PR4). Factory wires it.

Additive + reversible: loop reads/writes behave exactly as before; `runs` just gains shadow copies invisible to task queries. **3 tests; drizzle SQLite suite green (117).**

Next: **PR3** (backfill loop_runs→runs) — cloud-coordinated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)