### PR TITLE
[codex] Add Polpo Connect core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
           pnpm --filter @polpo-ai/vault-crypto pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/drizzle pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/llm pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/connect pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/connect-server pack --pack-destination /tmp/tarballs
+          pnpm --filter @polpo-ai/connectors pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/server pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/tools pack --pack-destination /tmp/tarballs
           pnpm --filter @polpo-ai/cli pack --pack-destination /tmp/tarballs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish @polpo-ai/connect
+        run: pnpm --filter @polpo-ai/connect publish --no-git-checks --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @polpo-ai/connect-server
+        run: pnpm --filter @polpo-ai/connect-server publish --no-git-checks --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @polpo-ai/connectors
+        run: pnpm --filter @polpo-ai/connectors publish --no-git-checks --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish @polpo-ai/tools
         run: pnpm --filter @polpo-ai/tools publish --no-git-checks --provenance --access public
         env:

--- a/packages/connect-server/README.md
+++ b/packages/connect-server/README.md
@@ -1,0 +1,15 @@
+# @polpo-ai/connect-server
+
+Server-side primitives for Polpo Connect.
+
+This package implements the backend lifecycle for API-key and OAuth2 connections:
+
+- API-key connection creation
+- OAuth authorization URL generation
+- OAuth callback and token exchange
+- access token retrieval
+- refresh token handling
+- policy checks before token release
+- revocation and secret deletion
+
+It is intentionally framework-agnostic. Cloud/OSS servers can mount it through Hono, Express, Workers, or another transport without coupling the core lifecycle to HTTP routes.

--- a/packages/connect-server/package.json
+++ b/packages/connect-server/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@polpo-ai/connect-server",
+  "version": "0.15.3",
+  "description": "Server-side Polpo Connect primitives for OAuth, API-key connections, token refresh, and policy checks",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "prepublishOnly": "tsc"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "dependencies": {
+    "@polpo-ai/connect": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.4"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "polpo",
+    "oauth",
+    "connectors",
+    "agents",
+    "permissions"
+  ],
+  "author": "OpenPolpo Contributors",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lumea-labs/polpo.git",
+    "directory": "packages/connect-server"
+  },
+  "homepage": "https://github.com/lumea-labs/polpo/tree/main/packages/connect-server",
+  "bugs": {
+    "url": "https://github.com/lumea-labs/polpo/issues"
+  }
+}

