### PR TITLE
feat(loop): no synthesized default loop + label on ProjectLoopConfig

### DIFF
--- a/packages/core/src/loop/selector.test.ts
+++ b/packages/core/src/loop/selector.test.ts
@@ -2,12 +2,9 @@ import { describe, expect, it } from "vitest";
 import { resolveLoopSelection } from "./selector.js";
 
 describe("resolveLoopSelection", () => {
-  it("keeps current agent behavior when no loop is requested", () => {
+  it("returns undefined when no loop is requested or configured (agent runs as-is, no synthesized default)", () => {
     const agent = { name: "agent", model: "base", allowedTools: ["read"], systemPrompt: "base" };
-    const selected = resolveLoopSelection(agent);
-
-    expect(selected.name).toBe("default");
-    expect(selected.agent).toBe(agent);
+    expect(resolveLoopSelection(agent)).toBeUndefined();
   });
 
   it("applies requested loop overrides to the effective agent", () => {
@@ -28,7 +25,7 @@ describe("resolveLoopSelection", () => {
           maxTurns: 3,
         },
       },
-    }, "plan");
+    }, "plan")!;
 
     expect(selected.loop.name).toBe("plan");
     expect(selected.agent).toMatchObject({
@@ -52,7 +49,7 @@ describe("resolveLoopSelection", () => {
           tools: ["read", "bash"],
         },
       },
-    }, "verify");
+    }, "verify")!;
 
     expect(selected.agent.skills).toEqual(["general", "testing"]);
   });
