### PR TITLE
Release v0.15.3 — F2 PR4: flip loop-run reads to runs (shadow)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polpo-ai",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "The open backend for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/cli",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Command-line client for Polpo — create/link/deploy cloud projects from your terminal.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/sdk",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Polpo SDK — typed HTTP client, SSE streaming, and reactive store for AI agent orchestration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/core",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Pure business logic, types, schemas, and store interfaces for the Polpo AI agent orchestration platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/drizzle",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Drizzle ORM store implementations for the Polpo AI agent orchestration platform (PostgreSQL + SQLite)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/drizzle/src/__tests__/stores.test.ts
+++ b/packages/drizzle/src/__tests__/stores.test.ts
@@ -505,6 +505,24 @@ describe("DrizzleLoopRunStore — dual-write + runs-backed (F2)", () => {
     await backfillLoopRunsIntoRuns(db, "sqlite");
     expect(await db.select().from(runsSqlite).where(eq(runsSqlite.id, "hist-1"))).toHaveLength(1);
   });
+
+  it("after the PR4 flip, reads come from the shadow (runs), not legacy", async () => {
+    const { DrizzleLoopRunStore, DualWriteLoopRunStore } = await import("../stores/loop-run-store.js");
+    const { loopRunsSqlite } = await import("../schema/loop-runs.js");
+    const { runsSqlite } = await import("../schema/runs.js");
+    const legacy = new DrizzleLoopRunStore(db, loopRunsSqlite, "sqlite");
+    const shadow = new DrizzleLoopRunStore(db, runsSqlite, "sqlite", true);
+    const store = new DualWriteLoopRunStore(legacy, shadow, "shadow");
+
+    await store.createRun({ id: "lr-flip", loop: { name: "review" }, agentName: "chat" } as any);
+    // Diverge the two tables: legacy stays running, shadow completes.
+    await legacy.updateRun("lr-flip", { status: "running" as any });
+    await shadow.updateRun("lr-flip", { status: "completed" as any });
+
+    // readFrom="shadow" → the dual-write store returns the shadow's value.
+    expect((await store.getRun("lr-flip"))?.status).toBe("completed");
+    expect((await store.listRuns()).find((r) => r.id === "lr-flip")?.status).toBe("completed");
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -126,12 +126,12 @@ export function createPgStores(db: any): DrizzleStores {
     missionStore: taskStore as unknown as MissionStore,
     runStore: new DrizzleRunStore(db, runsPg, "pg"),
     // F2: dual-write loop runs to both loop_runs (legacy) and runs (shadow,
-    // engine="graph"); read from legacy until backfill+flip. Drops to the plain
-    // runs-backed store at PR5.
+    // engine="graph"). Reads now come from runs (shadow) — flipped in PR4 after
+    // the backfill. loop_runs is still written for rollback until PR5 drops it.
     loopRunStore: new DualWriteLoopRunStore(
       new DrizzleLoopRunStore(db, loopRunsPg, "pg"),
       new DrizzleLoopRunStore(db, runsPg, "pg", true),
-      "legacy",
+      "shadow",
     ),
     sessionStore: new DrizzleSessionStore(db, sessionsPg, messagesPg, "pg"),
     logStore: new DrizzleLogStore(db, logSessionsPg, logEntriesPg, "pg"),
@@ -165,11 +165,11 @@ export function createSqliteStores(db: any): DrizzleStores {
     // Same instance: the Drizzle task store also implements the mission block.
     missionStore: taskStore as unknown as MissionStore,
     runStore: new DrizzleRunStore(db, runsSqlite, "sqlite"),
-    // F2: dual-write (see pg factory above).
+    // F2: dual-write, reads from shadow (see pg factory above).
     loopRunStore: new DualWriteLoopRunStore(
       new DrizzleLoopRunStore(db, loopRunsSqlite, "sqlite"),
       new DrizzleLoopRunStore(db, runsSqlite, "sqlite", true),
-      "legacy",
+      "shadow",
     ),
     sessionStore: new DrizzleSessionStore(db, sessionsSqlite, messagesSqlite, "sqlite"),
     logStore: new DrizzleLogStore(db, logSessionsSqlite, logEntriesSqlite, "sqlite"),

--- a/packages/file-stores/package.json
+++ b/packages/file-stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/file-stores",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "File-based store implementations for Polpo — the default zero-dependency persistence backend (JSON/Markdown files)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/llm",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "LLM abstraction for Polpo — multi-provider model resolution, streaming, cost tracking, and failover built on Vercel AI SDK + AI Gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/node",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Polpo Node.js runtime — orchestrator wiring, adapters, server assembly, runner entry. The composition root behind the polpo-ai package.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/react",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "React SDK for OpenPolpo — hooks with real-time SSE updates, built on @polpo-ai/sdk",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/server",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Polpo API route factories — edge-compatible Hono routes for tasks, agents, missions, vault, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/tools",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Agent tools for Polpo — coding, browser, email, search, and more. Core tools work everywhere, extended tools are opt-in.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vault-crypto/package.json
+++ b/packages/vault-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polpo-ai/vault-crypto",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "AES-256-GCM encryption helpers for Polpo vault stores",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps all 12 `@polpo-ai` packages **0.15.2 → 0.15.3**.

**F2 PR4** — `DualWriteLoopRunStore` now **reads from the shadow** (`runs`, `engine='graph'`) instead of legacy (`loop_runs`). Writes still go to **both** tables, so `loop_runs` remains a rollback path until **PR5** drops it.

**Safe by construction in cloud**: `initProject` runs `ensurePgSchema → backfill → createPgStores`, so the backfill has populated `runs` before the `loopRunStore` is ever read. New test asserts reads return the shadow's value when the two tables diverge. drizzle **119 green**.

After merge: tag `v0.15.3` → publish → cloud upgrade → deploy → validate → then PR5 (drop `loop_runs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)