--- a/packages/connect-server/src/__tests__/connect-service.test.ts
+++ b/packages/connect-server/src/__tests__/connect-service.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConnectError, type ConnectorProviderDefinition, type TokenSet } from "@polpo-ai/connect";
+import { MemoryConnectStore, MemoryConnectionSecretStore, createConnectService } from "../index.js";
+
+const oauthProvider: ConnectorProviderDefinition = {
+  id: "test_oauth",
+  name: "Test OAuth",
+  auth: {
+    type: "oauth2",
+    authorizationUrl: "https://auth.example/authorize",
+    tokenUrl: "https://auth.example/token",
+    clientId: "client_id",
+    clientSecret: "client_secret",
+    defaultScopes: ["read"],
+    extraAuthorizeParams: { audience: "polpo" },
+  },
+  scopes: [
+    { id: "read" },
+    { id: "write", dangerous: true },
+  ],
+};
+
+const apiKeyProvider: ConnectorProviderDefinition = {
+  id: "custom_api",
+  name: "Custom API",
+  auth: {
+    type: "api_key",
+    defaultScopes: ["use"],
+  },
+  scopes: [{ id: "use" }],
+};
+
+describe("connect service", () => {
+  it("creates API-key connections and returns runtime tokens without leaking metadata", async () => {
+    const { service, secrets } = createHarness();
+    const connection = await service.createApiKeyConnection({
+      providerId: "custom_api",
+      apiKey: "  sk_live_123  ",
+      scopes: ["use"],
+      subject: { type: "user", id: "usr_1" },
+    });
+
+    expect(connection.status).toBe("active");
+    expect(connection.secretRef).toMatch(/^connsec_/);
+    expect(connection).not.toHaveProperty("apiKey");
+    expect(await secrets.getSecret(connection.secretRef!)).toEqual({ kind: "api_key", apiKey: "sk_live_123" });
+
+    await expect(service.getToken({ connectionId: connection.id, scopes: ["use"] })).resolves.toMatchObject({
+      accessToken: "sk_live_123",
+      tokenType: "ApiKey",
+      providerId: "custom_api",
+    });
+  });
+
+  it("rejects empty API keys and invalid API-key scopes", async () => {
+    const { service } = createHarness();
+    await expect(service.createApiKeyConnection({ providerId: "custom_api", apiKey: "  " })).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+    await expect(service.createApiKeyConnection({ providerId: "custom_api", apiKey: "sk", scopes: ["admin"] })).rejects.toMatchObject({
+      code: "invalid_scope",
+    });
+  });
+
+  it("builds OAuth authorization URLs with state, PKCE, normalized scopes, and extra params", async () => {
+    const { service } = createHarness();
+    const started = await service.startOAuth({
+      providerId: "test_oauth",
+      scopes: ["write", "read", "write"],
+      redirectUri: "https://app.example/callback",
+      subject: { type: "user", id: "usr_1" },
+    });
+
+    const url = new URL(started.authorizationUrl);
+    expect(url.origin + url.pathname).toBe("https://auth.example/authorize");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("client_id");
+    expect(url.searchParams.get("redirect_uri")).toBe("https://app.example/callback");
+    expect(url.searchParams.get("state")).toBe(started.state);
+    expect(url.searchParams.get("scope")).toBe("read write");
+    expect(url.searchParams.get("audience")).toBe("polpo");
+    expect(url.searchParams.get("code_challenge")).toBeTruthy();
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("fails OAuth start when provider credentials are incomplete", async () => {
+    const { service } = createHarness({
+      providers: [{ ...oauthProvider, auth: { ...oauthProvider.auth, clientId: undefined } }],
+    });
+
+    await expect(service.startOAuth({ providerId: "test_oauth", redirectUri: "https://app.example/callback" })).rejects.toMatchObject({
+      code: "invalid_provider",
+    });
+  });
+
+  it("exchanges OAuth code, stores tokens, and rejects reused state", async () => {
+    const fetchImpl = queueFetch([
+      jsonResponse(200, {
+        access_token: "access_1",
+        refresh_token: "refresh_1",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read write",
+      }),
+    ]);
+    const { service } = createHarness({ fetchImpl });
+    const started = await service.startOAuth({
+      providerId: "test_oauth",
+      scopes: ["read", "write"],
+      redirectUri: "https://app.example/callback",
+      connectionName: "Main account",
+    });
+    const connection = await service.completeOAuth({ state: started.state, code: "code_123" });
+
+    expect(connection).toMatchObject({
+      providerId: "test_oauth",
+      name: "Main account",
+      status: "active",
+      grantedScopes: ["read", "write"],
+    });
+    await expect(service.getToken({ connectionId: connection.id, scopes: ["read"] })).resolves.toMatchObject({
+      accessToken: "access_1",
+      tokenType: "Bearer",
+    });
+    await expect(service.completeOAuth({ state: started.state, code: "code_123" })).rejects.toMatchObject({
+      code: "oauth_state_not_found",
+    });
+
+    const body = String(fetchImpl.calls[0]!.init.body);
+    expect(body).toContain("grant_type=authorization_code");
+    expect(body).toContain("client_secret=client_secret");
+    expect(body).toContain("code_verifier=");
+  });
+
+  it("consumes OAuth state even when provider returns an OAuth error", async () => {
+    const { service } = createHarness();
+    const started = await service.startOAuth({ providerId: "test_oauth", redirectUri: "https://app.example/callback" });
+
+    await expect(service.completeOAuth({ state: started.state, error: "access_denied", errorDescription: "Denied" })).rejects.toMatchObject({
+      code: "oauth_error",
+    });
+    await expect(service.completeOAuth({ state: started.state, code: "code_123" })).rejects.toMatchObject({
+      code: "oauth_state_not_found",
+    });
+  });
+
+  it("rejects expired OAuth state before exchanging code", async () => {
+    let nowMs = Date.UTC(2026, 0, 1, 10, 0, 0);
+    const fetchImpl = queueFetch([jsonResponse(200, { access_token: "should_not_be_called" })]);
+    const { service } = createHarness({ now: () => new Date(nowMs), fetchImpl, oauthStateTtlMs: 1_000 });
+    const started = await service.startOAuth({ providerId: "test_oauth", redirectUri: "https://app.example/callback" });
+    nowMs += 1_001;
+
+    await expect(service.completeOAuth({ state: started.state, code: "code_123" })).rejects.toMatchObject({
+      code: "oauth_state_expired",
+    });
+    expect(fetchImpl.calls).toHaveLength(0);
+  });
+
+  it("rejects broken token endpoint responses", async () => {
+    for (const response of [
+      jsonResponse(500, { error: "temporarily_unavailable" }),
+      textResponse(200, "{not json"),
+      jsonResponse(200, { refresh_token: "refresh_without_access" }),
+    ]) {
+      const { service } = createHarness({ fetchImpl: queueFetch([response]) });
+      const started = await service.startOAuth({ providerId: "test_oauth", redirectUri: "https://app.example/callback" });
+      await expect(service.completeOAuth({ state: started.state, code: "code_123" })).rejects.toBeInstanceOf(ConnectError);
+    }
+  });
+
+  it("rejects OAuth tokens that grant scopes outside the curated provider contract", async () => {
+    const { service } = createHarness({
+      fetchImpl: queueFetch([jsonResponse(200, { access_token: "access_1", scope: "read admin" })]),
+    });
+    const started = await service.startOAuth({ providerId: "test_oauth", scopes: ["read"], redirectUri: "https://app.example/callback" });
+
+    await expect(service.completeOAuth({ state: started.state, code: "code_123" })).rejects.toMatchObject({
+      code: "invalid_scope",
+    });
+  });
+
+  it("refreshes expired OAuth tokens, preserves refresh token rotation fallback, and updates stored token", async () => {
+    let nowMs = Date.UTC(2026, 0, 1, 10, 0, 0);
+    const fetchImpl = queueFetch([
+      jsonResponse(200, {
+        access_token: "expired_access",
+        refresh_token: "refresh_1",
+        expires_in: 1,
+        scope: "read",
+      }),
+      jsonResponse(200, {
+        access_token: "fresh_access",
+        expires_in: 3600,
+        scope: "read",
+      }),
+    ]);
+    const { service, secrets } = createHarness({ now: () => new Date(nowMs), fetchImpl, tokenRefreshSkewMs: 0 });
+    const started = await service.startOAuth({ providerId: "test_oauth", scopes: ["read"], redirectUri: "https://app.example/callback" });
+    const connection = await service.completeOAuth({ state: started.state, code: "code_123" });
+
+    nowMs += 2_000;
+    await expect(service.getToken({ connectionId: connection.id, scopes: ["read"] })).resolves.toMatchObject({
+      accessToken: "fresh_access",
+    });
+    const secret = await secrets.getSecret(connection.secretRef!);
+    expect(secret?.tokens?.refreshToken).toBe("refresh_1");
+    expect(fetchImpl.calls[1]!.bodyString).toContain("grant_type=refresh_token");
+  });
+
+  it("fails expired OAuth tokens that cannot be refreshed", async () => {
+    let nowMs = Date.UTC(2026, 0, 1, 10, 0, 0);
+    const { service } = createHarness({
+      now: () => new Date(nowMs),
+      fetchImpl: queueFetch([jsonResponse(200, { access_token: "expired_access", expires_in: 1, scope: "read" })]),
+      tokenRefreshSkewMs: 0,
+    });
+    const started = await service.startOAuth({ providerId: "test_oauth", scopes: ["read"], redirectUri: "https://app.example/callback" });
+    const connection = await service.completeOAuth({ state: started.state, code: "code_123" });
+
+    nowMs += 2_000;
+    await expect(service.getToken({ connectionId: connection.id, scopes: ["read"] })).rejects.toMatchObject({
+      code: "token_not_available",
+    });
+  });
+
+  it("enforces requested scopes and optional runtime policy before returning tokens", async () => {
+    const { service } = createHarness({
+      policy: {
+        canUseConnection: ({ subject }) => subject?.id === "allowed_agent",
+      },
+    });
+    const connection = await service.createApiKeyConnection({ providerId: "custom_api", apiKey: "sk", scopes: ["use"] });
+
+    await expect(service.getToken({ connectionId: connection.id, scopes: ["admin"] })).rejects.toMatchObject({
+      code: "invalid_scope",
+    });
+    await expect(
+      service.getToken({ connectionId: connection.id, scopes: ["use"], subject: { type: "agent", id: "blocked_agent" } }),
+    ).rejects.toMatchObject({ code: "policy_denied" });
+    await expect(
+      service.getToken({ connectionId: connection.id, scopes: ["use"], subject: { type: "agent", id: "allowed_agent" } }),
+    ).resolves.toMatchObject({ accessToken: "sk" });
+  });
+
+  it("revokes connections and deletes stored secrets", async () => {
+    const { service, secrets } = createHarness();
+    const connection = await service.createApiKeyConnection({ providerId: "custom_api", apiKey: "sk", scopes: ["use"] });
+    const secretRef = connection.secretRef!;
+
+    const revoked = await service.revokeConnection({ connectionId: connection.id });
+    expect(revoked.status).toBe("revoked");
+    expect(revoked.secretRef).toBeUndefined();
+    expect(await secrets.getSecret(secretRef)).toBeNull();
+    await expect(service.getToken({ connectionId: connection.id })).rejects.toMatchObject({ code: "connection_revoked" });
+  });
+});
+
+function createHarness(input: {
+  providers?: ConnectorProviderDefinition[];
+  fetchImpl?: MockFetch;
+  now?: () => Date;
+  tokenRefreshSkewMs?: number;
+  oauthStateTtlMs?: number;
+  policy?: Parameters<typeof createConnectService>[0]["policy"];
+} = {}) {
+  const store = new MemoryConnectStore();
+  const secrets = new MemoryConnectionSecretStore();
+  const service = createConnectService({
+    providers: input.providers ?? [oauthProvider, apiKeyProvider],
+    store,
+    secrets,
+    fetch: input.fetchImpl ?? queueFetch([]),
+    now: input.now ?? (() => new Date(Date.UTC(2026, 0, 1, 10, 0, 0))),
+    tokenRefreshSkewMs: input.tokenRefreshSkewMs,
+    oauthStateTtlMs: input.oauthStateTtlMs,
+    policy: input.policy,
+  });
+  return { service, store, secrets };
+}
+
+interface MockFetchCall {
+  url: string;
+  init: RequestInit;
+  bodyString: string;
+}
+
+type MockFetch = ReturnType<typeof queueFetch>;
+
+function queueFetch(responses: Response[]) {
+  const calls: MockFetchCall[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL | Request, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init, bodyString: String(init.body ?? "") });
+    const next = responses.shift();
+    if (!next) throw new Error("Unexpected fetch call");
+    return next;
+  });
+  return Object.assign(fetchImpl, { calls });
+}
+
+function jsonResponse(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function textResponse(status: number, text: string): Response {
+  return new Response(text, { status });
+}

--- a/packages/connect-server/src/index.ts
+++ b/packages/connect-server/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./memory-store.js";
+export * from "./oauth.js";
+export * from "./secrets.js";
+export * from "./service.js";

--- a/packages/connect-server/src/memory-store.ts
+++ b/packages/connect-server/src/memory-store.ts
@@ -1,0 +1,55 @@
+import { ConnectError, type ConnectStore, type ConnectionListFilter, type ConnectionRecord, type OAuthStateRecord } from "@polpo-ai/connect";
+
+export class MemoryConnectStore implements ConnectStore {
+  private readonly connections = new Map<string, ConnectionRecord>();
+  private readonly oauthStates = new Map<string, OAuthStateRecord>();
+
+  async listConnections(filter: ConnectionListFilter = {}): Promise<ConnectionRecord[]> {
+    return [...this.connections.values()].filter((connection) => matchesFilter(connection, filter)).map(clone);
+  }
+
+  async getConnection(id: string): Promise<ConnectionRecord | null> {
+    const record = this.connections.get(id);
+    return record ? clone(record) : null;
+  }
+
+  async upsertConnection(record: ConnectionRecord): Promise<ConnectionRecord> {
+    this.connections.set(record.id, clone(record));
+    return clone(record);
+  }
+
+  async updateConnection(id: string, patch: Partial<Omit<ConnectionRecord, "id" | "createdAt">>): Promise<ConnectionRecord> {
+    const existing = this.connections.get(id);
+    if (!existing) throw new ConnectError("connection_not_found", `Connection not found: ${id}`);
+    const updated = { ...existing, ...patch, id, createdAt: existing.createdAt };
+    this.connections.set(id, clone(updated));
+    return clone(updated);
+  }
+
+  async deleteConnection(id: string): Promise<void> {
+    this.connections.delete(id);
+  }
+
+  async saveOAuthState(record: OAuthStateRecord): Promise<void> {
+    this.oauthStates.set(record.state, clone(record));
+  }
+
+  async consumeOAuthState(state: string): Promise<OAuthStateRecord | null> {
+    const record = this.oauthStates.get(state);
+    this.oauthStates.delete(state);
+    return record ? clone(record) : null;
+  }
+}
+
+function matchesFilter(connection: ConnectionRecord, filter: ConnectionListFilter): boolean {
+  if (filter.providerId && connection.providerId !== filter.providerId) return false;
+  if (filter.projectId && connection.projectId !== filter.projectId) return false;
+  if (filter.orgId && connection.orgId !== filter.orgId) return false;
+  if (filter.status && connection.status !== filter.status) return false;
+  if (filter.owner && (connection.owner?.type !== filter.owner.type || connection.owner.id !== filter.owner.id)) return false;
+  return true;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/packages/connect-server/src/oauth.ts
+++ b/packages/connect-server/src/oauth.ts
@@ -1,0 +1,24 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export function createOpaqueToken(bytes = 32): string {
+  return randomBytes(bytes).toString("base64url");
+}
+
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = createOpaqueToken(48);
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+export function toFormBody(input: Record<string, string | undefined>): URLSearchParams {
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined && value !== "") body.set(key, value);
+  }
+  return body;
+}
+
+export function parseScopes(scope: string | undefined, fallback: readonly string[]): string[] {
+  if (!scope) return [...fallback];
+  return scope.split(/[,\s]+/).map((part) => part.trim()).filter(Boolean);
+}