@@ -65,8 +62,8 @@ describe("resolveLoopSelection", () => {
       defaultLoop: "coding-flow",
     };
 
-    expect(resolveLoopSelection(agent).name).toBe("coding-flow");
-    expect(resolveLoopSelection(agent, "coding-flow").agent).toBe(agent);
+    expect(resolveLoopSelection(agent)!.name).toBe("coding-flow");
+    expect(resolveLoopSelection(agent, "coding-flow")!.agent).toBe(agent);
   });
 
   it("throws a clear error for unknown requested loops", () => {

--- a/packages/core/src/loop/selector.ts
+++ b/packages/core/src/loop/selector.ts
@@ -16,7 +16,7 @@ export function resolveActiveLoopSkills(agent: AgentConfig, loop?: LoopConfig): 
   return loop?.skills ?? agent.skills;
 }
 
-export function resolveLoopSelection(agent: AgentConfig, requestedLoop?: string): LoopSelection {
+export function resolveLoopSelection(agent: AgentConfig, requestedLoop?: string): LoopSelection | undefined {
   if (!requestedLoop) {
     if (agent.defaultLoop) {
       return {
@@ -27,11 +27,10 @@ export function resolveLoopSelection(agent: AgentConfig, requestedLoop?: string)
     }
     const defaultLoop = agent.loops?.default;
     if (!defaultLoop) {
-      return {
-        name: "default",
-        loop: { name: "default", tools: agent.allowedTools, model: agent.model, reasoning: agent.reasoning, maxTurns: agent.maxTurns },
-        agent,
-      };
+      // No loop requested and none configured: run the agent as-is, with no
+      // loop overlay. We deliberately do NOT synthesize a "default" loop — the
+      // caller treats `undefined` as "no loop".
+      return undefined;
     }
     return materializeLoopSelection(agent, "default", defaultLoop);
   }

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -221,6 +221,8 @@ export interface ProjectLoopConfig {
   version?: ProjectLoopVersion;
   kind?: ProjectLoopKind;
   name: string;
+  /** Human-readable label for UI (e.g. "Plan", "Build"). Falls back to `name`. */
+  label?: string;
   description?: string;
   metadata?: Record<string, unknown>;
   context?: "shared";

--- a/packages/node/src/adapters/loop-engine.ts
+++ b/packages/node/src/adapters/loop-engine.ts
@@ -92,13 +92,6 @@ async function loadProjectLoop(fs: FileSystem, polpoDir: string, name: string): 
   return projectLoopConfigSchema.parse(JSON.parse(raw)) as ProjectLoopConfig;
 }
 
-/** An agent with no loop configuration at all runs the implicit default
- *  loop — byte-identical to the legacy engine (no overlay, no step header
- *  in the system prompt). */
-function isImplicitDefault(agent: AgentConfig, selectionName: string): boolean {
-  return selectionName === "default" && !agent.defaultLoop && !agent.loops?.default;
-}
-
 // ─── Durable turns ─────────────────────────────────────
 
 /**
@@ -728,21 +721,13 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
         return { exitCode: 0, stdout: session.lastText, stderr: "", duration: Date.now() - start };
       }
       const selection = resolveLoopSelection(agentConfig);
-      const assigned = agentConfig.assignedLoops ?? [];
 
       let stdout: string;
-      if (assigned.includes(selection.name)) {
-        // Project loop graph mode — polpoDir/fs come straight from ctx
-        // (the base agent's model may never be used; steps resolve their own).
-        if (!ctx?.polpoDir) {
-          throw new Error("spawnEngine: ctx.polpoDir is required (cannot derive .polpo from cwd when settings.workDir is set)");
-        }
-        const fs = ctx.fs ?? new NodeFileSystem();
-        const projectLoop = await loadProjectLoop(fs, ctx.polpoDir, selection.name);
-        stdout = await runPipeline(projectLoop);
-      } else if (isImplicitDefault(agentConfig, selection.name)) {
-        // Parity path: agents without loop config behave exactly like the
-        // legacy engine (no overlay, no step header).
+      if (!selection) {
+        // No loop requested or configured: plain agent turn-loop, no overlay or
+        // step header (parity with the legacy engine). The durable-resume
+        // checkpoint keeps a stable internal "default" key — nothing here is a
+        // user-facing loop.
         const session = await runLoopSession({
           sessionAgent: agentConfig,
           loopName: "default",
@@ -751,6 +736,15 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
           onCheckpoint: ctx?.onTurnCheckpoint,
         });
         stdout = session.lastText;
+      } else if ((agentConfig.assignedLoops ?? []).includes(selection.name)) {
+        // Project loop graph mode — polpoDir/fs come straight from ctx
+        // (the base agent's model may never be used; steps resolve their own).
+        if (!ctx?.polpoDir) {
+          throw new Error("spawnEngine: ctx.polpoDir is required (cannot derive .polpo from cwd when settings.workDir is set)");
+        }
+        const fs = ctx.fs ?? new NodeFileSystem();
+        const projectLoop = await loadProjectLoop(fs, ctx.polpoDir, selection.name);
+        stdout = await runPipeline(projectLoop);
       } else {
         // Selected single loop (defaultLoop or inline loops.default):
         // apply the loop's overlays, same semantics as completions.

--- a/packages/server/src/routes/completions.ts
+++ b/packages/server/src/routes/completions.ts
@@ -187,16 +187,19 @@ export function completionRoutes(getDeps: () => CompletionRouteDeps, apiKeys?: s
       }
       try {
         const selection = resolveLoopSelection(agentConfig, body.loop);
-        agentConfig = selection.agent;
+        if (selection) {
+          agentConfig = selection.agent;
+          c.header("x-loop", selection.name);
+          const assignedLoops = Array.isArray(agentConfig.assignedLoops) ? agentConfig.assignedLoops : [];
+          if (assignedLoops.includes(selection.name) && deps.getProjectLoop) {
+            const projectLoop = await deps.getProjectLoop(selection.name);
+            if (!projectLoop) throw new Error(`Assigned project loop "${selection.name}" was not found`);
+            projectLoopRuntime = { agentConfig, projectLoop };
+          }
+        }
+        // No loop selected → agent runs as-is (no overlay, no x-loop header).
         resolvedAgentConfig = agentConfig;
         modelToolChoice = toAIToolChoice(agentConfig.toolChoice);
-        c.header("x-loop", selection.name);
-        const assignedLoops = Array.isArray(agentConfig.assignedLoops) ? agentConfig.assignedLoops : [];
-        if (assignedLoops.includes(selection.name) && deps.getProjectLoop) {
-          const projectLoop = await deps.getProjectLoop(selection.name);
-          if (!projectLoop) throw new Error(`Assigned project loop "${selection.name}" was not found`);
-          projectLoopRuntime = { agentConfig, projectLoop };
-        }
       } catch (loopErr) {
         const msg = loopErr instanceof Error ? loopErr.message : String(loopErr);
         return c.json({ error: { message: msg, type: "invalid_request_error", code: "loop_not_found" } }, 400 as any);


### PR DESCRIPTION
Two loop changes:

**1. No forced default loop.** `resolveLoopSelection` now returns `LoopSelection | undefined`: with no requested loop AND no `defaultLoop`/`loops.default`, it returns `undefined` → the agent runs **as-is, no loop overlay** (no synthesized `default`). Explicit `defaultLoop`/`loops.default` unchanged. Callers handle `undefined`: completions drops the fabricated `x-loop: default` header; loop-engine runs the plain turn-loop (replaces the `isImplicitDefault` branch). Durable-resume checkpoint keeps a stable internal `default` key (invisible, back-compat).

**2. `label` on `ProjectLoopConfig`** (e.g. "Plan", "Build") for UI — `LoopConfig` already had one; falls back to `name`.

Additive/non-breaking. **core 5 · node 50 · server 22 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)