### PR TITLE
feat(loop): remove defaultLoop; loops run only when explicitly requested

### DIFF
--- a/packages/cli/src/util/pull.ts
+++ b/packages/cli/src/util/pull.ts
@@ -70,7 +70,6 @@ export async function pullProject(
             reasoning: a.reasoning,
             runtime: a.runtime,
             assignedLoops: a.assignedLoops,
-            defaultLoop: a.defaultLoop,
             reportsTo: a.reportsTo,
             identity: a.identity,
             browserProfile: a.browserProfile,

--- a/packages/cli/tests/pull.test.ts
+++ b/packages/cli/tests/pull.test.ts
@@ -19,7 +19,6 @@ describe("pullProject", () => {
                 role: "router",
                 runtime: "polpo-runner",
                 assignedLoops: ["router-flow"],
-                defaultLoop: "router-flow",
                 teamName: "platform",
               }],
             },
@@ -50,7 +49,6 @@ describe("pullProject", () => {
       const agents = JSON.parse(await readFile(join(polpoDir, "agents.json"), "utf-8"));
       expect(agents[0].agent.runtime).toBe("polpo-runner");
       expect(agents[0].agent.assignedLoops).toEqual(["router-flow"]);
-      expect(agents[0].agent.defaultLoop).toBe("router-flow");
       expect(agents[0].agent.loops).toBeUndefined();
       expect(agents[0].agent.pipeline).toBeUndefined();
       expect(agents[0].teamName).toBe("platform");

--- a/packages/client-sdk/src/client/types.ts
+++ b/packages/client-sdk/src/client/types.ts
@@ -646,7 +646,6 @@ export interface AddAgentRequest {
   maxTurns?: number;
   runtime?: string;
   assignedLoops?: string[];
-  defaultLoop?: string;
   loops?: Record<string, LoopConfig>;
   pipeline?: Pipeline;
   /** Max concurrent tasks for this agent. */
@@ -676,7 +675,6 @@ export interface UpdateAgentRequest {
   maxConcurrency?: number;
   runtime?: string;
   assignedLoops?: string[];
-  defaultLoop?: string;
   loops?: Record<string, LoopConfig>;
   pipeline?: Pipeline;
   identity?: AgentIdentity;

--- a/packages/core/src/loop/selector.test.ts
+++ b/packages/core/src/loop/selector.test.ts
@@ -54,16 +54,19 @@ describe("resolveLoopSelection", () => {
     expect(selected.agent.skills).toEqual(["general", "testing"]);
   });
 
-  it("selects an assigned project-level loop without requiring inline definitions", () => {
+  it("selects an assigned project-level loop only when requested explicitly (no default)", () => {
     const agent = {
       name: "agent",
       model: "base",
       assignedLoops: ["coding-flow"],
-      defaultLoop: "coding-flow",
     };
 
-    expect(resolveLoopSelection(agent)!.name).toBe("coding-flow");
-    expect(resolveLoopSelection(agent, "coding-flow")!.agent).toBe(agent);
+    // No implicit default: nothing runs unless the loop is requested.
+    expect(resolveLoopSelection(agent)).toBeUndefined();
+    // Explicit request resolves the assigned loop without inline definitions.
+    const selected = resolveLoopSelection(agent, "coding-flow")!;
+    expect(selected.name).toBe("coding-flow");
+    expect(selected.agent).toBe(agent);
   });
 
   it("throws a clear error for unknown requested loops", () => {

--- a/packages/core/src/loop/selector.ts
+++ b/packages/core/src/loop/selector.ts
@@ -18,21 +18,11 @@ export function resolveActiveLoopSkills(agent: AgentConfig, loop?: LoopConfig): 
 
 export function resolveLoopSelection(agent: AgentConfig, requestedLoop?: string): LoopSelection | undefined {
   if (!requestedLoop) {
-    if (agent.defaultLoop) {
-      return {
-        name: agent.defaultLoop,
-        loop: { name: agent.defaultLoop, tools: agent.allowedTools, model: agent.model, reasoning: agent.reasoning, maxTurns: agent.maxTurns },
-        agent,
-      };
-    }
-    const defaultLoop = agent.loops?.default;
-    if (!defaultLoop) {
-      // No loop requested and none configured: run the agent as-is, with no
-      // loop overlay. We deliberately do NOT synthesize a "default" loop — the
-      // caller treats `undefined` as "no loop".
-      return undefined;
-    }
-    return materializeLoopSelection(agent, "default", defaultLoop);
+    // No loop requested: the agent runs as-is, with no loop overlay. There is
+    // deliberately no agent-level "default loop" concept — a loop only ever
+    // runs when explicitly requested (per call, or via a task's assigned loop).
+    // The caller treats `undefined` as "no loop".
+    return undefined;
   }
 
   const loop = agent.loops?.[requestedLoop];

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -129,8 +129,6 @@ export interface AgentConfig {
   toolChoice?: LoopToolChoice;
   /** Project-level loop names this agent is allowed to use. */
   assignedLoops?: string[];
-  /** Default project-level loop name for this agent. */
-  defaultLoop?: string;
   /** Legacy inline loop steps. Prefer project-level loops + assignedLoops. */
   loops?: Record<string, LoopConfig>;
   /** Legacy inline pipeline wiring loop, switch, parallel, and human steps. */

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -116,6 +116,9 @@ export interface Task {
   title: string;
   description: string;
   assignTo: string;
+  /** Project loop this task runs (a name in the agent's assignedLoops, or an
+   *  inline loop). Explicit — omitted means the agent runs as-is, no loop. */
+  loop?: string;
   group?: string;
   /** ID of the mission this task belongs to (set when created via executeMission). */
   missionId?: string;

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -1143,14 +1143,12 @@ describe("DrizzleAgentStore", () => {
     await stores.agentStore.createAgent({
       name: "claude",
       assignedLoops: ["Coding Loop"],
-      defaultLoop: "Coding Loop",
       loops: { plan: { systemPrompt: "Plan" } },
       pipeline: { steps: [{ loop: "plan" }] },
     } as any, "alpha");
 
     const created = await stores.agentStore.getAgent("claude") as any;
     expect(created.assignedLoops).toEqual(["Coding Loop"]);
-    expect(created.defaultLoop).toBe("Coding Loop");
     expect(created.loops).toBeUndefined();
     expect(created.pipeline).toBeUndefined();
 

--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -60,6 +60,8 @@ export async function ensurePgTables(db: any): Promise<void> {
 
   // OpenAI-compat user column — additive, idempotent
   await db.execute(sql`ALTER TABLE tasks ADD COLUMN IF NOT EXISTS "user" TEXT`);
+  // Explicit per-task project loop — additive, idempotent
+  await db.execute(sql`ALTER TABLE tasks ADD COLUMN IF NOT EXISTS loop TEXT`);
 
   await db.execute(sql`CREATE TABLE IF NOT EXISTS missions (
     id               TEXT PRIMARY KEY,

--- a/packages/drizzle/src/schema/tasks.ts
+++ b/packages/drizzle/src/schema/tasks.ts
@@ -8,6 +8,8 @@ export const tasksSqlite = sqliteTable("tasks", {
   title: text("title").notNull(),
   description: text("description").notNull(),
   assignTo: text("assign_to").notNull(),
+  /** Explicit project loop this task runs (name in the agent's assignedLoops). */
+  loop: text("loop"),
   group: text("group"),
   missionId: text("mission_id"),
   dependsOn: text("depends_on").notNull().default("[]"),
@@ -85,6 +87,8 @@ export const tasksPg = pgTable("tasks", {
   title: pgText("title").notNull(),
   description: pgText("description").notNull(),
   assignTo: pgText("assign_to").notNull(),
+  /** Explicit project loop this task runs (name in the agent's assignedLoops). */
+  loop: pgText("loop"),
   group: pgText("group"),
   missionId: pgText("mission_id"),
   dependsOn: jsonb("depends_on").notNull().default([]),

--- a/packages/drizzle/src/stores/task-store.ts
+++ b/packages/drizzle/src/stores/task-store.ts
@@ -33,6 +33,7 @@ export class DrizzleTaskStore implements TaskStore {
       title: row.title,
       description: row.description,
       assignTo: row.assignTo,
+      loop: row.loop ?? undefined,
       group: row.group ?? undefined,
       missionId: row.missionId ?? undefined,
       dependsOn: deserializeJson<string[]>(row.dependsOn, [], d),
@@ -69,6 +70,7 @@ export class DrizzleTaskStore implements TaskStore {
     if (task.title !== undefined) v.title = task.title;
     if (task.description !== undefined) v.description = task.description;
     if (task.assignTo !== undefined) v.assignTo = task.assignTo;
+    if (task.loop !== undefined) v.loop = task.loop;
     if (task.group !== undefined) v.group = task.group;
     if (task.missionId !== undefined) v.missionId = task.missionId;
     if (task.dependsOn !== undefined) v.dependsOn = serializeJson(task.dependsOn, d);

--- a/packages/node/src/__tests__/completions.test.ts
+++ b/packages/node/src/__tests__/completions.test.ts
@@ -191,7 +191,6 @@ describe("POST /v1/chat/completions", () => {
           name: "loop-agent",
           role: "Loop test agent",
           assignedLoops: ["plan"],
-          defaultLoop: "plan",
         }),
       });
       setMockModel(mockTextModel("Loop selected."));

--- a/packages/node/src/__tests__/loop-engine-pipeline-durable.test.ts
+++ b/packages/node/src/__tests__/loop-engine-pipeline-durable.test.ts
@@ -67,7 +67,6 @@ function makeAgent(loopName: string): AgentConfig {
     name: "pipeline-agent",
     role: "developer",
     assignedLoops: [loopName],
-    defaultLoop: loopName,
   };
 }
 
@@ -145,7 +144,7 @@ async function runEngine(model: MockLanguageModelV3, options: RunOptions) {
   activeResolvedModel = mockResolvedModel(model);
   const checkpoints: LoopResumeState[] = [];
   const transcript: Array<Record<string, unknown>> = [];
-  const handle = spawnLoopEngine(options.agent, makeTask(), cwd, {
+  const handle = spawnLoopEngine(options.agent, makeTask({ loop: options.agent.assignedLoops?.[0] }), cwd, {
     polpoDir,
     resumeState: options.resumeState,
     onTurnCheckpoint: (state) => {

--- a/packages/node/src/__tests__/loop-engine-pipeline.test.ts
+++ b/packages/node/src/__tests__/loop-engine-pipeline.test.ts
@@ -5,7 +5,7 @@
  * - project loop graphs (.polpo/loops/<name>.json) driven by the
  *   PipelineExecutor: agent steps as independent LLM sessions over a
  *   shared context bag, deterministic tool steps without LLM turns
- * - single-loop overlays (inline loops / defaultLoop): tools subset,
+ * - single-loop overlays (task.loop names an inline loop): tools subset,
  *   maxTurns, systemPrompt merge — same semantics as chat completions
  *
  * Agents WITHOUT loop config are covered by the parity suite in
@@ -67,7 +67,10 @@ interface TranscriptEntry {
 async function runAgent(agent: AgentConfig, responses: MockResponse[]) {
   activeResolvedModel = mockResolvedModel(mockTurnSequenceModel(responses));
   const transcript: TranscriptEntry[] = [];
-  const handle = spawnLoopEngine(agent, makeTask(), cwd, { polpoDir, outputDir });
+  // Loops now run only when the task explicitly requests one. Request the
+  // agent's assigned project loop, or its inline loop, by name.
+  const loop = agent.assignedLoops?.[0] ?? Object.keys(agent.loops ?? {})[0];
+  const handle = spawnLoopEngine(agent, makeTask({ loop }), cwd, { polpoDir, outputDir });
   handle.onTranscript = (entry) => transcript.push(entry as TranscriptEntry);
   const result = await handle.done;
   return { handle, result, transcript };
@@ -109,7 +112,6 @@ describe("spawnLoopEngine — project loop graphs", () => {
         name: "loop-agent",
         role: "developer",
         assignedLoops: ["ship-flow"],
-        defaultLoop: "ship-flow",
       },
       [
         { type: "text", text: "PLAN: do the thing" },
@@ -154,7 +156,6 @@ describe("spawnLoopEngine — project loop graphs", () => {
         name: "loop-agent",
         role: "developer",
         assignedLoops: ["fetch-flow"],
-        defaultLoop: "fetch-flow",
       },
       [
         // Only ONE model response: the summarize step. The greet tool step
@@ -179,7 +180,6 @@ describe("spawnLoopEngine — project loop graphs", () => {
         name: "loop-agent",
         role: "developer",
         assignedLoops: ["ghost-flow"],
-        defaultLoop: "ghost-flow",
       },
       [{ type: "text", text: "never used" }],
     );
@@ -203,7 +203,6 @@ describe("spawnLoopEngine — project loop graphs", () => {
         name: "loop-agent",
         role: "developer",
         assignedLoops: ["human-flow"],
-        defaultLoop: "human-flow",
       },
       [{ type: "text", text: "never used" }],
     );

--- a/packages/node/src/__tests__/server-api.test.ts
+++ b/packages/node/src/__tests__/server-api.test.ts
@@ -490,7 +490,6 @@ describe("Agents API", () => {
         role: "loop router",
         runtime: "polpo-runner",
         assignedLoops: ["router-flow"],
-        defaultLoop: "router-flow",
       }),
     );
     expect(res.status).toBe(201);
@@ -500,7 +499,6 @@ describe("Agents API", () => {
     const agent = listBody.data.find((a: any) => a.name === "agent-loop-create");
     expect(agent.runtime).toBe("polpo-runner");
     expect(agent.assignedLoops).toEqual(["router-flow"]);
-    expect(agent.defaultLoop).toBe("router-flow");
     expect(agent.loops).toBeUndefined();
     expect(agent.pipeline).toBeUndefined();
   });
@@ -1166,7 +1164,6 @@ describe("Update Agent API", () => {
       jsonReq("PATCH", {
         runtime: "polpo-runner",
         assignedLoops: ["classify-flow"],
-        defaultLoop: "classify-flow",
       }),
     );
     expect(res.status).toBe(200);
@@ -1174,7 +1171,6 @@ describe("Update Agent API", () => {
     expect(body.ok).toBe(true);
     expect(body.data.runtime).toBe("polpo-runner");
     expect(body.data.assignedLoops).toEqual(["classify-flow"]);
-    expect(body.data.defaultLoop).toBe("classify-flow");
     expect(body.data.loops).toBeUndefined();
     expect(body.data.pipeline).toBeUndefined();
 

--- a/packages/node/src/adapters/loop-engine.ts
+++ b/packages/node/src/adapters/loop-engine.ts
@@ -5,12 +5,12 @@
  * but the agentic loop is @polpo-ai/core's LoopRunner instead of a manual
  * for-loop, and agents with configured loops get the full graph runtime:
  *
- * - No loop config on the agent  → one implicit "default" loop, behavior
+ * - No loop requested (task.loop unset) → plain agent turn-loop, behavior
  *   identical to the legacy engine (proven by the parity suite).
- * - defaultLoop/loops on the agent → the selected loop's overlays apply
+ * - task.loop names an inline loop → the selected loop's overlays apply
  *   (tools subset, systemPrompt, model, maxTurns), same merge semantics
  *   as chat completions (buildLoopStepAgent).
- * - assignedLoops + project loop graph (.polpo/loops/<name>.json) → the
+ * - task.loop names an assignedLoops project loop graph (.polpo/loops/<name>.json) → the
  *   PipelineExecutor drives the step graph: agent steps are independent
  *   LLM sessions communicating through the context bag, tool steps run
  *   deterministically without an LLM turn.
@@ -720,7 +720,7 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
         alive = false;
         return { exitCode: 0, stdout: session.lastText, stderr: "", duration: Date.now() - start };
       }
-      const selection = resolveLoopSelection(agentConfig);
+      const selection = resolveLoopSelection(agentConfig, task.loop);
 
       let stdout: string;
       if (!selection) {
@@ -746,7 +746,7 @@ export function spawnLoopEngine(agentConfig: AgentConfig, task: Task, cwd: strin
         const projectLoop = await loadProjectLoop(fs, ctx.polpoDir, selection.name);
         stdout = await runPipeline(projectLoop);
       } else {
-        // Selected single loop (defaultLoop or inline loops.default):
+        // Selected single loop (task.loop names an inline loop):
         // apply the loop's overlays, same semantics as completions.
         const stepAgent = buildLoopStepAgent(agentConfig, selection.name, selection.loop);
         const session = await runLoopSession({

--- a/packages/server/src/loop-contract.test.ts
+++ b/packages/server/src/loop-contract.test.ts
@@ -6,24 +6,11 @@ describe("agent loop API contract", () => {
     expect(AddAgentSchema.parse({
       name: "loop-agent",
       assignedLoops: ["coding-flow"],
-      defaultLoop: "coding-flow",
-    })).toMatchObject({ assignedLoops: ["coding-flow"], defaultLoop: "coding-flow" });
+    })).toMatchObject({ assignedLoops: ["coding-flow"] });
 
     expect(UpdateAgentSchema.parse({
       assignedLoops: ["coding-flow", "support-flow"],
-      defaultLoop: "support-flow",
-    })).toMatchObject({ defaultLoop: "support-flow" });
-  });
-
-  it("rejects defaultLoop when it is not assigned", () => {
-    const parsed = AddAgentSchema.safeParse({
-      name: "loop-agent",
-      assignedLoops: ["coding-flow"],
-      defaultLoop: "missing-flow",
-    });
-
-    expect(parsed.success).toBe(false);
-    expect(parsed.error?.issues[0]?.message).toContain("is not in assignedLoops");
+    })).toMatchObject({ assignedLoops: ["coding-flow", "support-flow"] });
   });
 
   it("strips legacy inline loops from agent create/update payloads", () => {

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -96,7 +96,6 @@ export function agentRoutes(getDeps: () => {
       reportsTo: body.reportsTo,
       runtime: body.runtime,
       assignedLoops: body.assignedLoops,
-      defaultLoop: body.defaultLoop,
       browserProfile: body.browserProfile,
       mcpServers: body.mcpServers,
     }, teamName);
@@ -398,7 +397,6 @@ export function agentRoutes(getDeps: () => {
       ...(body.reasoning !== undefined && { reasoning: body.reasoning }),
       ...(body.runtime !== undefined && { runtime: body.runtime }),
       ...(body.assignedLoops !== undefined && { assignedLoops: body.assignedLoops }),
-      ...(body.defaultLoop !== undefined && { defaultLoop: body.defaultLoop }),
       ...(body.maxTurns !== undefined && { maxTurns: body.maxTurns }),
       ...(body.maxConcurrency !== undefined && { maxConcurrency: body.maxConcurrency }),
       ...(body.browserProfile !== undefined && { browserProfile: body.browserProfile }),

--- a/packages/server/src/routes/completions-loop-runtime.test.ts
+++ b/packages/server/src/routes/completions-loop-runtime.test.ts
@@ -10,7 +10,6 @@ describe("completionRoutes project loop runtime", () => {
         name: "timer",
         model: "test",
         assignedLoops: ["time-tracker"],
-        defaultLoop: "time-tracker",
         allowedTools: ["unix_time"],
       }],
       getConfig: () => ({}),
@@ -65,6 +64,7 @@ describe("completionRoutes project loop runtime", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         agent: "timer",
+        loop: "time-tracker",
         messages: [{ role: "user", content: "track it" }],
       }),
     });
@@ -109,6 +109,7 @@ describe("completionRoutes project loop runtime", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         agent: "timer",
+        loop: "time-tracker",
         messages: [{ role: "user", content: "track it" }],
       }),
     });
@@ -143,6 +144,7 @@ describe("completionRoutes project loop runtime", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         agent: "timer",
+        loop: "time-tracker",
         stream: true,
         messages: [{ role: "user", content: "track it" }],
       }),
@@ -199,6 +201,7 @@ describe("completionRoutes project loop runtime", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         agent: "timer",
+        loop: "time-tracker",
         messages: [{ role: "user", content: "track it" }],
       }),
     });
@@ -240,6 +243,7 @@ describe("completionRoutes project loop runtime", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         agent: "timer",
+        loop: "time-tracker",
         messages: [{ role: "user", content: "track it" }],
       }),
     });

--- a/packages/server/src/routes/completions-provider-tools.test.ts
+++ b/packages/server/src/routes/completions-provider-tools.test.ts
@@ -33,7 +33,6 @@ describe("completionRoutes provider-executed tools", () => {
         name: "researcher",
         model: "test",
         assignedLoops: ["research-loop"],
-        defaultLoop: "research-loop",
         allowedTools: ["search_web"],
       }],
       getConfig: () => ({}),
@@ -144,6 +143,7 @@ describe("completionRoutes provider-executed tools", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         agent: "researcher",
+        loop: "research-loop",
         messages: [{ role: "user", content: "Research Polpo" }],
       }),
     });
@@ -186,7 +186,6 @@ describe("completionRoutes loop agent-step tool streaming", () => {
         name: "coder",
         model: "test",
         assignedLoops: ["coding-loop"],
-        defaultLoop: "coding-loop",
         allowedTools: ["bash"],
       }],
       getConfig: () => ({}),
@@ -269,6 +268,7 @@ describe("completionRoutes loop agent-step tool streaming", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         agent: "coder",
+        loop: "coding-loop",
         stream: true,
         messages: [{ role: "user", content: "change the app" }],
       }),

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -324,6 +324,7 @@ export function taskRoutes(getDeps: () => {
       title: body.title,
       description: body.description,
       assignTo: body.assignTo,
+      loop: body.loop,
       expectations: body.expectations,
       expectedOutcomes: body.expectedOutcomes,
       dependsOn: body.dependsOn,
@@ -359,6 +360,9 @@ export function taskRoutes(getDeps: () => {
     }
     if (body.assignTo !== undefined) {
       await deps.updateTaskAssignment(taskId, body.assignTo);
+    }
+    if (body.loop !== undefined) {
+      await deps.taskStore.updateTask(taskId, { loop: body.loop });
     }
     if (body.expectations !== undefined) {
       await deps.updateTaskExpectations(taskId, body.expectations);

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -67,6 +67,8 @@ export const CreateTaskSchema = z.object({
   title: z.string().min(1),
   description: z.string().min(1),
   assignTo: z.string().min(1),
+  /** Explicit project loop this task runs (a name in the agent's assignedLoops). */
+  loop: z.string().min(1).optional(),
   /** Create task as draft (won't be picked up by orchestrator until moved to pending). Default: false. */
   draft: z.boolean().optional(),
   expectations: z.array(z.any()).optional(),
@@ -95,6 +97,7 @@ export const CreateTaskSchema = z.object({
 export const UpdateTaskSchema = z.object({
   description: z.string().min(1).optional(),
   assignTo: z.string().min(1).optional(),
+  loop: z.string().min(1).optional(),
   status: z.enum(["draft", "pending", "awaiting_approval", "assigned", "in_progress", "review", "done", "failed"]).optional(),
   expectations: z.array(z.any()).optional(),
   retries: z.number().int().min(0).optional(),
@@ -512,15 +515,6 @@ function collectLoopRefs(step: unknown, refs: string[]): void {
 const AgentLoopFieldsSchema = z.object({
   runtime: z.string().optional(),
   assignedLoops: z.array(z.string().min(1)).optional(),
-  defaultLoop: z.string().min(1).optional(),
-}).superRefine((config, ctx) => {
-  if (config.defaultLoop && config.assignedLoops && !config.assignedLoops.includes(config.defaultLoop)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `defaultLoop "${config.defaultLoop}" is not in assignedLoops`,
-      path: ["defaultLoop"],
-    });
-  }
 });
 
 export const AddAgentSchema = z.object({


### PR DESCRIPTION
Completes the *no forced default* direction: an agent no longer auto-runs a default loop — a loop runs **only when explicitly requested**, per invocation.

- **core**: drop `AgentConfig.defaultLoop` entirely. `resolveLoopSelection` with no requested loop **always returns `undefined`** (no `defaultLoop`, no `loops.default` auto-selection). `Task` gains an explicit **`loop`** field.
- **node**: loop-engine passes `task.loop` to `resolveLoopSelection` → a task runs its project loop only when it names one; no `task.loop` → plain agent turn-loop.
- **drizzle**: `tasks.loop` column (sqlite + pg) + `migrate.ts` ALTER (PG drift gotcha) + store round-trip.
- **server**: `CreateTask`/`UpdateTask` accept `loop` and the route persists it; agents route + `AgentLoopFieldsSchema` drop `defaultLoop` (+ its validation).
- **client-sdk / cli**: drop `defaultLoop` from mirrored types + pull.

Chat already had explicit `body.loop`; this gives tasks the same explicit channel. Full build green; **core 148 · node 1040 · server 21 · drizzle 118 · cli 267**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)