--- a/packages/connect-server/src/secrets.ts
+++ b/packages/connect-server/src/secrets.ts
@@ -1,0 +1,28 @@
+import type { StoredConnectionSecret } from "@polpo-ai/connect";
+
+export interface ConnectionSecretStore {
+  setSecret(ref: string, secret: StoredConnectionSecret): Promise<void>;
+  getSecret(ref: string): Promise<StoredConnectionSecret | null>;
+  deleteSecret(ref: string): Promise<void>;
+}
+
+export class MemoryConnectionSecretStore implements ConnectionSecretStore {
+  private readonly records = new Map<string, StoredConnectionSecret>();
+
+  async setSecret(ref: string, secret: StoredConnectionSecret): Promise<void> {
+    this.records.set(ref, clone(secret));
+  }
+
+  async getSecret(ref: string): Promise<StoredConnectionSecret | null> {
+    const secret = this.records.get(ref);
+    return secret ? clone(secret) : null;
+  }
+
+  async deleteSecret(ref: string): Promise<void> {
+    this.records.delete(ref);
+  }
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/packages/connect-server/src/service.ts
+++ b/packages/connect-server/src/service.ts
@@ -1,0 +1,390 @@
+import {
+  ConnectError,
+  assertAllowedScopes,
+  assertGrantedScopes,
+  createConnectorRegistry,
+  normalizeScopes,
+  type ConnectPolicy,
+  type ConnectStore,
+  type ConnectSubject,
+  type ConnectionRecord,
+  type ConnectorProviderDefinition,
+  type OAuth2AuthConfig,
+  type RuntimeToken,
+  type StoredConnectionSecret,
+  type TokenSet,
+} from "@polpo-ai/connect";
+import type { ConnectionSecretStore } from "./secrets.js";
+import { createOpaqueToken, createPkcePair, parseScopes, toFormBody } from "./oauth.js";
+
+export interface CreateConnectServiceOptions {
+  providers: readonly ConnectorProviderDefinition[];
+  store: ConnectStore;
+  secrets: ConnectionSecretStore;
+  policy?: ConnectPolicy;
+  fetch?: typeof fetch;
+  now?: () => Date;
+  tokenRefreshSkewMs?: number;
+  oauthStateTtlMs?: number;
+}
+
+export interface CreateApiKeyConnectionInput {
+  providerId: string;
+  apiKey: string;
+  scopes?: string[];
+  subject?: ConnectSubject;
+  name?: string;
+  projectId?: string;
+  orgId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StartOAuthInput {
+  providerId: string;
+  scopes?: string[];
+  subject?: ConnectSubject;
+  redirectUri: string;
+  projectId?: string;
+  orgId?: string;
+  connectionName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StartOAuthResult {
+  authorizationUrl: string;
+  state: string;
+  expiresAt: string;
+}
+
+export interface CompleteOAuthInput {
+  state: string;
+  code?: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+export interface GetTokenInput {
+  connectionId: string;
+  scopes?: string[];
+  subject?: ConnectSubject;
+  actionId?: string;
+  forceRefresh?: boolean;
+}
+
+export interface RevokeConnectionInput {
+  connectionId: string;
+}
+
+export interface ConnectService {
+  listProviders(): ConnectorProviderDefinition[];
+  listConnections(filter?: Parameters<ConnectStore["listConnections"]>[0]): Promise<ConnectionRecord[]>;
+  createApiKeyConnection(input: CreateApiKeyConnectionInput): Promise<ConnectionRecord>;
+  startOAuth(input: StartOAuthInput): Promise<StartOAuthResult>;
+  completeOAuth(input: CompleteOAuthInput): Promise<ConnectionRecord>;
+  getToken(input: GetTokenInput): Promise<RuntimeToken>;
+  revokeConnection(input: RevokeConnectionInput): Promise<ConnectionRecord>;
+}
+
+export function createConnectService(options: CreateConnectServiceOptions): ConnectService {
+  const registry = createConnectorRegistry(options.providers);
+  const fetchImpl = options.fetch ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const tokenRefreshSkewMs = options.tokenRefreshSkewMs ?? 60_000;
+  const oauthStateTtlMs = options.oauthStateTtlMs ?? 10 * 60_000;
+
+  return {
+    listProviders() {
+      return registry.list();
+    },
+
+    listConnections(filter) {
+      return options.store.listConnections(filter);
+    },
+
+    async createApiKeyConnection(input) {
+      const provider = registry.require(input.providerId);
+      if (provider.auth.type !== "api_key") {
+        throw new ConnectError("unsupported_auth", `Provider "${provider.id}" does not use API-key auth`);
+      }
+      const apiKey = input.apiKey.trim();
+      if (!apiKey) {
+        throw new ConnectError("invalid_request", "API key cannot be empty");
+      }
+      const grantedScopes = assertAllowedScopes(provider, input.scopes ?? provider.auth.defaultScopes);
+      const id = createId("conn");
+      const secretRef = createId("connsec");
+      await options.secrets.setSecret(secretRef, { kind: "api_key", apiKey });
+      return options.store.upsertConnection({
+        id,
+        providerId: provider.id,
+        name: input.name,
+        projectId: input.projectId,
+        orgId: input.orgId,
+        owner: input.subject,
+        authType: "api_key",
+        status: "active",
+        grantedScopes,
+        secretRef,
+        createdAt: now().toISOString(),
+        updatedAt: now().toISOString(),
+        metadata: input.metadata,
+      });
+    },
+
+    async startOAuth(input) {
+      const provider = registry.require(input.providerId);
+      if (provider.auth.type !== "oauth2") {
+        throw new ConnectError("unsupported_auth", `Provider "${provider.id}" does not use OAuth2 auth`);
+      }
+      const auth = provider.auth;
+      if (!auth.clientId) {
+        throw new ConnectError("invalid_provider", `OAuth provider "${provider.id}" is missing clientId`);
+      }
+      const requestedScopes = assertAllowedScopes(provider, input.scopes ?? auth.defaultScopes);
+      const state = createOpaqueToken();
+      const pkce = auth.supportsPkce === false ? undefined : createPkcePair();
+      const expiresAt = new Date(now().getTime() + oauthStateTtlMs).toISOString();
+      await options.store.saveOAuthState({
+        state,
+        providerId: provider.id,
+        subject: input.subject,
+        requestedScopes,
+        redirectUri: input.redirectUri,
+        codeVerifier: pkce?.verifier,
+        codeChallenge: pkce?.challenge,
+        projectId: input.projectId,
+        orgId: input.orgId,
+        connectionName: input.connectionName,
+        expiresAt,
+        createdAt: now().toISOString(),
+        metadata: input.metadata,
+      });
+
+      const url = new URL(auth.authorizationUrl);
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("client_id", auth.clientId);
+      url.searchParams.set("redirect_uri", input.redirectUri);
+      url.searchParams.set("state", state);
+      if (requestedScopes.length > 0) url.searchParams.set("scope", requestedScopes.join(" "));
+      if (pkce) {
+        url.searchParams.set("code_challenge", pkce.challenge);
+        url.searchParams.set("code_challenge_method", "S256");
+      }
+      for (const [key, value] of Object.entries(auth.extraAuthorizeParams ?? {})) {
+        url.searchParams.set(key, value);
+      }
+      return { authorizationUrl: url.toString(), state, expiresAt };
+    },
+
+    async completeOAuth(input) {
+      const state = await options.store.consumeOAuthState(input.state);
+      if (!state) {
+        throw new ConnectError("oauth_state_not_found", "OAuth state was not found or has already been used");
+      }
+      if (new Date(state.expiresAt).getTime() <= now().getTime()) {
+        throw new ConnectError("oauth_state_expired", "OAuth state has expired");
+      }
+      if (input.error) {
+        throw new ConnectError("oauth_error", input.errorDescription ?? input.error, {
+          details: { error: input.error, errorDescription: input.errorDescription },
+        });
+      }
+      if (!input.code) {
+        throw new ConnectError("invalid_request", "OAuth callback is missing code");
+      }
+
+      const provider = registry.require(state.providerId);
+      if (provider.auth.type !== "oauth2") {
+        throw new ConnectError("unsupported_auth", `Provider "${provider.id}" does not use OAuth2 auth`);
+      }
+      const tokenSet = await exchangeCode(fetchImpl, provider.auth, input.code, state.redirectUri, state.codeVerifier);
+      const grantedScopes = assertAllowedScopes(provider, parseScopes(tokenSet.scope, state.requestedScopes));
+      assertGrantedScopes(grantedScopes, state.requestedScopes);
+      const id = createId("conn");
+      const secretRef = createId("connsec");
+      const tokens = normalizeTokenSet(tokenSet, grantedScopes, now());
+      await options.secrets.setSecret(secretRef, { kind: "oauth2", tokens });
+      return options.store.upsertConnection({
+        id,
+        providerId: provider.id,
+        name: state.connectionName,
+        projectId: state.projectId,
+        orgId: state.orgId,
+        owner: state.subject,
+        authType: "oauth2",
+        status: "active",
+        grantedScopes,
+        secretRef,
+        tokenExpiresAt: tokens.expiresAt,
+        createdAt: now().toISOString(),
+        updatedAt: now().toISOString(),
+        metadata: state.metadata,
+      });
+    },
+
+    async getToken(input) {
+      const connection = await options.store.getConnection(input.connectionId);
+      if (!connection) {
+        throw new ConnectError("connection_not_found", `Connection not found: ${input.connectionId}`);
+      }
+      if (connection.status !== "active") {
+        throw new ConnectError("connection_revoked", `Connection is not active: ${connection.id}`);
+      }
+
+      const scopes = assertGrantedScopes(connection.grantedScopes, input.scopes ?? []);
+      const allowed = await options.policy?.canUseConnection({
+        connection,
+        subject: input.subject,
+        scopes,
+        actionId: input.actionId,
+      });
+      if (allowed === false) {
+        throw new ConnectError("policy_denied", `Connection use denied by policy: ${connection.id}`);
+      }
+      if (!connection.secretRef) {
+        throw new ConnectError("secret_not_found", `Connection has no secret reference: ${connection.id}`);
+      }
+
+      const secret = await options.secrets.getSecret(connection.secretRef);
+      if (!secret) {
+        throw new ConnectError("secret_not_found", `Connection secret not found: ${connection.secretRef}`);
+      }
+
+      if (secret.kind === "api_key") {
+        if (!secret.apiKey) throw new ConnectError("token_not_available", "API-key connection secret is empty");
+        return {
+          accessToken: secret.apiKey,
+          tokenType: "ApiKey",
+          scopes: connection.grantedScopes,
+          connectionId: connection.id,
+          providerId: connection.providerId,
+        };
+      }
+
+      if (secret.kind !== "oauth2" || !secret.tokens?.accessToken) {
+        throw new ConnectError("token_not_available", "Connection does not contain an OAuth access token");
+      }
+
+      let tokens = secret.tokens;
+      if (input.forceRefresh || shouldRefresh(tokens, now(), tokenRefreshSkewMs)) {
+        const provider = registry.require(connection.providerId);
+        if (provider.auth.type !== "oauth2") {
+          throw new ConnectError("unsupported_auth", `Provider "${provider.id}" does not use OAuth2 auth`);
+        }
+        if (!tokens.refreshToken) {
+          throw new ConnectError("token_not_available", "OAuth access token is expired and no refresh token is available");
+        }
+        tokens = await refreshToken(fetchImpl, provider.auth, tokens.refreshToken, connection.grantedScopes, now());
+        await options.secrets.setSecret(connection.secretRef, { ...secret, tokens });
+        await options.store.updateConnection(connection.id, {
+          tokenExpiresAt: tokens.expiresAt,
+          updatedAt: now().toISOString(),
+        });
+      }
+
+      return {
+        accessToken: tokens.accessToken,
+        tokenType: tokens.tokenType ?? "Bearer",
+        expiresAt: tokens.expiresAt,
+        scopes: tokens.scopes ?? connection.grantedScopes,
+        connectionId: connection.id,
+        providerId: connection.providerId,
+      };
+    },
+
+    async revokeConnection(input) {
+      const connection = await options.store.getConnection(input.connectionId);
+      if (!connection) {
+        throw new ConnectError("connection_not_found", `Connection not found: ${input.connectionId}`);
+      }
+      if (connection.secretRef) {
+        await options.secrets.deleteSecret(connection.secretRef);
+      }
+      return options.store.updateConnection(connection.id, {
+        status: "revoked",
+        secretRef: undefined,
+        updatedAt: now().toISOString(),
+      });
+    },
+  };
+}
+
+async function exchangeCode(fetchImpl: typeof fetch, auth: OAuth2AuthConfig, code: string, redirectUri: string, codeVerifier?: string): Promise<ProviderTokenResponse> {
+  return requestToken(fetchImpl, auth.tokenUrl, {
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: auth.clientId,
+    client_secret: auth.clientSecret,
+    code_verifier: codeVerifier,
+    ...auth.extraTokenParams,
+  });
+}
+
+async function refreshToken(fetchImpl: typeof fetch, auth: OAuth2AuthConfig, refreshTokenValue: string, fallbackScopes: string[], now: Date): Promise<TokenSet> {
+  const tokenSet = await requestToken(fetchImpl, auth.tokenUrl, {
+    grant_type: "refresh_token",
+    refresh_token: refreshTokenValue,
+    client_id: auth.clientId,
+    client_secret: auth.clientSecret,
+    ...auth.extraTokenParams,
+  });
+  return normalizeTokenSet(tokenSet, parseScopes(tokenSet.scope, fallbackScopes), now, refreshTokenValue);
+}
+
+async function requestToken(fetchImpl: typeof fetch, tokenUrl: string, body: Record<string, string | undefined>): Promise<ProviderTokenResponse> {
+  const response = await fetchImpl(tokenUrl, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+    body: toFormBody(body),
+  });
+  const text = await response.text();
+  const payload = text ? safeJson(text) : {};
+  if (!response.ok) {
+    throw new ConnectError("token_exchange_failed", "OAuth token endpoint returned an error", {
+      status: response.status,
+      details: payload,
+    });
+  }
+  if (!payload || typeof payload !== "object" || typeof (payload as ProviderTokenResponse).access_token !== "string") {
+    throw new ConnectError("token_exchange_failed", "OAuth token endpoint did not return access_token", { details: payload });
+  }
+  return payload as ProviderTokenResponse;
+}
+
+function normalizeTokenSet(payload: ProviderTokenResponse, scopes: string[], now: Date, fallbackRefreshToken?: string): TokenSet {
+  return {
+    accessToken: payload.access_token,
+    refreshToken: payload.refresh_token ?? fallbackRefreshToken,
+    tokenType: payload.token_type ?? "Bearer",
+    expiresAt: typeof payload.expires_in === "number" ? new Date(now.getTime() + payload.expires_in * 1000).toISOString() : undefined,
+    scopes: normalizeScopes(scopes),
+    raw: payload,
+  };
+}
+
+function shouldRefresh(tokens: TokenSet, now: Date, skewMs: number): boolean {
+  if (!tokens.expiresAt) return false;
+  return new Date(tokens.expiresAt).getTime() - skewMs <= now.getTime();
+}
+
+function createId(prefix: string): string {
+  return `${prefix}_${createOpaqueToken(18)}`;
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ConnectError("token_exchange_failed", "OAuth token endpoint returned invalid JSON", { details: text });
+  }
+}
+
+interface ProviderTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+  [key: string]: unknown;
+}

--- a/packages/connect-server/tsconfig.json
+++ b/packages/connect-server/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__"]
+}

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,0 +1,15 @@
+# @polpo-ai/connect
+
+Shared contracts and client SDK for Polpo Connect.
+
+Polpo Connect models external service connections as scoped, revocable capabilities that can be assigned to agents without exposing raw access tokens to the model.
+
+This package contains:
+
+- connector provider definitions
+- connection and OAuth state types
+- scope normalization and validation helpers
+- connector registry helpers
+- a small HTTP client for Connect APIs
+
+Server-side OAuth/token lifecycle lives in `@polpo-ai/connect-server`.

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@polpo-ai/connect",
+  "version": "0.15.3",
+  "description": "Polpo Connect contracts and client SDK for OAuth, API-key, and MCP connections",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "prepublishOnly": "tsc"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "license": "Apache-2.0",
+  "keywords": [
+    "polpo",
+    "agents",
+    "oauth",
+    "connections",
+    "connectors",
+    "mcp"
+  ],
+  "author": "OpenPolpo Contributors",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lumea-labs/polpo.git",
+    "directory": "packages/connect"
+  },
+  "homepage": "https://github.com/lumea-labs/polpo/tree/main/packages/connect",
+  "bugs": {
+    "url": "https://github.com/lumea-labs/polpo/issues"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.4"
+  }
+}

