### PR TITLE
refactor(drizzle): backfill loop_runs into runs (F2 PR3)

### DIFF
--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -476,6 +476,35 @@ describe("DrizzleLoopRunStore — dual-write + runs-backed (F2)", () => {
     expect(fetched?.status).toBe("completed");
     expect(fetched?.trace).toHaveLength(1);
   });
+
+  it("backfillLoopRunsIntoRuns copies historical loop_runs into runs, idempotently (F2 PR3)", async () => {
+    const { DrizzleLoopRunStore } = await import("../stores/loop-run-store.js");
+    const { backfillLoopRunsIntoRuns } = await import("../backfill.js");
+    const { loopRunsSqlite } = await import("../schema/loop-runs.js");
+    const { runsSqlite } = await import("../schema/runs.js");
+    const { eq } = await import("drizzle-orm");
+
+    // A legacy-only loop run (write straight to loop_runs, bypassing the shadow).
+    const legacy = new DrizzleLoopRunStore(db, loopRunsSqlite, "sqlite");
+    await legacy.createRun({ id: "hist-1", loop: { name: "old" }, agentName: "chat" } as any);
+    await legacy.updateRun("hist-1", { status: "awaiting_approval" as any, resume: { context: {}, steps: [], createdAt: "t", accumText: "x" } as any });
+    expect(await db.select().from(runsSqlite).where(eq(runsSqlite.id, "hist-1"))).toHaveLength(0);
+
+    await backfillLoopRunsIntoRuns(db, "sqlite");
+
+    const rows: any[] = await db.select().from(runsSqlite).where(eq(runsSqlite.id, "hist-1"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].engine).toBe("graph");
+    expect(rows[0].status).toBe("awaiting_approval");
+    expect(rows[0].loopName).toBe("old");
+    // resume folded into resume_state.
+    const runsBacked = new DrizzleLoopRunStore(db, runsSqlite, "sqlite", true);
+    expect(((await runsBacked.getRun("hist-1"))?.resume as any)?.accumText).toBe("x");
+
+    // Idempotent — re-run inserts nothing new.
+    await backfillLoopRunsIntoRuns(db, "sqlite");
+    expect(await db.select().from(runsSqlite).where(eq(runsSqlite.id, "hist-1"))).toHaveLength(1);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/drizzle/src/backfill.ts
+++ b/packages/drizzle/src/backfill.ts
@@ -1,0 +1,41 @@
+/**
+ * F2 backfill — copy historical `loop_runs` rows into the unified `runs` table.
+ *
+ * The dual-write store (PR2) shadows NEW loop runs into `runs`; this covers the
+ * rows that existed before dual-write. Idempotent (`ON CONFLICT (id) DO
+ * NOTHING`), so it is safe to run on every deploy. Runs AFTER `ensurePgSchema`
+ * (the new columns must exist). Maps loop columns → runs columns, fills the
+ * NOT-NULL task columns with the same sentinels the runs-backed store uses, and
+ * tags every copied row `engine='graph'`.
+ *
+ * Read-flip (PR4) must happen AFTER this has run, or historical loop runs would
+ * momentarily vanish from `listRuns`.
+ */
+import { sql } from "drizzle-orm";
+import type { Dialect } from "./utils.js";
+
+const COLUMNS =
+  "id, task_id, pid, agent_name, adapter_type, session_id, status, started_at, updated_at, activity, config_path, resume_state, loop_name, context, trace, error, approval_request_id, approval, metadata, completed_at, engine";
+
+export async function backfillLoopRunsIntoRuns(db: any, dialect: Dialect): Promise<void> {
+  if (dialect === "pg") {
+    await db.execute(sql.raw(
+      `INSERT INTO runs (${COLUMNS}, "user")
+       SELECT id, id, 0, COALESCE(agent_name, ''), 'loop', session_id, status, started_at, updated_at,
+              '{}'::jsonb, '', resume, loop_name, context, trace, error, approval_request_id, approval,
+              metadata, completed_at, 'graph', "user"
+       FROM loop_runs
+       ON CONFLICT (id) DO NOTHING`,
+    ));
+  } else {
+    // SQLite: `INSERT OR IGNORE` for idempotency — SQLite can't parse a bare
+    // `ON CONFLICT … DO NOTHING` after a SELECT without a WHERE/LIMIT.
+    await db.run(sql.raw(
+      `INSERT OR IGNORE INTO runs (${COLUMNS}, user)
+       SELECT id, id, 0, COALESCE(agent_name, ''), 'loop', session_id, status, started_at, updated_at,
+              '{}', '', resume, loop_name, context, trace, error, approval_request_id, approval,
+              metadata, completed_at, 'graph', user
+       FROM loop_runs`,
+    ));
+  }
+}

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -20,6 +20,7 @@ export * from "./schema/index.js";
 export { ensurePgSchema } from "./migrate.js";
 export { migratePgSchema } from "./migrator.js";
 export { ensureSqliteTables, ensureSqliteIndexes, migrateSqliteSchema } from "./sqlite-migrator.js";
+export { backfillLoopRunsIntoRuns } from "./backfill.js";
 export type { Dialect } from "./utils.js";
 
 // ── Schema sets ───────────────────────────────────────────────────────


### PR DESCRIPTION
**F2 PR3** — idempotent `backfillLoopRunsIntoRuns(db, dialect)` copying historical `loop_runs` rows into `runs` (the dual-write store shadows new rows; this covers pre-existing ones).

Maps loop→runs columns, fills NOT-NULL task sentinels, `resume`→`resume_state`, tags `engine='graph'`. PG: `ON CONFLICT (id) DO NOTHING`; SQLite: `INSERT OR IGNORE`.

**Must run after `ensurePgSchema` and BEFORE the read-flip (PR4)** — cloud calls it once per deploy. 1 test (copies + idempotent). SQLite suite green (118).

**Operational note:** PR4 (flip reads → runs) and PR5 (drop loop_runs) are gated on this backfill having RUN against the cloud Neon DB — merging the drop before the backfill runs would lose cloud loop-run data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)