--- a/packages/connect/src/__tests__/registry.test.ts
+++ b/packages/connect/src/__tests__/registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { ConnectError, createConnectorRegistry, normalizeScopes } from "../index.js";
+import type { ConnectorProviderDefinition } from "../index.js";
+
+const provider: ConnectorProviderDefinition = {
+  id: "github",
+  name: "GitHub",
+  auth: { type: "oauth2", authorizationUrl: "https://github.test/auth", tokenUrl: "https://github.test/token" },
+  scopes: [
+    { id: "repo" },
+    { id: "read:user" },
+  ],
+};
+
+describe("connect registry", () => {
+  it("normalizes scopes deterministically", () => {
+    expect(normalizeScopes([" repo ", "", "read:user", "repo"])).toEqual(["read:user", "repo"]);
+  });
+
+  it("rejects duplicate provider ids", () => {
+    expect(() => createConnectorRegistry([provider, provider])).toThrow(ConnectError);
+  });
+
+  it("rejects invalid provider ids", () => {
+    expect(() => createConnectorRegistry([{ ...provider, id: "GitHub!" }])).toThrow(ConnectError);
+  });
+
+  it("throws provider_not_found for unknown providers", () => {
+    const registry = createConnectorRegistry([provider]);
+    expect(() => registry.require("slack")).toThrow(/Unknown connector provider/);
+  });
+
+  it("rejects scopes not declared by curated providers", () => {
+    const registry = createConnectorRegistry([provider]);
+    expect(() => registry.validateScopes("github", ["repo", "admin:org"])).toThrow(/does not allow scopes/);
+  });
+
+  it("allows custom scopes for generic providers", () => {
+    const registry = createConnectorRegistry([{ ...provider, id: "custom_oauth", allowCustomScopes: true }]);
+    expect(registry.validateScopes("custom_oauth", ["custom.write", "custom.read"])).toEqual(["custom.read", "custom.write"]);
+  });
+});

--- a/packages/connect/src/client/index.ts
+++ b/packages/connect/src/client/index.ts
@@ -1,0 +1,123 @@
+import { ConnectError } from "../errors.js";
+import type {
+  ConnectSubject,
+  ConnectionRecord,
+  ConnectorProviderDefinition,
+  RuntimeToken,
+} from "../types.js";
+
+export interface PolpoConnectClientOptions {
+  baseUrl: string;
+  headers?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>);
+  fetch?: typeof fetch;
+}
+
+export interface CreateApiKeyConnectionRequest {
+  providerId: string;
+  apiKey: string;
+  scopes?: string[];
+  subject?: ConnectSubject;
+  name?: string;
+  projectId?: string;
+  orgId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StartOAuthRequest {
+  providerId: string;
+  scopes?: string[];
+  subject?: ConnectSubject;
+  redirectUri: string;
+  projectId?: string;
+  orgId?: string;
+  connectionName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StartOAuthResponse {
+  authorizationUrl: string;
+  state: string;
+  expiresAt: string;
+}
+
+export interface CompleteOAuthRequest {
+  state: string;
+  code?: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+export interface GetTokenRequest {
+  scopes?: string[];
+  subject?: ConnectSubject;
+  actionId?: string;
+  forceRefresh?: boolean;
+}
+
+export class PolpoConnectClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly headers?: PolpoConnectClientOptions["headers"];
+
+  constructor(options: PolpoConnectClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.fetchImpl = options.fetch ?? fetch;
+    this.headers = options.headers;
+  }
+
+  listProviders(): Promise<ConnectorProviderDefinition[]> {
+    return this.request("GET", "/v1/connect/providers");
+  }
+
+  listConnections(): Promise<ConnectionRecord[]> {
+    return this.request("GET", "/v1/connect/connections");
+  }
+
+  createApiKeyConnection(input: CreateApiKeyConnectionRequest): Promise<ConnectionRecord> {
+    return this.request("POST", "/v1/connect/connections/api-key", input);
+  }
+
+  startOAuth(input: StartOAuthRequest): Promise<StartOAuthResponse> {
+    return this.request("POST", "/v1/connect/oauth/start", input);
+  }
+
+  completeOAuth(input: CompleteOAuthRequest): Promise<ConnectionRecord> {
+    return this.request("POST", "/v1/connect/oauth/callback", input);
+  }
+
+  getToken(connectionId: string, input: GetTokenRequest = {}): Promise<RuntimeToken> {
+    return this.request("POST", `/v1/connect/connections/${encodeURIComponent(connectionId)}/token`, input);
+  }
+
+  revokeConnection(connectionId: string): Promise<ConnectionRecord> {
+    return this.request("POST", `/v1/connect/connections/${encodeURIComponent(connectionId)}/revoke`);
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const dynamicHeaders = typeof this.headers === "function" ? await this.headers() : this.headers;
+    const headers = new Headers(dynamicHeaders);
+    if (body !== undefined) headers.set("content-type", "application/json");
+
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const text = await response.text();
+    const payload = text ? safeJson(text) : undefined;
+    if (!response.ok) {
+      const message = payload && typeof payload === "object" && "error" in payload ? String(payload.error) : response.statusText;
+      throw new ConnectError("http_error", message, { status: response.status, details: payload });
+    }
+    return payload as T;
+  }
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/packages/connect/src/errors.ts
+++ b/packages/connect/src/errors.ts
@@ -1,0 +1,60 @@
+export type ConnectErrorCode =
+  | "invalid_request"
+  | "invalid_provider"
+  | "invalid_scope"
+  | "provider_not_found"
+  | "unsupported_auth"
+  | "connection_not_found"
+  | "connection_revoked"
+  | "secret_not_found"
+  | "token_not_available"
+  | "token_exchange_failed"
+  | "oauth_state_not_found"
+  | "oauth_state_expired"
+  | "oauth_error"
+  | "policy_denied"
+  | "http_error";
+
+export class ConnectError extends Error {
+  readonly code: ConnectErrorCode;
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor(code: ConnectErrorCode, message: string, options: { status?: number; details?: unknown } = {}) {
+    super(message);
+    this.name = "ConnectError";
+    this.code = code;
+    this.status = options.status ?? defaultStatus(code);
+    this.details = options.details;
+  }
+}
+
+function defaultStatus(code: ConnectErrorCode): number {
+  switch (code) {
+    case "invalid_request":
+    case "invalid_provider":
+    case "invalid_scope":
+    case "unsupported_auth":
+    case "oauth_error":
+      return 400;
+    case "connection_not_found":
+    case "provider_not_found":
+    case "oauth_state_not_found":
+    case "secret_not_found":
+      return 404;
+    case "connection_revoked":
+    case "oauth_state_expired":
+    case "policy_denied":
+      return 403;
+    case "token_exchange_failed":
+    case "token_not_available":
+    case "http_error":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+export function isConnectError(error: unknown): error is ConnectError {
+  return error instanceof ConnectError;
+}

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./errors.js";
+export * from "./registry.js";
+export * from "./scopes.js";
+export * from "./types.js";

--- a/packages/connect/src/registry.ts
+++ b/packages/connect/src/registry.ts
@@ -1,0 +1,46 @@
+import { ConnectError } from "./errors.js";
+import { assertAllowedScopes } from "./scopes.js";
+import type { ConnectorProviderDefinition } from "./types.js";
+
+export interface ConnectorRegistry {
+  list(): ConnectorProviderDefinition[];
+  get(providerId: string): ConnectorProviderDefinition | undefined;
+  require(providerId: string): ConnectorProviderDefinition;
+  validateScopes(providerId: string, scopes?: readonly string[]): string[];
+}
+
+export function createConnectorRegistry(providers: readonly ConnectorProviderDefinition[]): ConnectorRegistry {
+  const byId = new Map<string, ConnectorProviderDefinition>();
+  for (const provider of providers) {
+    validateProviderId(provider.id);
+    if (byId.has(provider.id)) {
+      throw new ConnectError("invalid_provider", `Duplicate connector provider id: ${provider.id}`);
+    }
+    byId.set(provider.id, Object.freeze({ ...provider }));
+  }
+
+  return {
+    list() {
+      return [...byId.values()];
+    },
+    get(providerId) {
+      return byId.get(providerId);
+    },
+    require(providerId) {
+      const provider = byId.get(providerId);
+      if (!provider) {
+        throw new ConnectError("provider_not_found", `Unknown connector provider: ${providerId}`);
+      }
+      return provider;
+    },
+    validateScopes(providerId, scopes) {
+      return assertAllowedScopes(this.require(providerId), scopes);
+    },
+  };
+}
+
+export function validateProviderId(providerId: string): void {
+  if (!/^[a-z0-9][a-z0-9_-]{1,63}$/.test(providerId)) {
+    throw new ConnectError("invalid_provider", `Invalid connector provider id: ${providerId}`);
+  }
+}

--- a/packages/connect/src/scopes.ts
+++ b/packages/connect/src/scopes.ts
@@ -1,0 +1,40 @@
+import { ConnectError } from "./errors.js";
+import type { ConnectorProviderDefinition } from "./types.js";
+
+export function normalizeScopes(scopes: readonly string[] | undefined): string[] {
+  if (!scopes?.length) return [];
+  const normalized = scopes.map((scope) => scope.trim()).filter(Boolean);
+  return [...new Set(normalized)].sort((a, b) => a.localeCompare(b));
+}
+
+export function hasScopes(grantedScopes: readonly string[], requestedScopes: readonly string[]): boolean {
+  const granted = new Set(normalizeScopes(grantedScopes));
+  return normalizeScopes(requestedScopes).every((scope) => granted.has(scope));
+}
+
+export function assertAllowedScopes(provider: ConnectorProviderDefinition, scopes: readonly string[] | undefined): string[] {
+  const normalized = normalizeScopes(scopes);
+  if (provider.allowCustomScopes) return normalized;
+
+  const allowed = new Set((provider.scopes ?? []).map((scope) => scope.id));
+  const invalid = normalized.filter((scope) => !allowed.has(scope));
+  if (invalid.length > 0) {
+    throw new ConnectError("invalid_scope", `Provider "${provider.id}" does not allow scopes: ${invalid.join(", ")}`, {
+      details: { providerId: provider.id, invalidScopes: invalid },
+    });
+  }
+
+  return normalized;
+}
+
+export function assertGrantedScopes(grantedScopes: readonly string[], requestedScopes: readonly string[]): string[] {
+  const normalized = normalizeScopes(requestedScopes);
+  if (!hasScopes(grantedScopes, normalized)) {
+    const granted = new Set(normalizeScopes(grantedScopes));
+    const missing = normalized.filter((scope) => !granted.has(scope));
+    throw new ConnectError("invalid_scope", `Connection is missing required scopes: ${missing.join(", ")}`, {
+      details: { missingScopes: missing },
+    });
+  }
+  return normalized;
+}

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -1,0 +1,168 @@
+export type ConnectorAuthType = "api_key" | "oauth2" | "mcp";
+
+export type ConnectSubjectType = "user" | "project" | "org" | "agent" | "service";
+
+export interface ConnectSubject {
+  type: ConnectSubjectType;
+  id: string;
+}
+
+export interface ConnectorScopeDefinition {
+  id: string;
+  label?: string;
+  description?: string;
+  required?: boolean;
+  dangerous?: boolean;
+}
+
+export type ConnectorActionRisk = "read" | "write" | "admin";
+
+export interface ConnectorActionDefinition {
+  id: string;
+  label?: string;
+  description?: string;
+  scopes?: string[];
+  risk?: ConnectorActionRisk;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ConnectorTriggerDefinition {
+  id: string;
+  label?: string;
+  description?: string;
+  scopes?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ApiKeyAuthConfig {
+  type: "api_key";
+  headerName?: string;
+  queryParam?: string;
+  instructions?: string;
+  defaultScopes?: string[];
+}
+
+export interface OAuth2AuthConfig {
+  type: "oauth2";
+  authorizationUrl: string;
+  tokenUrl: string;
+  revokeUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+  defaultScopes?: string[];
+  supportsPkce?: boolean;
+  extraAuthorizeParams?: Record<string, string>;
+  extraTokenParams?: Record<string, string>;
+}
+
+export interface McpAuthConfig {
+  type: "mcp";
+  auth?: "none" | "bearer" | "oauth2";
+  defaultScopes?: string[];
+}
+
+export type ConnectorAuthConfig = ApiKeyAuthConfig | OAuth2AuthConfig | McpAuthConfig;
+
+export interface ConnectorProviderDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  auth: ConnectorAuthConfig;
+  scopes?: ConnectorScopeDefinition[];
+  actions?: ConnectorActionDefinition[];
+  triggers?: ConnectorTriggerDefinition[];
+  allowCustomScopes?: boolean;
+  icon?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type ConnectionStatus = "active" | "pending" | "revoked" | "error";
+
+export interface ConnectionRecord {
+  id: string;
+  providerId: string;
+  name?: string;
+  projectId?: string;
+  orgId?: string;
+  owner?: ConnectSubject;
+  authType: ConnectorAuthType;
+  status: ConnectionStatus;
+  grantedScopes: string[];
+  secretRef?: string;
+  tokenExpiresAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OAuthStateRecord {
+  state: string;
+  providerId: string;
+  subject?: ConnectSubject;
+  requestedScopes: string[];
+  redirectUri: string;
+  codeVerifier?: string;
+  codeChallenge?: string;
+  projectId?: string;
+  orgId?: string;
+  connectionName?: string;
+  expiresAt: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TokenSet {
+  accessToken: string;
+  refreshToken?: string;
+  tokenType?: string;
+  expiresAt?: string;
+  scopes?: string[];
+  raw?: unknown;
+}
+
+export interface RuntimeToken {
+  accessToken: string;
+  tokenType: string;
+  expiresAt?: string;
+  scopes: string[];
+  connectionId: string;
+  providerId: string;
+}
+
+export interface StoredConnectionSecret {
+  kind: "api_key" | "oauth2" | "mcp";
+  apiKey?: string;
+  tokens?: TokenSet;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ConnectionListFilter {
+  providerId?: string;
+  projectId?: string;
+  orgId?: string;
+  owner?: ConnectSubject;
+  status?: ConnectionStatus;
+}
+
+export interface ConnectStore {
+  listConnections(filter?: ConnectionListFilter): Promise<ConnectionRecord[]>;
+  getConnection(id: string): Promise<ConnectionRecord | null>;
+  upsertConnection(record: ConnectionRecord): Promise<ConnectionRecord>;
+  updateConnection(id: string, patch: Partial<Omit<ConnectionRecord, "id" | "createdAt">>): Promise<ConnectionRecord>;
+  deleteConnection(id: string): Promise<void>;
+  saveOAuthState(record: OAuthStateRecord): Promise<void>;
+  consumeOAuthState(state: string): Promise<OAuthStateRecord | null>;
+}
+
+export interface ConnectPolicyDecisionInput {
+  connection: ConnectionRecord;
+  subject?: ConnectSubject;
+  scopes: string[];
+  actionId?: string;
+}
+
+export interface ConnectPolicy {
+  canUseConnection(input: ConnectPolicyDecisionInput): Promise<boolean> | boolean;
+}

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__"]
+}

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -1,0 +1,14 @@
+# @polpo-ai/connectors
+
+Curated connector provider definitions for Polpo Connect.
+
+The initial catalog includes:
+
+- API Key
+- GitHub
+- Slack
+- Google Drive
+- MCP Server URL
+- a factory for custom OAuth2 connectors
+
+These definitions describe auth mode, scopes, agent-facing actions, and triggers. They do not execute provider API calls by themselves; execution belongs to connector tools/runtime integrations.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@polpo-ai/connectors",
+  "version": "0.15.3",
+  "description": "Curated connector provider definitions for Polpo Connect",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "prepublishOnly": "tsc"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "dependencies": {
+    "@polpo-ai/connect": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.4"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "polpo",
+    "connectors",
+    "oauth",
+    "github",
+    "slack",
+    "google-drive",
+    "mcp"
+  ],
+  "author": "OpenPolpo Contributors",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lumea-labs/polpo.git",
+    "directory": "packages/connectors"
+  },
+  "homepage": "https://github.com/lumea-labs/polpo/tree/main/packages/connectors",
+  "bugs": {
+    "url": "https://github.com/lumea-labs/polpo/issues"
+  }
+}

--- a/packages/connectors/src/__tests__/connectors.test.ts
+++ b/packages/connectors/src/__tests__/connectors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createConnectorRegistry } from "@polpo-ai/connect";
+import { createGenericOAuthConnector, defaultConnectors, githubConnector, googleDriveConnector, mcpUrlConnector, slackConnector } from "../index.js";
+
+describe("curated connectors", () => {
+  it("has unique valid provider definitions", () => {
+    const registry = createConnectorRegistry(defaultConnectors);
+    expect(registry.list().map((provider) => provider.id)).toEqual(["api_key", "github", "slack", "google_drive", "mcp_url"]);
+  });
+
+  it("declares actions only with scopes supported by each provider", () => {
+    for (const provider of defaultConnectors) {
+      const scopeIds = new Set((provider.scopes ?? []).map((scope) => scope.id));
+      for (const action of provider.actions ?? []) {
+        for (const scope of action.scopes ?? []) {
+          expect(scopeIds.has(scope), `${provider.id}.${action.id} references unknown scope ${scope}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("covers GitHub, Slack, Drive, and MCP with agent-facing actions", () => {
+    expect(githubConnector.actions?.map((action) => action.id)).toContain("github_create_issue");
+    expect(slackConnector.actions?.map((action) => action.id)).toContain("slack_send_message");
+    expect(googleDriveConnector.actions?.map((action) => action.id)).toContain("drive_search_files");
+    expect(mcpUrlConnector.actions?.map((action) => action.id)).toContain("mcp_call_tool");
+  });
+
+  it("allows generic OAuth connectors to define custom scopes", () => {
+    const provider = createGenericOAuthConnector({
+      id: "custom_crm",
+      name: "Custom CRM",
+      authorizationUrl: "https://crm.example/oauth/authorize",
+      tokenUrl: "https://crm.example/oauth/token",
+      defaultScopes: ["contacts.read"],
+    });
+    const registry = createConnectorRegistry([provider]);
+
+    expect(registry.validateScopes("custom_crm", ["contacts.write", "contacts.read"])).toEqual(["contacts.read", "contacts.write"]);
+  });
+});

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,0 +1,199 @@
+import type { ConnectorProviderDefinition } from "@polpo-ai/connect";
+
+export const apiKeyConnector: ConnectorProviderDefinition = {
+  id: "api_key",
+  name: "API Key",
+  description: "Store a project or user API key and expose it to approved connector tools without showing it to the model.",
+  auth: {
+    type: "api_key",
+    defaultScopes: ["use"],
+  },
+  scopes: [{ id: "use", label: "Use API key" }],
+  actions: [
+    {
+      id: "api_key_get_token",
+      label: "Get runtime token",
+      description: "Resolve the stored API key for server-side tool execution.",
+      scopes: ["use"],
+      risk: "read",
+    },
+  ],
+};
+
+export const githubConnector: ConnectorProviderDefinition = {
+  id: "github",
+  name: "GitHub",
+  description: "Read repositories, inspect issues and pull requests, and create issues through scoped GitHub OAuth.",
+  auth: {
+    type: "oauth2",
+    authorizationUrl: "https://github.com/login/oauth/authorize",
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    defaultScopes: ["read:user", "repo"],
+  },
+  scopes: [
+    { id: "read:user", label: "Read user profile" },
+    { id: "repo", label: "Repository read/write", dangerous: true },
+  ],
+  actions: [
+    {
+      id: "github_list_repos",
+      label: "List repositories",
+      description: "List repositories visible to the connected account.",
+      scopes: ["repo"],
+      risk: "read",
+    },
+    {
+      id: "github_create_issue",
+      label: "Create issue",
+      description: "Create an issue in an authorized repository.",
+      scopes: ["repo"],
+      risk: "write",
+    },
+    {
+      id: "github_read_file",
+      label: "Read file",
+      description: "Read a file from an authorized repository.",
+      scopes: ["repo"],
+      risk: "read",
+    },
+  ],
+  triggers: [
+    { id: "github_issue_opened", label: "Issue opened", scopes: ["repo"] },
+    { id: "github_pr_opened", label: "Pull request opened", scopes: ["repo"] },
+  ],
+};
+
+export const slackConnector: ConnectorProviderDefinition = {
+  id: "slack",
+  name: "Slack",
+  description: "Read channels and send messages through scoped Slack OAuth.",
+  auth: {
+    type: "oauth2",
+    authorizationUrl: "https://slack.com/oauth/v2/authorize",
+    tokenUrl: "https://slack.com/api/oauth.v2.access",
+    defaultScopes: ["channels:read", "chat:write"],
+  },
+  scopes: [
+    { id: "channels:read", label: "Read channels" },
+    { id: "chat:write", label: "Send messages", dangerous: true },
+    { id: "users:read", label: "Read users" },
+  ],
+  actions: [
+    {
+      id: "slack_list_channels",
+      label: "List channels",
+      description: "List channels available to the connected Slack installation.",
+      scopes: ["channels:read"],
+      risk: "read",
+    },
+    {
+      id: "slack_send_message",
+      label: "Send message",
+      description: "Send a message to an authorized Slack channel.",
+      scopes: ["chat:write"],
+      risk: "write",
+    },
+  ],
+  triggers: [
+    { id: "slack_message_posted", label: "Message posted", scopes: ["channels:read"] },
+  ],
+};
+
+export const googleDriveConnector: ConnectorProviderDefinition = {
+  id: "google_drive",
+  name: "Google Drive",
+  description: "Search and read Drive files through scoped Google OAuth.",
+  auth: {
+    type: "oauth2",
+    authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    defaultScopes: ["https://www.googleapis.com/auth/drive.readonly"],
+    extraAuthorizeParams: {
+      access_type: "offline",
+      prompt: "consent",
+    },
+  },
+  scopes: [
+    { id: "https://www.googleapis.com/auth/drive.readonly", label: "Read Drive files" },
+    { id: "https://www.googleapis.com/auth/drive.file", label: "Create and edit selected Drive files", dangerous: true },
+  ],
+  actions: [
+    {
+      id: "drive_search_files",
+      label: "Search files",
+      description: "Search files in the connected Google Drive.",
+      scopes: ["https://www.googleapis.com/auth/drive.readonly"],
+      risk: "read",
+    },
+    {
+      id: "drive_read_file",
+      label: "Read file",
+      description: "Read an authorized file from Google Drive.",
+      scopes: ["https://www.googleapis.com/auth/drive.readonly"],
+      risk: "read",
+    },
+  ],
+};
+
+export const mcpUrlConnector: ConnectorProviderDefinition = {
+  id: "mcp_url",
+  name: "MCP Server URL",
+  description: "Connect a remote MCP server and expose discovered tools through Polpo permissions and traces.",
+  auth: {
+    type: "mcp",
+    auth: "bearer",
+    defaultScopes: ["tools:read", "tools:call"],
+  },
+  scopes: [
+    { id: "tools:read", label: "Discover tools" },
+    { id: "tools:call", label: "Call tools", dangerous: true },
+  ],
+  actions: [
+    {
+      id: "mcp_discover_tools",
+      label: "Discover MCP tools",
+      description: "List tools exposed by the connected MCP server.",
+      scopes: ["tools:read"],
+      risk: "read",
+    },
+    {
+      id: "mcp_call_tool",
+      label: "Call MCP tool",
+      description: "Call an allowlisted tool on the connected MCP server.",
+      scopes: ["tools:call"],
+      risk: "write",
+    },
+  ],
+};
+
+export function createGenericOAuthConnector(input: {
+  id: string;
+  name: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  revokeUrl?: string;
+  defaultScopes?: string[];
+  description?: string;
+}): ConnectorProviderDefinition {
+  return {
+    id: input.id,
+    name: input.name,
+    description: input.description ?? "Custom OAuth2 connector.",
+    allowCustomScopes: true,
+    auth: {
+      type: "oauth2",
+      authorizationUrl: input.authorizationUrl,
+      tokenUrl: input.tokenUrl,
+      revokeUrl: input.revokeUrl,
+      defaultScopes: input.defaultScopes,
+    },
+  };
+}
+
+export const defaultConnectors: ConnectorProviderDefinition[] = [
+  apiKeyConnector,
+  githubConnector,
+  slackConnector,
+  googleDriveConnector,
+  mcpUrlConnector,
+];

--- a/packages/connectors/tsconfig.json
+++ b/packages/connectors/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,6 +21,8 @@
   ],
   "dependencies": {
     "@hono/zod-openapi": ">=1.0.0",
+    "@polpo-ai/connect": "workspace:*",
+    "@polpo-ai/connect-server": "workspace:*",
     "@polpo-ai/core": "workspace:*",
     "@polpo-ai/tools": "workspace:*",
     "hono": ">=4.0.0",

--- a/packages/server/src/deps.ts
+++ b/packages/server/src/deps.ts
@@ -13,6 +13,7 @@ import type { LogStore } from "@polpo-ai/core/log-store";
 import type { VaultStore } from "@polpo-ai/core/vault-store";
 import type { PlaybookStore } from "@polpo-ai/core/playbook-store";
 import type { SessionStore } from "@polpo-ai/core/session-store";
+import type { ConnectService } from "@polpo-ai/connect-server";
 
 // ── Store-centric deps ───────────────────────────────────────────────
 
@@ -26,6 +27,10 @@ export interface ChatRouteDeps {
 
 export interface LoopRunRouteDeps {
   loopRunStore?: LoopRunStore;
+}
+
+export interface ConnectRouteDeps {
+  connectService?: ConnectService;
 }
 
 // ── Task deps ────────────────────────────────────────────────────────

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,6 +27,7 @@ export { eventRoutes, type EventBridge, type EventClient } from "./routes/events
 export { configRoutes } from "./routes/config.js";
 export { fileRoutes, type FileRouteDeps } from "./routes/files.js";
 export { skillRoutes, type SkillRouteDeps } from "./routes/skills.js";
+export { connectRoutes } from "./routes/connect.js";
 // Dependency types
 export type {
   TaskRouteDeps,
@@ -41,6 +42,7 @@ export type {
   ConfigRouteDeps,
   AuthRouteDeps,
   AgentRouteDeps,
+  ConnectRouteDeps,
 } from "./deps.js";
 
 // Validation schemas (Zod — reusable by CLI for pre-flight validation)

--- a/packages/server/src/routes/connect.test.ts
+++ b/packages/server/src/routes/connect.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ConnectorProviderDefinition } from "@polpo-ai/connect";
+import { MemoryConnectStore, MemoryConnectionSecretStore, createConnectService } from "@polpo-ai/connect-server";
+import { connectRoutes } from "./connect.js";
+
+const apiKeyProvider: ConnectorProviderDefinition = {
+  id: "custom_api",
+  name: "Custom API",
+  auth: { type: "api_key", defaultScopes: ["use"] },
+  scopes: [{ id: "use" }],
+};
+
+const oauthProvider: ConnectorProviderDefinition = {
+  id: "test_oauth",
+  name: "Test OAuth",
+  auth: {
+    type: "oauth2",
+    authorizationUrl: "https://auth.example/authorize",
+    tokenUrl: "https://auth.example/token",
+    clientId: "client_id",
+    clientSecret: "client_secret",
+    defaultScopes: ["read"],
+  },
+  scopes: [{ id: "read" }, { id: "write" }],
+};
+
+describe("connectRoutes", () => {
+  it("returns 501 when connect service is not wired", async () => {
+    const app = connectRoutes(() => ({}));
+    const res = await app.request("/providers");
+    const body = await res.json();
+
+    expect(res.status).toBe(501);
+    expect(body).toMatchObject({ ok: false, code: "CONNECT_SERVICE_UNAVAILABLE" });
+  });
+
+  it("creates API-key connections without returning secret values and can issue runtime tokens", async () => {
+    const harness = createHarness();
+    const app = connectRoutes(() => ({ connectService: harness.service }));
+    const createRes = await app.request("/connections/api-key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        providerId: "custom_api",
+        apiKey: "sk_test_123",
+        scopes: ["use"],
+        subject: { type: "agent", id: "support" },
+      }),
+    });
+    const created = await createRes.json();
+
+    expect(createRes.status).toBe(200);
+    expect(created.data).toMatchObject({ providerId: "custom_api", status: "active" });
+    expect(JSON.stringify(created)).not.toContain("sk_test_123");
+
+    const tokenRes = await app.request(`/connections/${created.data.id}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scopes: ["use"], subject: { type: "agent", id: "support" } }),
+    });
+    const token = await tokenRes.json();
+
+    expect(tokenRes.status).toBe(200);
+    expect(token.data).toMatchObject({
+      accessToken: "sk_test_123",
+      tokenType: "ApiKey",
+      providerId: "custom_api",
+    });
+  });
+
+  it("maps connect errors to structured HTTP errors", async () => {
+    const app = connectRoutes(() => ({ connectService: createHarness().service }));
+    const res = await app.request("/connections/api-key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ providerId: "custom_api", apiKey: "sk", scopes: ["admin"] }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toMatchObject({ ok: false, code: "invalid_scope" });
+  });
+
+  it("supports OAuth start and callback through the HTTP contract", async () => {
+    const harness = createHarness({
+      fetchImpl: queueFetch([
+        jsonResponse(200, {
+          access_token: "oauth_access",
+          refresh_token: "oauth_refresh",
+          expires_in: 3600,
+          scope: "read write",
+        }),
+      ]),
+    });
+    const app = connectRoutes(() => ({ connectService: harness.service }));
+    const startRes = await app.request("/oauth/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        providerId: "test_oauth",
+        scopes: ["read", "write"],
+        redirectUri: "https://app.example/callback",
+      }),
+    });
+    const started = await startRes.json();
+
+    expect(startRes.status).toBe(200);
+    expect(started.data.authorizationUrl).toContain("https://auth.example/authorize");
+    expect(started.data.state).toBeTruthy();
+
+    const callbackRes = await app.request("/oauth/callback", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ state: started.data.state, code: "code_123" }),
+    });
+    const callback = await callbackRes.json();
+
+    expect(callbackRes.status).toBe(200);
+    expect(callback.data).toMatchObject({
+      providerId: "test_oauth",
+      status: "active",
+      grantedScopes: ["read", "write"],
+    });
+    expect(harness.fetchImpl.calls[0]!.bodyString).toContain("grant_type=authorization_code");
+  });
+
+  it("filters listed connections by provider, status, and owner", async () => {
+    const harness = createHarness();
+    const app = connectRoutes(() => ({ connectService: harness.service }));
+    await harness.service.createApiKeyConnection({
+      providerId: "custom_api",
+      apiKey: "sk_1",
+      scopes: ["use"],
+      subject: { type: "agent", id: "support" },
+    });
+    await harness.service.createApiKeyConnection({
+      providerId: "custom_api",
+      apiKey: "sk_2",
+      scopes: ["use"],
+      subject: { type: "agent", id: "sales" },
+    });
+
+    const res = await app.request("/connections?providerId=custom_api&status=active&ownerType=agent&ownerId=support");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].owner).toEqual({ type: "agent", id: "support" });
+  });
+});
+
+function createHarness(input: { fetchImpl?: MockFetch } = {}) {
+  const store = new MemoryConnectStore();
+  const secrets = new MemoryConnectionSecretStore();
+  const fetchImpl = input.fetchImpl ?? queueFetch([]);
+  const service = createConnectService({
+    providers: [apiKeyProvider, oauthProvider],
+    store,
+    secrets,
+    fetch: fetchImpl,
+    now: () => new Date(Date.UTC(2026, 0, 1, 10, 0, 0)),
+  });
+  return { service, store, secrets, fetchImpl };
+}
+
+interface MockFetchCall {
+  url: string;
+  init: RequestInit;
+  bodyString: string;
+}
+
+type MockFetch = ReturnType<typeof queueFetch>;
+
+function queueFetch(responses: Response[]) {
+  const calls: MockFetchCall[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL | Request, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init, bodyString: String(init.body ?? "") });
+    const next = responses.shift();
+    if (!next) throw new Error("Unexpected fetch call");
+    return next;
+  });
+  return Object.assign(fetchImpl, { calls });
+}
+
+function jsonResponse(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/packages/server/src/routes/connect.ts
+++ b/packages/server/src/routes/connect.ts
@@ -1,0 +1,234 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { ConnectError } from "@polpo-ai/connect";
+import type { ConnectSubject, ConnectionListFilter } from "@polpo-ai/connect";
+import type { ConnectService } from "@polpo-ai/connect-server";
+import type { ConnectRouteDeps } from "../deps.js";
+
+const subjectSchema = z.object({
+  type: z.enum(["user", "project", "org", "agent", "service"]),
+  id: z.string().min(1),
+});
+
+const createApiKeyConnectionBody = z.object({
+  providerId: z.string().min(1),
+  apiKey: z.string().min(1),
+  scopes: z.array(z.string()).optional(),
+  subject: subjectSchema.optional(),
+  name: z.string().optional(),
+  projectId: z.string().optional(),
+  orgId: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+const startOAuthBody = z.object({
+  providerId: z.string().min(1),
+  scopes: z.array(z.string()).optional(),
+  subject: subjectSchema.optional(),
+  redirectUri: z.string().url(),
+  projectId: z.string().optional(),
+  orgId: z.string().optional(),
+  connectionName: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+const completeOAuthBody = z.object({
+  state: z.string().min(1),
+  code: z.string().optional(),
+  error: z.string().optional(),
+  errorDescription: z.string().optional(),
+});
+
+const getTokenBody = z.object({
+  scopes: z.array(z.string()).optional(),
+  subject: subjectSchema.optional(),
+  actionId: z.string().optional(),
+  forceRefresh: z.boolean().optional(),
+}).optional();
+
+const connectionFilterQuery = z.object({
+  providerId: z.string().optional(),
+  projectId: z.string().optional(),
+  orgId: z.string().optional(),
+  status: z.enum(["active", "pending", "revoked", "error"]).optional(),
+  ownerType: z.enum(["user", "project", "org", "agent", "service"]).optional(),
+  ownerId: z.string().optional(),
+});
+
+const okAnySchema = z.object({ ok: z.boolean(), data: z.any() });
+const errorSchema = z.object({ ok: z.literal(false), error: z.string(), code: z.string().optional(), details: z.unknown().optional() });
+
+export function connectRoutes(getDeps: () => ConnectRouteDeps): OpenAPIHono {
+  const app = new OpenAPIHono();
+  const openapi = app.openapi.bind(app) as any;
+
+  openapi(
+    createRoute({
+      method: "get",
+      path: "/providers",
+      tags: ["Connect"],
+      summary: "List connector providers",
+      responses: {
+        200: { content: { "application/json": { schema: okAnySchema } }, description: "Connector providers" },
+        501: { content: { "application/json": { schema: errorSchema } }, description: "Connect service unavailable" },
+      },
+    }),
+    async (c: any) => withConnect(c, getDeps, async (service) => c.json({ ok: true, data: service.listProviders() }, 200)),
+  );
+
+  openapi(
+    createRoute({
+      method: "get",
+      path: "/connections",
+      tags: ["Connect"],
+      summary: "List connections",
+      request: { query: connectionFilterQuery },
+      responses: {
+        200: { content: { "application/json": { schema: okAnySchema } }, description: "Connections" },
+        501: { content: { "application/json": { schema: errorSchema } }, description: "Connect service unavailable" },
+      },
+    }),
+    async (c: any) => withConnect(c, getDeps, async (service) => {
+      const query = c.req.valid("query");
+      const owner = query.ownerType && query.ownerId ? { type: query.ownerType, id: query.ownerId } satisfies ConnectSubject : undefined;
+      const filter: ConnectionListFilter = {
+        providerId: query.providerId,
+        projectId: query.projectId,
+        orgId: query.orgId,
+        status: query.status,
+        owner,
+      };
+      return c.json({ ok: true, data: await service.listConnections(filter) }, 200);
+    }),
+  );
+
+  openapi(
+    createRoute({
+      method: "post",
+      path: "/connections/api-key",
+      tags: ["Connect"],
+      summary: "Create API-key connection",
+      request: { body: { content: { "application/json": { schema: createApiKeyConnectionBody } } } },
+      responses: {
+        200: { content: { "application/json": { schema: okAnySchema } }, description: "Connection created" },
+        400: { content: { "application/json": { schema: errorSchema } }, description: "Invalid request" },
+        501: { content: { "application/json": { schema: errorSchema } }, description: "Connect service unavailable" },
+      },
+    }),
+    async (c: any) => withConnect(c, getDeps, async (service) => {
+      const body = c.req.valid("json");
+      const data = await service.createApiKeyConnection(body);
+      return c.json({ ok: true, data }, 200);
+    }),
+  );
+
+  openapi(
+    createRoute({
+      method: "post",
+      path: "/oauth/start",
+      tags: ["Connect"],
+      summary: "Start OAuth connection flow",
+      request: { body: { content: { "application/json": { schema: startOAuthBody } } } },
+      responses: {
+        200: { content: { "application/json": { schema: okAnySchema } }, description: "OAuth authorization URL" },
+        400: { content: { "application/json": { schema: errorSchema } }, description: "Invalid request" },
+        501: { content: { "application/json": { schema: errorSchema } }, description: "Connect service unavailable" },
+      },
+    }),
+    async (c: any) => withConnect(c, getDeps, async (service) => {
+      const data = await service.startOAuth(c.req.valid("json"));
+      return c.json({ ok: true, data }, 200);
+    }),
+  );
+
+  openapi(
+    createRoute({
+      method: "post",
+      path: "/oauth/callback",
+      tags: ["Connect"],
+      summary: "Complete OAuth connection flow",
+      request: { body: { content: { "application/json": { schema: completeOAuthBody } } } },
+      responses: {
+        200: { content: { "application/json": { schema: okAnySchema } }, description: "Connection created" },
+        400: { content: { "application/json": { schema: errorSchema } }, description: "Invalid OAuth callback" },
+        403: { content: { "application/json": { schema: errorSchema } }, description: "Expired OAuth state" },
+        404: { content: { "application/json": { schema: errorSchema } }, description: "OAuth state not found" },
+        501: { content: { "application/json": { schema: errorSchema } }, description: "Connect service unavailable" },
+      },
+    }),
+    async (c: any) => withConnect(c, getDeps, async (service) => {
+      const data = await service.completeOAuth(c.req.valid("json"));
+      return c.json({ ok: true, data }, 200);
+    }),
+  );
+
+  openapi(
+    createRoute({
+      method: "post",
+      path: "/connections/:id/token",
+      tags: ["Connect"],
+      summary: "Get runtime token for a connection",
+      request: {
+        params: z.object({ id: z.string().min(1) }),
+        body: { content: { "application/json": { schema: getTokenBody } }, required: false },
+      },
+      responses: {
+        200: { content: { "application/json": { schema: okAnySchema } }, description: "Runtime token" },
+        403: { content: { "application/json": { schema: errorSchema } }, description: "Connection denied" },
+        404: { content: { "application/json": { schema: errorSchema } }, description: "Connection not found" },
+        501: { content: { "application/json": { schema: errorSchema } }, description: "Connect service unavailable" },
+      },
+    }),
+    async (c: any) => withConnect(c, getDeps, async (service) => {
+      const input = (await parseOptionalJson(c)) ?? {};
+      const data = await service.getToken({ connectionId: c.req.param("id"), ...input });
+      return c.json({ ok: true, data }, 200);
+    }),
+  );
+
+  openapi(
+    createRoute({
+      method: "post",
+      path: "/connections/:id/revoke",
+      tags: ["Connect"],
+      summary: "Revoke a connection",
+      request: { params: z.object({ id: z.string().min(1) }) },
+      responses: {
+        200: { content: { "application/json": { schema: okAnySchema } }, description: "Connection revoked" },
+        404: { content: { "application/json": { schema: errorSchema } }, description: "Connection not found" },
+        501: { content: { "application/json": { schema: errorSchema } }, description: "Connect service unavailable" },
+      },
+    }),
+    async (c: any) => withConnect(c, getDeps, async (service) => {
+      const data = await service.revokeConnection({ connectionId: c.req.param("id") });
+      return c.json({ ok: true, data }, 200);
+    }),
+  );
+
+  return app;
+}
+
+async function withConnect(
+  c: any,
+  getDeps: () => ConnectRouteDeps,
+  handler: (service: ConnectService) => Promise<Response> | Response,
+): Promise<Response> {
+  const service = getDeps().connectService;
+  if (!service) {
+    return c.json({ ok: false, error: "Connect service is not configured", code: "CONNECT_SERVICE_UNAVAILABLE" }, 501);
+  }
+  try {
+    return await handler(service);
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return c.json({ ok: false, error: error.message, code: error.code, details: error.details }, error.status);
+    }
+    throw error;
+  }
+}
+
+async function parseOptionalJson(c: any): Promise<z.infer<typeof getTokenBody>> {
+  const length = c.req.header("content-length");
+  const type = c.req.header("content-type");
+  if (length === "0" || !type?.includes("application/json")) return undefined;
+  return getTokenBody.parse(await c.req.json());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,41 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connect:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/connect-server:
+    dependencies:
+      '@polpo-ai/connect':
+        specifier: workspace:*
+        version: link:../connect
+    devDependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/connectors:
+    dependencies:
+      '@polpo-ai/connect':
+        specifier: workspace:*
+        version: link:../connect
+    devDependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/core:
     dependencies:
       '@sinclair/typebox':
@@ -267,6 +302,12 @@ importers:
       '@hono/zod-openapi':
         specifier: '>=1.0.0'
         version: 1.2.2(hono@4.11.9)(zod@4.3.6)
+      '@polpo-ai/connect':
+        specifier: workspace:*
+        version: link:../connect
+      '@polpo-ai/connect-server':
+        specifier: workspace:*
+        version: link:../connect-server
       '@polpo-ai/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

Adds the initial OSS foundation for Polpo Connect, before any Cloud UI work.

This introduces:

- `@polpo-ai/connect` for shared connection contracts, errors, scope validation, provider registry, and a lightweight HTTP client
- `@polpo-ai/connect-server` for framework-agnostic API-key/OAuth2 lifecycle logic
- `@polpo-ai/connectors` for the initial curated provider catalog: API Key, GitHub, Slack, Google Drive, MCP Server URL, and Generic OAuth factory
- `connectRoutes` in `@polpo-ai/server` for provider list, connection list, API-key creation, OAuth start/callback, runtime token retrieval, and revoke

## Why

This is the contract-first OSS layer for managed agent connections: OAuth/API-key lifecycle, scoped runtime tokens, policy checks, and connector metadata that can later be wired into Cloud DB storage, Vault encryption, audit traces, builder instructions, and V2 UI.

No dashboard/UI changes are included in this PR.

## Validation

- `pnpm --filter @polpo-ai/connect --filter @polpo-ai/connect-server --filter @polpo-ai/connectors test`
- `pnpm vitest run packages/server/src/routes/connect.test.ts`
- `pnpm build`

## Notes

The server route depends on an injected `ConnectService`; Cloud/OSS runtime wiring can provide the real DB/encryption-backed implementation in a follow-up PR.
